### PR TITLE
Refactor ICoreConfigBase to use AbstractUICollection

### DIFF
--- a/src/Cores/StrixMusic.Cores.LocalFiles/LocalFilesCoreConfig.cs
+++ b/src/Cores/StrixMusic.Cores.LocalFiles/LocalFilesCoreConfig.cs
@@ -65,7 +65,7 @@ namespace StrixMusic.Cores.LocalFiles
 
             _configDoneButton = new AbstractButton("FilesCoreDoneButton", "Done", null, AbstractButtonType.Confirm);
 
-            AbstractUIElements = CreateGenericConfig().IntoList();
+            AbstractUIElements = CreateGenericConfig();
         }
 
         private void AttachEvents()
@@ -101,7 +101,7 @@ namespace StrixMusic.Cores.LocalFiles
         public IServiceProvider? Services { get; private set; }
 
         /// <inheritdoc/>
-        public IReadOnlyList<AbstractUICollection> AbstractUIElements { get; private set; }
+        public AbstractUICollection AbstractUIElements { get; private set; }
 
         /// <inheritdoc />
         public MediaPlayerType PlaybackType => MediaPlayerType.Standard;
@@ -154,7 +154,7 @@ namespace StrixMusic.Cores.LocalFiles
             var genericConfig = CreateGenericConfig();
             genericConfig.Subtitle = folderData.Path;
 
-            AbstractUIElements = genericConfig.IntoList();
+            AbstractUIElements = genericConfig;
             AbstractUIElementsChanged?.Invoke(this, EventArgs.Empty);
         }
 
@@ -242,7 +242,7 @@ namespace StrixMusic.Cores.LocalFiles
 
         public void SaveAbstractUI(AbstractUICollection collection)
         {
-            AbstractUIElements = collection.IntoList();
+            AbstractUIElements = collection;
             AbstractUIElementsChanged?.Invoke(this, EventArgs.Empty);
         }
 

--- a/src/Cores/StrixMusic.Cores.OneDriveCore/OneDriveCoreConfig.cs
+++ b/src/Cores/StrixMusic.Cores.OneDriveCore/OneDriveCoreConfig.cs
@@ -78,7 +78,7 @@ namespace StrixMusic.Cores.OneDrive
         }
 
         /// <inheritdoc />
-        public IReadOnlyList<AbstractUICollection> AbstractUIElements { get; private set; } = new List<AbstractUICollection>();
+        public AbstractUICollection AbstractUIElements { get; private set; } = new(string.Empty);
 
         /// <inheritdoc />
         public MediaPlayerType PlaybackType => MediaPlayerType.Standard;
@@ -374,7 +374,7 @@ namespace StrixMusic.Cores.OneDrive
 
             // Show folder explorer
             _logger.LogInformation($"Displaying abstract folder explorer");
-            AbstractUIElements = fileExplorer.IntoList();
+            AbstractUIElements = fileExplorer;
             AbstractUIElementsChanged?.Invoke(this, EventArgs.Empty);
 
             fileExplorer.DirectoryChanged += OnDirectoryChanged;
@@ -407,7 +407,7 @@ namespace StrixMusic.Cores.OneDrive
 
                 _logger.LogInformation($"Directory changed: {e.Id}");
 
-                AbstractUIElements = folderExplorer.IntoList();
+                AbstractUIElements = folderExplorer;
                 AbstractUIElementsChanged?.Invoke(this, EventArgs.Empty);
             }
 
@@ -419,7 +419,7 @@ namespace StrixMusic.Cores.OneDrive
 
         public void SaveAbstractUI(AbstractUICollection collection)
         {
-            AbstractUIElements = collection.IntoList();
+            AbstractUIElements = collection;
             AbstractUIElementsChanged?.Invoke(this, EventArgs.Empty);
         }
 
@@ -449,7 +449,7 @@ namespace StrixMusic.Cores.OneDrive
                     authenticateButton,
                     cancelButton
                 },
-            }.IntoList();
+            };
 
             AbstractUIElementsChanged?.Invoke(this, EventArgs.Empty);
 

--- a/src/Sdk/StrixMusic.Sdk/Data/Base/ICoreConfigBase.cs
+++ b/src/Sdk/StrixMusic.Sdk/Data/Base/ICoreConfigBase.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using OwlCore.AbstractUI;
 using OwlCore.AbstractUI.Models;
 using StrixMusic.Sdk.MediaPlayback;
 
@@ -9,12 +7,12 @@ namespace StrixMusic.Sdk.Data.Base
     /// <summary>
     /// Configuration settings set by the source core.
     /// </summary>
-    public interface ICoreConfigBase: IAsyncDisposable
+    public interface ICoreConfigBase : IAsyncDisposable
     {
         /// <summary>
         /// Abstract UI elements that will be presented to the user for Settings, About, Legal notices, Donation links, etc.
         /// </summary>
-        public IReadOnlyList<AbstractUICollection> AbstractUIElements { get; }
+        public AbstractUICollection AbstractUIElements { get; }
 
         /// <summary>
         /// The player type supported by this core. <see cref="MediaPlayerType"/> for information on the different types.

--- a/src/Sdk/StrixMusic.Sdk/Plugins/CoreRemote/RemoteCoreConfig.cs
+++ b/src/Sdk/StrixMusic.Sdk/Plugins/CoreRemote/RemoteCoreConfig.cs
@@ -1,10 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.Toolkit.Diagnostics;
 using OwlCore.AbstractUI.Models;
-using OwlCore.Provisos;
 using StrixMusic.Sdk.Data.Core;
 using StrixMusic.Sdk.MediaPlayback;
 
@@ -19,7 +15,7 @@ namespace StrixMusic.Sdk.Plugins.CoreRemote
         public RemoteCoreConfig(string sourceCoreInstanceId)
         {
             SourceCore = RemoteCore.GetInstance(sourceCoreInstanceId);
-            AbstractUIElements = new List<AbstractUICollection>();
+            AbstractUIElements = new AbstractUICollection(string.Empty);
         }
 
         /// <inheritdoc />
@@ -29,7 +25,7 @@ namespace StrixMusic.Sdk.Plugins.CoreRemote
         public IServiceProvider? Services { get; private set; }
 
         /// <inheritdoc/>
-        public IReadOnlyList<AbstractUICollection> AbstractUIElements { get; private set; }
+        public AbstractUICollection AbstractUIElements { get; private set; }
 
         /// <inheritdoc />
         public MediaPlayerType PlaybackType { get; set; }

--- a/src/Sdk/StrixMusic.Sdk/ViewModels/CoreConfigViewModel.cs
+++ b/src/Sdk/StrixMusic.Sdk/ViewModels/CoreConfigViewModel.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Threading.Tasks;
 using Microsoft.Toolkit.Mvvm.ComponentModel;
@@ -27,13 +26,7 @@ namespace StrixMusic.Sdk.ViewModels
         {
             _coreConfig = coreConfig;
 
-            AbstractUIElements = new ObservableCollection<AbstractUICollectionViewModel>();
-            AbstractUIElements.Clear();
-
-            foreach (var abstractUIElement in _coreConfig.AbstractUIElements)
-            {
-                AbstractUIElements.Add(new AbstractUICollectionViewModel(abstractUIElement));
-            }
+            AbstractUIElements = new ObservableCollection<AbstractUICollectionViewModel> { new(_coreConfig.AbstractUIElements) };
 
             AttachEvents();
         }
@@ -53,11 +46,7 @@ namespace StrixMusic.Sdk.ViewModels
             await Threading.OnPrimaryThread(() =>
             {
                 AbstractUIElements.Clear();
-
-                foreach (var abstractUIElement in _coreConfig.AbstractUIElements)
-                {
-                    AbstractUIElements.Add(new AbstractUICollectionViewModel(abstractUIElement));
-                }
+                AbstractUIElements.Add(new AbstractUICollectionViewModel(_coreConfig.AbstractUIElements));
             });
         }
 
@@ -65,7 +54,7 @@ namespace StrixMusic.Sdk.ViewModels
         public IServiceProvider? Services => _coreConfig.Services;
 
         /// <inheritdoc/>
-        IReadOnlyList<AbstractUICollection> ICoreConfigBase.AbstractUIElements => _coreConfig.AbstractUIElements;
+        AbstractUICollection ICoreConfigBase.AbstractUIElements => _coreConfig.AbstractUIElements;
 
         /// <inheritdoc cref="ICoreConfigBase.AbstractUIElements" />
         public ObservableCollection<AbstractUICollectionViewModel> AbstractUIElements { get; }


### PR DESCRIPTION
Sorry this one took a while. 🙃

Changes only reach as far as the `CoreConfigViewModel`, which still uses an `ObservableCollection`, but the core config classes themselves now only use a single `AbstractUICollection` instead of a list of them.