### PR TITLE
Add mutexes to PopulateMore... methods in ViewModels

### DIFF
--- a/src/Sdk/StrixMusic.Sdk/ViewModels/AlbumCollectionViewModel.cs
+++ b/src/Sdk/StrixMusic.Sdk/ViewModels/AlbumCollectionViewModel.cs
@@ -7,9 +7,7 @@ using Microsoft.Toolkit.Diagnostics;
 using Microsoft.Toolkit.Mvvm.ComponentModel;
 using Microsoft.Toolkit.Mvvm.DependencyInjection;
 using Microsoft.Toolkit.Mvvm.Input;
-
 using Nito.AsyncEx;
-
 using OwlCore;
 using OwlCore.Events;
 using OwlCore.Extensions;

--- a/src/Sdk/StrixMusic.Sdk/ViewModels/AlbumViewModel.cs
+++ b/src/Sdk/StrixMusic.Sdk/ViewModels/AlbumViewModel.cs
@@ -7,9 +7,7 @@ using Microsoft.Toolkit.Diagnostics;
 using Microsoft.Toolkit.Mvvm.ComponentModel;
 using Microsoft.Toolkit.Mvvm.DependencyInjection;
 using Microsoft.Toolkit.Mvvm.Input;
-
 using Nito.AsyncEx;
-
 using OwlCore;
 using OwlCore.Collections;
 using OwlCore.Events;

--- a/src/Sdk/StrixMusic.Sdk/ViewModels/ArtistCollectionViewModel.cs
+++ b/src/Sdk/StrixMusic.Sdk/ViewModels/ArtistCollectionViewModel.cs
@@ -6,9 +6,7 @@ using System.Threading.Tasks;
 using Microsoft.Toolkit.Diagnostics;
 using Microsoft.Toolkit.Mvvm.ComponentModel;
 using Microsoft.Toolkit.Mvvm.Input;
-
 using Nito.AsyncEx;
-
 using OwlCore;
 using OwlCore.Collections;
 using OwlCore.Events;

--- a/src/Sdk/StrixMusic.Sdk/ViewModels/ArtistViewModel.cs
+++ b/src/Sdk/StrixMusic.Sdk/ViewModels/ArtistViewModel.cs
@@ -7,9 +7,7 @@ using Microsoft.Toolkit.Diagnostics;
 using Microsoft.Toolkit.Mvvm.ComponentModel;
 using Microsoft.Toolkit.Mvvm.DependencyInjection;
 using Microsoft.Toolkit.Mvvm.Input;
-
 using Nito.AsyncEx;
-
 using OwlCore;
 using OwlCore.Collections;
 using OwlCore.Events;

--- a/src/Sdk/StrixMusic.Sdk/ViewModels/PlayableCollectionGroupViewModel.cs
+++ b/src/Sdk/StrixMusic.Sdk/ViewModels/PlayableCollectionGroupViewModel.cs
@@ -7,9 +7,7 @@ using Microsoft.Toolkit.Diagnostics;
 using Microsoft.Toolkit.Mvvm.ComponentModel;
 using Microsoft.Toolkit.Mvvm.DependencyInjection;
 using Microsoft.Toolkit.Mvvm.Input;
-
 using Nito.AsyncEx;
-
 using OwlCore;
 using OwlCore.Events;
 using OwlCore.Extensions;

--- a/src/Sdk/StrixMusic.Sdk/ViewModels/PlaylistCollectionViewModel.cs
+++ b/src/Sdk/StrixMusic.Sdk/ViewModels/PlaylistCollectionViewModel.cs
@@ -5,9 +5,7 @@ using System.Threading.Tasks;
 using Microsoft.Toolkit.Diagnostics;
 using Microsoft.Toolkit.Mvvm.ComponentModel;
 using Microsoft.Toolkit.Mvvm.Input;
-
 using Nito.AsyncEx;
-
 using OwlCore;
 using OwlCore.Events;
 using OwlCore.Extensions;

--- a/src/Sdk/StrixMusic.Sdk/ViewModels/PlaylistViewModel.cs
+++ b/src/Sdk/StrixMusic.Sdk/ViewModels/PlaylistViewModel.cs
@@ -7,9 +7,7 @@ using Microsoft.Toolkit.Diagnostics;
 using Microsoft.Toolkit.Mvvm.ComponentModel;
 using Microsoft.Toolkit.Mvvm.DependencyInjection;
 using Microsoft.Toolkit.Mvvm.Input;
-
 using Nito.AsyncEx;
-
 using OwlCore;
 using OwlCore.Collections;
 using OwlCore.Events;

--- a/src/Sdk/StrixMusic.Sdk/ViewModels/TrackCollectionViewModel.cs
+++ b/src/Sdk/StrixMusic.Sdk/ViewModels/TrackCollectionViewModel.cs
@@ -7,9 +7,7 @@ using Microsoft.Toolkit.Diagnostics;
 using Microsoft.Toolkit.Mvvm.ComponentModel;
 using Microsoft.Toolkit.Mvvm.DependencyInjection;
 using Microsoft.Toolkit.Mvvm.Input;
-
 using Nito.AsyncEx;
-
 using OwlCore;
 using OwlCore.Events;
 using OwlCore.Extensions;

--- a/src/Sdk/StrixMusic.Sdk/ViewModels/TrackViewModel.cs
+++ b/src/Sdk/StrixMusic.Sdk/ViewModels/TrackViewModel.cs
@@ -8,9 +8,7 @@ using Microsoft.Toolkit.Diagnostics;
 using Microsoft.Toolkit.Mvvm.ComponentModel;
 using Microsoft.Toolkit.Mvvm.DependencyInjection;
 using Microsoft.Toolkit.Mvvm.Input;
-
 using Nito.AsyncEx;
-
 using OwlCore;
 using OwlCore.Collections;
 using OwlCore.Events;


### PR DESCRIPTION
Appears to fix duplicate items in the Zune shell.