### PR TITLE
Cleanup model plugin tests

### DIFF
--- a/src/Sdk/StrixMusic.Sdk.Tests/Plugins/Models/AlbumCollectionPluginBaseTests.cs
+++ b/src/Sdk/StrixMusic.Sdk.Tests/Plugins/Models/AlbumCollectionPluginBaseTests.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Threading.Tasks;
+using StrixMusic.Sdk.Models.Base;
 
 namespace StrixMusic.Sdk.Tests.Plugins.Models
 {
@@ -17,6 +18,16 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
     {
         private static bool NoInner(MemberInfo x) => !x.Name.Contains("Inner");
         private static bool NoInnerOrSources(MemberInfo x) => NoInner(x) && x.Name != "get_Sources" && x.Name != "get_SourceCores";
+
+        [Flags]
+        public enum PossiblePlugins
+        {
+            None = 0,
+            Playable = 1,
+            Downloadable = 2,
+            ImageCollection = 4,
+            UrlCollection = 8,
+        }
 
         [TestMethod, Timeout(1000)]
         public void NoPlugins()
@@ -86,377 +97,110 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
         }
 
         [TestMethod, Timeout(5000)]
-        public void PluginFullyCustomWith_Downloadable()
+        [AllEnumFlagCombinations(typeof(PossiblePlugins))]
+        public void PluginFullyCustomWith_AllCombinations(PossiblePlugins data)
         {
             var builder = new SdkModelPlugins().AlbumCollection;
-            var finalTestClass = new Unimplemented();
-            builder.Add(x => new NoOverride(x) { InnerDownloadable = new DownloadablePluginBaseTests.Unimplemented() });
-
-            var finalImpl = builder.Execute(finalTestClass);
-
-            Assert.AreNotSame(finalImpl, finalTestClass);
-            Assert.IsInstanceOfType(finalImpl, typeof(NoOverride));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<DownloadablePluginBaseTests.Unimplemented>, DownloadablePluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInner, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<Unimplemented>, NoOverride>(finalImpl, customFilter: NoInner, typesToExclude: new[] { typeof(IAsyncDisposable), typeof(DownloadablePluginBaseTests.Unimplemented) });
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(finalImpl, customFilter: NoInner, expectedExceptions: new[] {
-                typeof(AccessedException<Unimplemented>),
-                typeof(AccessedException<DownloadablePluginBaseTests.Unimplemented>),
-            });
-        }
-
-        [TestMethod, Timeout(5000)]
-        public void PluginFullyCustomWith_ImageCollection()
-        {
-            var builder = new SdkModelPlugins().AlbumCollection;
-            var finalTestClass = new Unimplemented();
-            builder.Add(x => new NoOverride(x) { InnerImageCollection = new ImageCollectionPluginBaseTests.Unimplemented() });
-
-            var finalImpl = builder.Execute(finalTestClass);
-
-            Assert.AreNotSame(finalImpl, finalTestClass);
-            Assert.IsInstanceOfType(finalImpl, typeof(NoOverride));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<ImageCollectionPluginBaseTests.Unimplemented>, ImageCollectionPluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInnerOrSources, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<Unimplemented>, NoOverride>(finalImpl, customFilter: NoInner, typesToExclude: new[] { typeof(IAsyncDisposable), typeof(ImageCollectionPluginBaseTests.Unimplemented) });
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(finalImpl, customFilter: NoInner, expectedExceptions: new[] {
-                typeof(AccessedException<Unimplemented>),
-                typeof(AccessedException<ImageCollectionPluginBaseTests.Unimplemented>),
-            });
-        }
-
-        [TestMethod, Timeout(5000)]
-        public void PluginFullyCustomWith_UrlCollection()
-        {
-            var builder = new SdkModelPlugins().AlbumCollection;
-            var finalTestClass = new Unimplemented();
-            builder.Add(x => new NoOverride(x) { InnerUrlCollection = new UrlCollectionPluginBaseTests.Unimplemented() });
-
-            var finalImpl = builder.Execute(finalTestClass);
-
-            Assert.AreNotSame(finalImpl, finalTestClass);
-            Assert.IsInstanceOfType(finalImpl, typeof(NoOverride));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<UrlCollectionPluginBaseTests.Unimplemented>, UrlCollectionPluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInnerOrSources, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<Unimplemented>, NoOverride>(finalImpl, customFilter: NoInner, typesToExclude: new[] { typeof(IAsyncDisposable), typeof(UrlCollectionPluginBaseTests.Unimplemented) });
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(finalImpl, customFilter: NoInner, expectedExceptions: new[] {
-                typeof(AccessedException<Unimplemented>),
-                typeof(AccessedException<UrlCollectionPluginBaseTests.Unimplemented>),
-            });
-        }
-
-        [TestMethod, Timeout(5000)]
-        public void PluginFullyCustomWith_Downloadable_ImageCollection()
-        {
-            var builder = new SdkModelPlugins().AlbumCollection;
-            var finalTestClass = new Unimplemented();
-            builder.Add(x => new NoOverride(x)
-            {
-                InnerDownloadable = new DownloadablePluginBaseTests.Unimplemented(),
-                InnerImageCollection = new ImageCollectionPluginBaseTests.Unimplemented()
-            });
-
-            var finalImpl = builder.Execute(finalTestClass);
-
-            Assert.AreNotSame(finalImpl, finalTestClass);
-            Assert.IsInstanceOfType(finalImpl, typeof(NoOverride));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<DownloadablePluginBaseTests.Unimplemented>, DownloadablePluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInner, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<ImageCollectionPluginBaseTests.Unimplemented>, ImageCollectionPluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInnerOrSources, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<Unimplemented>, NoOverride>(finalImpl, customFilter: NoInnerOrSources, typesToExclude: new[] { typeof(IAsyncDisposable), typeof(DownloadablePluginBaseTests.Unimplemented), typeof(ImageCollectionPluginBaseTests.Unimplemented) });
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(finalImpl, customFilter: NoInner, expectedExceptions: new[] {
-                typeof(AccessedException<Unimplemented>),
-                typeof(AccessedException<DownloadablePluginBaseTests.Unimplemented>),
-                typeof(AccessedException<ImageCollectionPluginBaseTests.Unimplemented>),
-            });
-        }
-
-        [TestMethod, Timeout(5000)]
-        public void PluginFullyCustomWith_Downloadable_UrlCollection()
-        {
-            var builder = new SdkModelPlugins().AlbumCollection;
-            var finalTestClass = new Unimplemented();
-            builder.Add(x => new NoOverride(x)
-            {
-                InnerDownloadable = new DownloadablePluginBaseTests.Unimplemented(),
-                InnerUrlCollection = new UrlCollectionPluginBaseTests.Unimplemented()
-            });
-
-            var finalImpl = builder.Execute(finalTestClass);
-
-            Assert.AreNotSame(finalImpl, finalTestClass);
-            Assert.IsInstanceOfType(finalImpl, typeof(NoOverride));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<DownloadablePluginBaseTests.Unimplemented>, DownloadablePluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInner, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<UrlCollectionPluginBaseTests.Unimplemented>, UrlCollectionPluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInnerOrSources, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<Unimplemented>, NoOverride>(finalImpl, customFilter: NoInner, typesToExclude: new[] { typeof(IAsyncDisposable), typeof(DownloadablePluginBaseTests.Unimplemented), typeof(UrlCollectionPluginBaseTests.Unimplemented) });
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(finalImpl, customFilter: NoInner, expectedExceptions: new[] {
-                typeof(AccessedException<Unimplemented>),
-                typeof(AccessedException<DownloadablePluginBaseTests.Unimplemented>),
-                typeof(AccessedException<UrlCollectionPluginBaseTests.Unimplemented>),
-            });
-        }
-
-        [TestMethod, Timeout(5000)]
-        public void PluginFullyCustomWith_Downloadable_ImageCollection_UrlCollection()
-        {
-            var builder = new SdkModelPlugins().AlbumCollection;
-
             var defaultImplementation = new Unimplemented();
             builder.Add(x => new NoOverride(x)
             {
-                InnerDownloadable = new DownloadablePluginBaseTests.Unimplemented(),
-                InnerImageCollection = new ImageCollectionPluginBaseTests.Unimplemented(),
-                InnerUrlCollection = new UrlCollectionPluginBaseTests.Unimplemented(),
+                InnerDownloadable = data.HasFlag(PossiblePlugins.Downloadable) ? new DownloadablePluginBaseTests.Unimplemented() : x,
+                InnerPlayable = data.HasFlag(PossiblePlugins.Playable) ? new PlayablePluginBaseTests.Unimplemented() : x,
+                InnerImageCollection = data.HasFlag(PossiblePlugins.ImageCollection) ? new ImageCollectionPluginBaseTests.Unimplemented() : x,
+                InnerUrlCollection = data.HasFlag(PossiblePlugins.UrlCollection) ? new UrlCollectionPluginBaseTests.Unimplemented() : x,
             });
 
             var finalImpl = builder.Execute(defaultImplementation);
 
             Assert.AreNotSame(finalImpl, defaultImplementation);
             Assert.IsInstanceOfType(finalImpl, typeof(NoOverride));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<DownloadablePluginBaseTests.Unimplemented>, DownloadablePluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInner, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<ImageCollectionPluginBaseTests.Unimplemented>, ImageCollectionPluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInnerOrSources, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<UrlCollectionPluginBaseTests.Unimplemented>, UrlCollectionPluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInnerOrSources, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<Unimplemented>, NoOverride>(finalImpl, customFilter: NoInnerOrSources, typesToExclude: new[] { typeof(IAsyncDisposable), typeof(DownloadablePluginBaseTests.Unimplemented), typeof(ImageCollectionPluginBaseTests.Unimplemented), typeof(UrlCollectionPluginBaseTests.Unimplemented) });
 
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(finalImpl, customFilter: NoInner, expectedExceptions: new[] {
+            var expectedExceptionsWhenDisposing = new List<Type>
+            {
                 typeof(AccessedException<Unimplemented>),
-                typeof(AccessedException<DownloadablePluginBaseTests.Unimplemented>),
-                typeof(AccessedException<ImageCollectionPluginBaseTests.Unimplemented>),
-                typeof(AccessedException<UrlCollectionPluginBaseTests.Unimplemented>),
-            });
+            };
+
+            if (data.HasFlag(PossiblePlugins.Downloadable))
+            {
+                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<DownloadablePluginBaseTests.Unimplemented>));
+
+                Helpers.AssertAllMembersThrowOnAccess<AccessedException<DownloadablePluginBaseTests.Unimplemented>,
+                    DownloadablePluginBaseTests.Unimplemented>(
+                    finalImpl,
+                    customFilter: NoInnerOrSources,
+                    typesToExclude: typeof(IAsyncDisposable)
+                );
+            }
+
+            if (data.HasFlag(PossiblePlugins.Playable))
+            {
+                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<PlayablePluginBaseTests.Unimplemented>));
+
+                Helpers.AssertAllMembersThrowOnAccess<AccessedException<PlayablePluginBaseTests.Unimplemented>,
+                    PlayablePluginBaseTests.Unimplemented>(
+                    finalImpl,
+                    customFilter: NoInnerOrSources,
+                    typesToExclude: new[]
+                    {
+                        typeof(IAsyncDisposable),
+                        typeof(DownloadablePluginBaseTests.Unimplemented),
+                        typeof(ImageCollectionPluginBaseTests.Unimplemented),
+                        typeof(UrlCollectionPluginBaseTests.Unimplemented)
+                    }
+                );
+            }
+
+            if (data.HasFlag(PossiblePlugins.ImageCollection))
+            {
+                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<ImageCollectionPluginBaseTests.Unimplemented>));
+
+                Helpers.AssertAllMembersThrowOnAccess<AccessedException<ImageCollectionPluginBaseTests.Unimplemented>,
+                    ImageCollectionPluginBaseTests.Unimplemented>(
+                    finalImpl,
+                    customFilter: NoInnerOrSources,
+                    typesToExclude: typeof(IAsyncDisposable)
+                );
+            }
+
+            if (data.HasFlag(PossiblePlugins.UrlCollection))
+            {
+                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<UrlCollectionPluginBaseTests.Unimplemented>));
+
+                Helpers.AssertAllMembersThrowOnAccess<AccessedException<UrlCollectionPluginBaseTests.Unimplemented>, UrlCollectionPluginBaseTests.Unimplemented>(
+                    finalImpl,
+                    customFilter: NoInnerOrSources,
+                    typesToExclude: typeof(IAsyncDisposable)
+                );
+            }
+
+            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(
+                finalImpl,
+                customFilter: NoInnerOrSources,
+                expectedExceptions: expectedExceptionsWhenDisposing.ToArray()
+            );
         }
 
         [TestMethod, Timeout(5000)]
-        public void PluginFullyCustomWith_ImageCollection_UrlCollection()
+        [AllEnumFlagCombinations(typeof(PossiblePlugins))]
+        public async Task DisposeAsync_AllCombinations(PossiblePlugins data)
         {
             var builder = new SdkModelPlugins().AlbumCollection;
-            var finalTestClass = new Unimplemented();
+            var defaultImplementation = new NotBlockingDisposeAsync();
             builder.Add(x => new NoOverride(x)
             {
-                InnerUrlCollection = new UrlCollectionPluginBaseTests.Unimplemented(),
-                InnerImageCollection = new ImageCollectionPluginBaseTests.Unimplemented()
-            });
-
-            var finalImpl = builder.Execute(finalTestClass);
-
-            Assert.AreNotSame(finalImpl, finalTestClass);
-            Assert.IsInstanceOfType(finalImpl, typeof(NoOverride));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<UrlCollectionPluginBaseTests.Unimplemented>, UrlCollectionPluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInnerOrSources, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<ImageCollectionPluginBaseTests.Unimplemented>, ImageCollectionPluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInnerOrSources, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<Unimplemented>, NoOverride>(finalImpl, customFilter: NoInnerOrSources, typesToExclude: new[] { typeof(IAsyncDisposable), typeof(UrlCollectionPluginBaseTests.Unimplemented), typeof(ImageCollectionPluginBaseTests.Unimplemented) });
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(finalImpl, customFilter: NoInner, expectedExceptions: new[] {
-                typeof(AccessedException<Unimplemented>),
-                typeof(AccessedException<UrlCollectionPluginBaseTests.Unimplemented>),
-                typeof(AccessedException<ImageCollectionPluginBaseTests.Unimplemented>),
-            });
-        }
-        
-        [TestMethod, Timeout(5000)]
-        public void PluginFullyCustomWith_Playable_Downloadable()
-        {
-            var builder = new SdkModelPlugins().AlbumCollection;
-            var finalTestClass = new Unimplemented();
-            builder.Add(x => new NoOverride(x)
-            {
-                InnerDownloadable = new DownloadablePluginBaseTests.Unimplemented(),
-                InnerPlayable = new PlayablePluginBaseTests.Unimplemented(),
-            });
-
-            var finalImpl = builder.Execute(finalTestClass);
-
-            Assert.AreNotSame(finalImpl, finalTestClass);
-            Assert.IsInstanceOfType(finalImpl, typeof(NoOverride));
-
-            // Testing InnerPlayable
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<PlayablePluginBaseTests.Unimplemented>, PlayablePluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInner, typesToExclude: new[] { typeof(IAsyncDisposable), typeof(DownloadablePluginBaseTests.Unimplemented), typeof(ImageCollectionPluginBaseTests.Unimplemented), typeof(UrlCollectionPluginBaseTests.Unimplemented) });
-
-            // Testing InnerDownloadable
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<DownloadablePluginBaseTests.Unimplemented>, DownloadablePluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInner, typesToExclude: typeof(IAsyncDisposable));
-
-            // Testing all other properties
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<Unimplemented>, NoOverride>(finalImpl, customFilter: NoInner, typesToExclude: new[] { typeof(IAsyncDisposable), typeof(DownloadablePluginBaseTests.Unimplemented), typeof(PlayablePluginBaseTests.Unimplemented) });
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(finalImpl, customFilter: NoInner, expectedExceptions: new[] {
-                typeof(AccessedException<Unimplemented>),
-                typeof(AccessedException<DownloadablePluginBaseTests.Unimplemented>),
-                typeof(AccessedException<PlayablePluginBaseTests.Unimplemented>),
-            });
-        }
-
-        [TestMethod, Timeout(5000)]
-        public void PluginFullyCustomWith_Playable_ImageCollection()
-        {
-            var builder = new SdkModelPlugins().AlbumCollection;
-            var finalTestClass = new Unimplemented();
-            builder.Add(x => new NoOverride(x)
-            {
-                InnerImageCollection = new ImageCollectionPluginBaseTests.Unimplemented(),
-                InnerPlayable = new PlayablePluginBaseTests.Unimplemented(),
-            });
-
-            var finalImpl = builder.Execute(finalTestClass);
-
-            Assert.AreNotSame(finalImpl, finalTestClass);
-            Assert.IsInstanceOfType(finalImpl, typeof(NoOverride));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<PlayablePluginBaseTests.Unimplemented>, PlayablePluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInner, typesToExclude: new[] { typeof(IAsyncDisposable), typeof(DownloadablePluginBaseTests.Unimplemented), typeof(ImageCollectionPluginBaseTests.Unimplemented), typeof(UrlCollectionPluginBaseTests.Unimplemented) });
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<ImageCollectionPluginBaseTests.Unimplemented>, ImageCollectionPluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInnerOrSources, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<Unimplemented>, NoOverride>(finalImpl, customFilter: NoInner, typesToExclude: new[] { typeof(IAsyncDisposable), typeof(ImageCollectionPluginBaseTests.Unimplemented), typeof(PlayablePluginBaseTests.Unimplemented) });
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(finalImpl, customFilter: NoInner, expectedExceptions: new[] {
-                typeof(AccessedException<Unimplemented>),
-                typeof(AccessedException<ImageCollectionPluginBaseTests.Unimplemented>),
-                typeof(AccessedException<PlayablePluginBaseTests.Unimplemented>),
-            });
-        }
-
-        [TestMethod, Timeout(5000)]
-        public void PluginFullyCustomWith_Playable_UrlCollection()
-        {
-            var builder = new SdkModelPlugins().AlbumCollection;
-            var finalTestClass = new Unimplemented();
-            builder.Add(x => new NoOverride(x)
-            {
-                InnerUrlCollection = new UrlCollectionPluginBaseTests.Unimplemented(),
-                InnerPlayable = new PlayablePluginBaseTests.Unimplemented(),
-            });
-
-            var finalImpl = builder.Execute(finalTestClass);
-
-            Assert.AreNotSame(finalImpl, finalTestClass);
-            Assert.IsInstanceOfType(finalImpl, typeof(NoOverride));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<PlayablePluginBaseTests.Unimplemented>, PlayablePluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInner, typesToExclude: new[] { typeof(IAsyncDisposable), typeof(DownloadablePluginBaseTests.Unimplemented), typeof(ImageCollectionPluginBaseTests.Unimplemented), typeof(UrlCollectionPluginBaseTests.Unimplemented) });
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<UrlCollectionPluginBaseTests.Unimplemented>, UrlCollectionPluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInnerOrSources, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<Unimplemented>, NoOverride>(finalImpl, customFilter: NoInner, typesToExclude: new[] { typeof(IAsyncDisposable), typeof(UrlCollectionPluginBaseTests.Unimplemented), typeof(PlayablePluginBaseTests.Unimplemented) });
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(finalImpl, customFilter: NoInner, expectedExceptions: new[] {
-                typeof(AccessedException<Unimplemented>),
-                typeof(AccessedException<UrlCollectionPluginBaseTests.Unimplemented>),
-                typeof(AccessedException<PlayablePluginBaseTests.Unimplemented>),
-            });
-        }
-
-        [TestMethod, Timeout(5000)]
-        public void PluginFullyCustomWith_Playable_Downloadable_ImageCollection()
-        {
-            var builder = new SdkModelPlugins().AlbumCollection;
-            var finalTestClass = new Unimplemented();
-            builder.Add(x => new NoOverride(x)
-            {
-                InnerDownloadable = new DownloadablePluginBaseTests.Unimplemented(),
-                InnerImageCollection = new ImageCollectionPluginBaseTests.Unimplemented(),
-                InnerPlayable = new PlayablePluginBaseTests.Unimplemented(),
-            });
-
-            var finalImpl = builder.Execute(finalTestClass);
-
-            Assert.AreNotSame(finalImpl, finalTestClass);
-            Assert.IsInstanceOfType(finalImpl, typeof(NoOverride));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<PlayablePluginBaseTests.Unimplemented>, PlayablePluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInner, typesToExclude: new[] { typeof(IAsyncDisposable), typeof(DownloadablePluginBaseTests.Unimplemented), typeof(ImageCollectionPluginBaseTests.Unimplemented), typeof(UrlCollectionPluginBaseTests.Unimplemented) });
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<DownloadablePluginBaseTests.Unimplemented>, DownloadablePluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInner, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<ImageCollectionPluginBaseTests.Unimplemented>, ImageCollectionPluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInnerOrSources, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<Unimplemented>, NoOverride>(finalImpl, customFilter: NoInnerOrSources, typesToExclude: new[] { typeof(IAsyncDisposable), typeof(DownloadablePluginBaseTests.Unimplemented), typeof(ImageCollectionPluginBaseTests.Unimplemented), typeof(PlayablePluginBaseTests.Unimplemented) });
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(finalImpl, customFilter: NoInner, expectedExceptions: new[] {
-                typeof(AccessedException<Unimplemented>),
-                typeof(AccessedException<DownloadablePluginBaseTests.Unimplemented>),
-                typeof(AccessedException<ImageCollectionPluginBaseTests.Unimplemented>),
-                typeof(AccessedException<PlayablePluginBaseTests.Unimplemented>),
-            });
-        }
-
-        [TestMethod, Timeout(5000)]
-        public void PluginFullyCustomWith_Playable_Downloadable_UrlCollection()
-        {
-            var builder = new SdkModelPlugins().AlbumCollection;
-            var finalTestClass = new Unimplemented();
-            builder.Add(x => new NoOverride(x)
-            {
-                InnerDownloadable = new DownloadablePluginBaseTests.Unimplemented(),
-                InnerUrlCollection = new UrlCollectionPluginBaseTests.Unimplemented(),
-                InnerPlayable = new PlayablePluginBaseTests.Unimplemented(),
-            });
-
-            var finalImpl = builder.Execute(finalTestClass);
-
-            Assert.AreNotSame(finalImpl, finalTestClass);
-            Assert.IsInstanceOfType(finalImpl, typeof(NoOverride));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<PlayablePluginBaseTests.Unimplemented>, PlayablePluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInner, typesToExclude: new[] { typeof(IAsyncDisposable), typeof(DownloadablePluginBaseTests.Unimplemented), typeof(ImageCollectionPluginBaseTests.Unimplemented), typeof(UrlCollectionPluginBaseTests.Unimplemented) });
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<DownloadablePluginBaseTests.Unimplemented>, DownloadablePluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInner, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<UrlCollectionPluginBaseTests.Unimplemented>, UrlCollectionPluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInnerOrSources, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<Unimplemented>, NoOverride>(finalImpl, customFilter: NoInner, typesToExclude: new[] { typeof(IAsyncDisposable), typeof(DownloadablePluginBaseTests.Unimplemented), typeof(UrlCollectionPluginBaseTests.Unimplemented), typeof(PlayablePluginBaseTests.Unimplemented) });
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(finalImpl, customFilter: NoInner, expectedExceptions: new[] {
-                typeof(AccessedException<Unimplemented>),
-                typeof(AccessedException<DownloadablePluginBaseTests.Unimplemented>),
-                typeof(AccessedException<UrlCollectionPluginBaseTests.Unimplemented>),
-                typeof(AccessedException<PlayablePluginBaseTests.Unimplemented>),
-            });
-        }
-
-        [TestMethod, Timeout(5000)]
-        public void PluginFullyCustomWith_Playable_Downloadable_ImageCollection_UrlCollection()
-        {
-            var builder = new SdkModelPlugins().AlbumCollection;
-
-            var defaultImplementation = new Unimplemented();
-            builder.Add(x => new NoOverride(x)
-            {
-                InnerDownloadable = new DownloadablePluginBaseTests.Unimplemented(),
-                InnerImageCollection = new ImageCollectionPluginBaseTests.Unimplemented(),
-                InnerUrlCollection = new UrlCollectionPluginBaseTests.Unimplemented(),
-                InnerPlayable = new PlayablePluginBaseTests.Unimplemented(),
+                InnerDownloadable = data.HasFlag(PossiblePlugins.Downloadable) ? new DownloadablePluginBaseTests.NotBlockingDisposeAsync() : x,
+                InnerPlayable = data.HasFlag(PossiblePlugins.Playable) ? new PlayablePluginBaseTests.NotBlockingDisposeAsync() : x,
+                InnerImageCollection = data.HasFlag(PossiblePlugins.ImageCollection) ? new ImageCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
+                InnerUrlCollection = data.HasFlag(PossiblePlugins.UrlCollection) ? new UrlCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
             });
 
             var finalImpl = builder.Execute(defaultImplementation);
 
             Assert.AreNotSame(finalImpl, defaultImplementation);
             Assert.IsInstanceOfType(finalImpl, typeof(NoOverride));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<PlayablePluginBaseTests.Unimplemented>, PlayablePluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInner, typesToExclude: new[] { typeof(IAsyncDisposable), typeof(DownloadablePluginBaseTests.Unimplemented), typeof(ImageCollectionPluginBaseTests.Unimplemented), typeof(UrlCollectionPluginBaseTests.Unimplemented) });
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<DownloadablePluginBaseTests.Unimplemented>, DownloadablePluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInner, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<ImageCollectionPluginBaseTests.Unimplemented>, ImageCollectionPluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInnerOrSources, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<UrlCollectionPluginBaseTests.Unimplemented>, UrlCollectionPluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInnerOrSources, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<Unimplemented>, NoOverride>(finalImpl, customFilter: NoInnerOrSources, typesToExclude: new[] { typeof(IAsyncDisposable), typeof(DownloadablePluginBaseTests.Unimplemented), typeof(ImageCollectionPluginBaseTests.Unimplemented), typeof(UrlCollectionPluginBaseTests.Unimplemented), typeof(PlayablePluginBaseTests.Unimplemented) });
 
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(finalImpl, customFilter: NoInner, expectedExceptions: new[] {
-                typeof(AccessedException<Unimplemented>),
-                typeof(AccessedException<DownloadablePluginBaseTests.Unimplemented>),
-                typeof(AccessedException<ImageCollectionPluginBaseTests.Unimplemented>),
-                typeof(AccessedException<UrlCollectionPluginBaseTests.Unimplemented>),
-                typeof(AccessedException<PlayablePluginBaseTests.Unimplemented>),
-            });
+            await finalImpl.DisposeAsync();
         }
-
-        [TestMethod, Timeout(5000)]
-        public void PluginFullyCustomWith_Playable_ImageCollection_UrlCollection()
-        {
-            var builder = new SdkModelPlugins().AlbumCollection;
-            var finalTestClass = new Unimplemented();
-            builder.Add(x => new NoOverride(x)
-            {
-                InnerUrlCollection = new UrlCollectionPluginBaseTests.Unimplemented(),
-                InnerImageCollection = new ImageCollectionPluginBaseTests.Unimplemented(),
-                InnerPlayable = new PlayablePluginBaseTests.Unimplemented(),
-            });
-
-            var finalImpl = builder.Execute(finalTestClass);
-
-            Assert.AreNotSame(finalImpl, finalTestClass);
-            Assert.IsInstanceOfType(finalImpl, typeof(NoOverride));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<PlayablePluginBaseTests.Unimplemented>, PlayablePluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInner, typesToExclude: new[] { typeof(IAsyncDisposable), typeof(DownloadablePluginBaseTests.Unimplemented), typeof(ImageCollectionPluginBaseTests.Unimplemented), typeof(UrlCollectionPluginBaseTests.Unimplemented) });
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<UrlCollectionPluginBaseTests.Unimplemented>, UrlCollectionPluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInnerOrSources, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<ImageCollectionPluginBaseTests.Unimplemented>, ImageCollectionPluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInnerOrSources, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<Unimplemented>, NoOverride>(finalImpl, customFilter: NoInnerOrSources, typesToExclude: new[] { typeof(IAsyncDisposable), typeof(UrlCollectionPluginBaseTests.Unimplemented), typeof(ImageCollectionPluginBaseTests.Unimplemented), typeof(PlayablePluginBaseTests.Unimplemented) });
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(finalImpl, customFilter: NoInner, expectedExceptions: new[] {
-                typeof(AccessedException<Unimplemented>),
-                typeof(AccessedException<UrlCollectionPluginBaseTests.Unimplemented>),
-                typeof(AccessedException<ImageCollectionPluginBaseTests.Unimplemented>),
-                typeof(AccessedException<PlayablePluginBaseTests.Unimplemented>),
-            });
-        }
-
 
         internal class FullyCustom : AlbumCollectionPluginBase
         {
@@ -523,7 +267,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
             public override Task<bool> IsRemoveImageAvailableAsync(int index) => throw AccessedException;
             public override Task<bool> IsRemoveUrlAvailableAsync(int index) => throw AccessedException;
             public override Task PauseAlbumCollectionAsync() => throw AccessedException;
-            public override Task PlayAlbumCollectionAsync(IAlbumCollectionItem AlbumItem) => throw AccessedException;
+            public override Task PlayAlbumCollectionAsync(IAlbumCollectionItem albumItem) => throw AccessedException;
             public override Task PlayAlbumCollectionAsync() => throw AccessedException;
             public override Task RemoveAlbumItemAsync(int index) => throw AccessedException;
             public override Task RemoveImageAsync(int index) => throw AccessedException;
@@ -537,6 +281,17 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
                 : base(new ModelPluginMetadata("", nameof(NoOverride), "", new Version()), inner)
             {
             }
+        }
+
+        internal class NotBlockingDisposeAsync : AlbumCollectionPluginBase
+        {
+            public NotBlockingDisposeAsync()
+                : base(new ModelPluginMetadata("", nameof(NotBlockingDisposeAsync), "", new Version()), new Unimplemented())
+            {
+            }
+
+            /// <inheritdoc />
+            public override ValueTask DisposeAsync() => default;
         }
 
         internal class Unimplemented : IAlbumCollection
@@ -583,7 +338,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
             public event CollectionChangedEventHandler<IUrl>? UrlsChanged { add => throw AccessedException; remove => throw AccessedException; }
             public event EventHandler<int>? UrlsCountChanged { add => throw AccessedException; remove => throw AccessedException; }
 
-            public Task AddAlbumItemAsync(IAlbumCollectionItem Album, int index) => throw AccessedException;
+            public Task AddAlbumItemAsync(IAlbumCollectionItem album, int index) => throw AccessedException;
             public Task AddImageAsync(IImage image, int index) => throw AccessedException;
             public Task AddUrlAsync(IUrl url, int index) => throw AccessedException;
             public Task ChangeDescriptionAsync(string? description) => throw AccessedException;

--- a/src/Sdk/StrixMusic.Sdk.Tests/Plugins/Models/AlbumPluginBaseTests.cs
+++ b/src/Sdk/StrixMusic.Sdk.Tests/Plugins/Models/AlbumPluginBaseTests.cs
@@ -246,6 +246,32 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
             );
         }
 
+        [TestMethod, Timeout(5000)]
+        [AllEnumFlagCombinations(typeof(PossiblePlugins))]
+        public async Task DisposeAsync_AllCombinations(PossiblePlugins data)
+        {
+            var builder = new SdkModelPlugins().Album;
+            var defaultImplementation = new NotBlockingDisposeAsync();
+            builder.Add(x => new NoOverride(x)
+                {
+                    InnerDownloadable = data.HasFlag(PossiblePlugins.Downloadable) ? new DownloadablePluginBaseTests.NotBlockingDisposeAsync() : x,
+                    InnerPlayable = data.HasFlag(PossiblePlugins.Playable) ? new PlayablePluginBaseTests.NotBlockingDisposeAsync() : x,
+                    InnerArtistCollection = data.HasFlag(PossiblePlugins.ArtistCollection) ? new ArtistCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
+                    InnerGenreCollection = data.HasFlag(PossiblePlugins.GenreCollection) ? new GenreCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
+                    InnerTrackCollection = data.HasFlag(PossiblePlugins.TrackCollection) ? new TrackCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
+                    InnerImageCollection = data.HasFlag(PossiblePlugins.ImageCollection) ? new ImageCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
+                    InnerUrlCollection = data.HasFlag(PossiblePlugins.UrlCollection) ? new UrlCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
+                }
+            );
+            
+            var finalImpl = builder.Execute(defaultImplementation);
+
+            Assert.AreNotSame(finalImpl, defaultImplementation);
+            Assert.IsInstanceOfType(finalImpl, typeof(NoOverride));
+
+            await finalImpl.DisposeAsync();
+        }
+
         internal class FullyCustom : AlbumPluginBase
         {
             public FullyCustom(IAlbum inner)
@@ -491,6 +517,17 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
                 : base(new ModelPluginMetadata("", nameof(NoOverride), "", new Version()), inner)
             {
             }
+        }
+
+        internal class NotBlockingDisposeAsync : AlbumPluginBase
+        {
+            public NotBlockingDisposeAsync()
+                : base(new ModelPluginMetadata("", nameof(NotBlockingDisposeAsync), "", new Version()), new Unimplemented())
+            {
+            }
+
+            /// <inheritdoc />
+            public override ValueTask DisposeAsync() => default;
         }
 
         internal class Unimplemented : IAlbum

--- a/src/Sdk/StrixMusic.Sdk.Tests/Plugins/Models/ArtistCollectionPluginBaseTests.cs
+++ b/src/Sdk/StrixMusic.Sdk.Tests/Plugins/Models/ArtistCollectionPluginBaseTests.cs
@@ -18,6 +18,16 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
         private static bool NoInner(MemberInfo x) => !x.Name.Contains("Inner");
         private static bool NoInnerOrSources(MemberInfo x) => NoInner(x) && x.Name != "get_Sources" && x.Name != "get_SourceCores";
 
+        [Flags]
+        public enum PossiblePlugins
+        {
+            None = 0,
+            Playable = 1,
+            Downloadable = 2,
+            ImageCollection = 4,
+            UrlCollection = 8,
+        }
+
         [TestMethod, Timeout(1000)]
         public void NoPlugins()
         {
@@ -86,377 +96,110 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
         }
 
         [TestMethod, Timeout(5000)]
-        public void PluginFullyCustomWith_Downloadable()
+        [AllEnumFlagCombinations(typeof(PossiblePlugins))]
+        public void PluginFullyCustomWith_AllCombinations(PossiblePlugins data)
         {
             var builder = new SdkModelPlugins().ArtistCollection;
-            var finalTestClass = new Unimplemented();
-            builder.Add(x => new NoOverride(x) { InnerDownloadable = new DownloadablePluginBaseTests.Unimplemented() });
-
-            var finalImpl = builder.Execute(finalTestClass);
-
-            Assert.AreNotSame(finalImpl, finalTestClass);
-            Assert.IsInstanceOfType(finalImpl, typeof(NoOverride));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<DownloadablePluginBaseTests.Unimplemented>, DownloadablePluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInner, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<Unimplemented>, NoOverride>(finalImpl, customFilter: NoInner, typesToExclude: new[] { typeof(IAsyncDisposable), typeof(DownloadablePluginBaseTests.Unimplemented) });
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(finalImpl, customFilter: NoInner, expectedExceptions: new[] {
-                typeof(AccessedException<Unimplemented>),
-                typeof(AccessedException<DownloadablePluginBaseTests.Unimplemented>),
-            });
-        }
-
-        [TestMethod, Timeout(5000)]
-        public void PluginFullyCustomWith_ImageCollection()
-        {
-            var builder = new SdkModelPlugins().ArtistCollection;
-            var finalTestClass = new Unimplemented();
-            builder.Add(x => new NoOverride(x) { InnerImageCollection = new ImageCollectionPluginBaseTests.Unimplemented() });
-
-            var finalImpl = builder.Execute(finalTestClass);
-
-            Assert.AreNotSame(finalImpl, finalTestClass);
-            Assert.IsInstanceOfType(finalImpl, typeof(NoOverride));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<ImageCollectionPluginBaseTests.Unimplemented>, ImageCollectionPluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInnerOrSources, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<Unimplemented>, NoOverride>(finalImpl, customFilter: NoInner, typesToExclude: new[] { typeof(IAsyncDisposable), typeof(ImageCollectionPluginBaseTests.Unimplemented) });
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(finalImpl, customFilter: NoInner, expectedExceptions: new[] {
-                typeof(AccessedException<Unimplemented>),
-                typeof(AccessedException<ImageCollectionPluginBaseTests.Unimplemented>),
-            });
-        }
-
-        [TestMethod, Timeout(5000)]
-        public void PluginFullyCustomWith_UrlCollection()
-        {
-            var builder = new SdkModelPlugins().ArtistCollection;
-            var finalTestClass = new Unimplemented();
-            builder.Add(x => new NoOverride(x) { InnerUrlCollection = new UrlCollectionPluginBaseTests.Unimplemented() });
-
-            var finalImpl = builder.Execute(finalTestClass);
-
-            Assert.AreNotSame(finalImpl, finalTestClass);
-            Assert.IsInstanceOfType(finalImpl, typeof(NoOverride));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<UrlCollectionPluginBaseTests.Unimplemented>, UrlCollectionPluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInnerOrSources, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<Unimplemented>, NoOverride>(finalImpl, customFilter: NoInner, typesToExclude: new[] { typeof(IAsyncDisposable), typeof(UrlCollectionPluginBaseTests.Unimplemented) });
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(finalImpl, customFilter: NoInner, expectedExceptions: new[] {
-                typeof(AccessedException<Unimplemented>),
-                typeof(AccessedException<UrlCollectionPluginBaseTests.Unimplemented>),
-            });
-        }
-
-        [TestMethod, Timeout(5000)]
-        public void PluginFullyCustomWith_Downloadable_ImageCollection()
-        {
-            var builder = new SdkModelPlugins().ArtistCollection;
-            var finalTestClass = new Unimplemented();
-            builder.Add(x => new NoOverride(x)
-            {
-                InnerDownloadable = new DownloadablePluginBaseTests.Unimplemented(),
-                InnerImageCollection = new ImageCollectionPluginBaseTests.Unimplemented()
-            });
-
-            var finalImpl = builder.Execute(finalTestClass);
-
-            Assert.AreNotSame(finalImpl, finalTestClass);
-            Assert.IsInstanceOfType(finalImpl, typeof(NoOverride));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<DownloadablePluginBaseTests.Unimplemented>, DownloadablePluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInner, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<ImageCollectionPluginBaseTests.Unimplemented>, ImageCollectionPluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInnerOrSources, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<Unimplemented>, NoOverride>(finalImpl, customFilter: NoInnerOrSources, typesToExclude: new[] { typeof(IAsyncDisposable), typeof(DownloadablePluginBaseTests.Unimplemented), typeof(ImageCollectionPluginBaseTests.Unimplemented) });
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(finalImpl, customFilter: NoInner, expectedExceptions: new[] {
-                typeof(AccessedException<Unimplemented>),
-                typeof(AccessedException<DownloadablePluginBaseTests.Unimplemented>),
-                typeof(AccessedException<ImageCollectionPluginBaseTests.Unimplemented>),
-            });
-        }
-
-        [TestMethod, Timeout(5000)]
-        public void PluginFullyCustomWith_Downloadable_UrlCollection()
-        {
-            var builder = new SdkModelPlugins().ArtistCollection;
-            var finalTestClass = new Unimplemented();
-            builder.Add(x => new NoOverride(x)
-            {
-                InnerDownloadable = new DownloadablePluginBaseTests.Unimplemented(),
-                InnerUrlCollection = new UrlCollectionPluginBaseTests.Unimplemented()
-            });
-
-            var finalImpl = builder.Execute(finalTestClass);
-
-            Assert.AreNotSame(finalImpl, finalTestClass);
-            Assert.IsInstanceOfType(finalImpl, typeof(NoOverride));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<DownloadablePluginBaseTests.Unimplemented>, DownloadablePluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInner, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<UrlCollectionPluginBaseTests.Unimplemented>, UrlCollectionPluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInnerOrSources, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<Unimplemented>, NoOverride>(finalImpl, customFilter: NoInner, typesToExclude: new[] { typeof(IAsyncDisposable), typeof(DownloadablePluginBaseTests.Unimplemented), typeof(UrlCollectionPluginBaseTests.Unimplemented) });
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(finalImpl, customFilter: NoInner, expectedExceptions: new[] {
-                typeof(AccessedException<Unimplemented>),
-                typeof(AccessedException<DownloadablePluginBaseTests.Unimplemented>),
-                typeof(AccessedException<UrlCollectionPluginBaseTests.Unimplemented>),
-            });
-        }
-
-        [TestMethod, Timeout(5000)]
-        public void PluginFullyCustomWith_Downloadable_ImageCollection_UrlCollection()
-        {
-            var builder = new SdkModelPlugins().ArtistCollection;
-
             var defaultImplementation = new Unimplemented();
             builder.Add(x => new NoOverride(x)
             {
-                InnerDownloadable = new DownloadablePluginBaseTests.Unimplemented(),
-                InnerImageCollection = new ImageCollectionPluginBaseTests.Unimplemented(),
-                InnerUrlCollection = new UrlCollectionPluginBaseTests.Unimplemented(),
+                InnerDownloadable = data.HasFlag(PossiblePlugins.Downloadable) ? new DownloadablePluginBaseTests.Unimplemented() : x,
+                InnerPlayable = data.HasFlag(PossiblePlugins.Playable) ? new PlayablePluginBaseTests.Unimplemented() : x,
+                InnerImageCollection = data.HasFlag(PossiblePlugins.ImageCollection) ? new ImageCollectionPluginBaseTests.Unimplemented() : x,
+                InnerUrlCollection = data.HasFlag(PossiblePlugins.UrlCollection) ? new UrlCollectionPluginBaseTests.Unimplemented() : x,
             });
 
             var finalImpl = builder.Execute(defaultImplementation);
 
             Assert.AreNotSame(finalImpl, defaultImplementation);
             Assert.IsInstanceOfType(finalImpl, typeof(NoOverride));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<DownloadablePluginBaseTests.Unimplemented>, DownloadablePluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInner, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<ImageCollectionPluginBaseTests.Unimplemented>, ImageCollectionPluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInnerOrSources, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<UrlCollectionPluginBaseTests.Unimplemented>, UrlCollectionPluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInnerOrSources, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<Unimplemented>, NoOverride>(finalImpl, customFilter: NoInnerOrSources, typesToExclude: new[] { typeof(IAsyncDisposable), typeof(DownloadablePluginBaseTests.Unimplemented), typeof(ImageCollectionPluginBaseTests.Unimplemented), typeof(UrlCollectionPluginBaseTests.Unimplemented) });
 
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(finalImpl, customFilter: NoInner, expectedExceptions: new[] {
+            var expectedExceptionsWhenDisposing = new List<Type>
+            {
                 typeof(AccessedException<Unimplemented>),
-                typeof(AccessedException<DownloadablePluginBaseTests.Unimplemented>),
-                typeof(AccessedException<ImageCollectionPluginBaseTests.Unimplemented>),
-                typeof(AccessedException<UrlCollectionPluginBaseTests.Unimplemented>),
-            });
+            };
+
+            if (data.HasFlag(PossiblePlugins.Downloadable))
+            {
+                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<DownloadablePluginBaseTests.Unimplemented>));
+
+                Helpers.AssertAllMembersThrowOnAccess<AccessedException<DownloadablePluginBaseTests.Unimplemented>,
+                    DownloadablePluginBaseTests.Unimplemented>(
+                    finalImpl,
+                    customFilter: NoInnerOrSources,
+                    typesToExclude: typeof(IAsyncDisposable)
+                );
+            }
+
+            if (data.HasFlag(PossiblePlugins.Playable))
+            {
+                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<PlayablePluginBaseTests.Unimplemented>));
+
+                Helpers.AssertAllMembersThrowOnAccess<AccessedException<PlayablePluginBaseTests.Unimplemented>,
+                    PlayablePluginBaseTests.Unimplemented>(
+                    finalImpl,
+                    customFilter: NoInnerOrSources,
+                    typesToExclude: new[]
+                    {
+                        typeof(IAsyncDisposable),
+                        typeof(DownloadablePluginBaseTests.Unimplemented),
+                        typeof(ImageCollectionPluginBaseTests.Unimplemented),
+                        typeof(UrlCollectionPluginBaseTests.Unimplemented)
+                    }
+                );
+            }
+
+            if (data.HasFlag(PossiblePlugins.ImageCollection))
+            {
+                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<ImageCollectionPluginBaseTests.Unimplemented>));
+
+                Helpers.AssertAllMembersThrowOnAccess<AccessedException<ImageCollectionPluginBaseTests.Unimplemented>,
+                    ImageCollectionPluginBaseTests.Unimplemented>(
+                    finalImpl,
+                    customFilter: NoInnerOrSources,
+                    typesToExclude: typeof(IAsyncDisposable)
+                );
+            }
+
+            if (data.HasFlag(PossiblePlugins.UrlCollection))
+            {
+                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<UrlCollectionPluginBaseTests.Unimplemented>));
+
+                Helpers.AssertAllMembersThrowOnAccess<AccessedException<UrlCollectionPluginBaseTests.Unimplemented>, UrlCollectionPluginBaseTests.Unimplemented>(
+                    finalImpl,
+                    customFilter: NoInnerOrSources,
+                    typesToExclude: typeof(IAsyncDisposable)
+                );
+            }
+
+            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(
+                finalImpl,
+                customFilter: NoInnerOrSources,
+                expectedExceptions: expectedExceptionsWhenDisposing.ToArray()
+            );
         }
 
         [TestMethod, Timeout(5000)]
-        public void PluginFullyCustomWith_ImageCollection_UrlCollection()
+        [AllEnumFlagCombinations(typeof(PossiblePlugins))]
+        public async Task DisposeAsync_AllCombinations(PossiblePlugins data)
         {
             var builder = new SdkModelPlugins().ArtistCollection;
-            var finalTestClass = new Unimplemented();
+            var defaultImplementation = new NotBlockingDisposeAsync();
             builder.Add(x => new NoOverride(x)
             {
-                InnerUrlCollection = new UrlCollectionPluginBaseTests.Unimplemented(),
-                InnerImageCollection = new ImageCollectionPluginBaseTests.Unimplemented()
-            });
-
-            var finalImpl = builder.Execute(finalTestClass);
-
-            Assert.AreNotSame(finalImpl, finalTestClass);
-            Assert.IsInstanceOfType(finalImpl, typeof(NoOverride));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<UrlCollectionPluginBaseTests.Unimplemented>, UrlCollectionPluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInnerOrSources, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<ImageCollectionPluginBaseTests.Unimplemented>, ImageCollectionPluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInnerOrSources, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<Unimplemented>, NoOverride>(finalImpl, customFilter: NoInnerOrSources, typesToExclude: new[] { typeof(IAsyncDisposable), typeof(UrlCollectionPluginBaseTests.Unimplemented), typeof(ImageCollectionPluginBaseTests.Unimplemented) });
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(finalImpl, customFilter: NoInner, expectedExceptions: new[] {
-                typeof(AccessedException<Unimplemented>),
-                typeof(AccessedException<UrlCollectionPluginBaseTests.Unimplemented>),
-                typeof(AccessedException<ImageCollectionPluginBaseTests.Unimplemented>),
-            });
-        }
-
-        [TestMethod, Timeout(5000)]
-        public void PluginFullyCustomWith_Playable_Downloadable()
-        {
-            var builder = new SdkModelPlugins().ArtistCollection;
-            var finalTestClass = new Unimplemented();
-            builder.Add(x => new NoOverride(x)
-            {
-                InnerDownloadable = new DownloadablePluginBaseTests.Unimplemented(),
-                InnerPlayable = new PlayablePluginBaseTests.Unimplemented(),
-            });
-
-            var finalImpl = builder.Execute(finalTestClass);
-
-            Assert.AreNotSame(finalImpl, finalTestClass);
-            Assert.IsInstanceOfType(finalImpl, typeof(NoOverride));
-
-            // Testing InnerPlayable
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<PlayablePluginBaseTests.Unimplemented>, PlayablePluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInner, typesToExclude: new[] { typeof(IAsyncDisposable), typeof(DownloadablePluginBaseTests.Unimplemented), typeof(ImageCollectionPluginBaseTests.Unimplemented), typeof(UrlCollectionPluginBaseTests.Unimplemented) });
-
-            // Testing InnerDownloadable
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<DownloadablePluginBaseTests.Unimplemented>, DownloadablePluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInner, typesToExclude: typeof(IAsyncDisposable));
-
-            // Testing all other properties
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<Unimplemented>, NoOverride>(finalImpl, customFilter: NoInner, typesToExclude: new[] { typeof(IAsyncDisposable), typeof(DownloadablePluginBaseTests.Unimplemented), typeof(PlayablePluginBaseTests.Unimplemented) });
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(finalImpl, customFilter: NoInner, expectedExceptions: new[] {
-                typeof(AccessedException<Unimplemented>),
-                typeof(AccessedException<DownloadablePluginBaseTests.Unimplemented>),
-                typeof(AccessedException<PlayablePluginBaseTests.Unimplemented>),
-            });
-        }
-
-        [TestMethod, Timeout(5000)]
-        public void PluginFullyCustomWith_Playable_ImageCollection()
-        {
-            var builder = new SdkModelPlugins().ArtistCollection;
-            var finalTestClass = new Unimplemented();
-            builder.Add(x => new NoOverride(x)
-            {
-                InnerImageCollection = new ImageCollectionPluginBaseTests.Unimplemented(),
-                InnerPlayable = new PlayablePluginBaseTests.Unimplemented(),
-            });
-
-            var finalImpl = builder.Execute(finalTestClass);
-
-            Assert.AreNotSame(finalImpl, finalTestClass);
-            Assert.IsInstanceOfType(finalImpl, typeof(NoOverride));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<PlayablePluginBaseTests.Unimplemented>, PlayablePluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInner, typesToExclude: new[] { typeof(IAsyncDisposable), typeof(DownloadablePluginBaseTests.Unimplemented), typeof(ImageCollectionPluginBaseTests.Unimplemented), typeof(UrlCollectionPluginBaseTests.Unimplemented) });
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<ImageCollectionPluginBaseTests.Unimplemented>, ImageCollectionPluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInnerOrSources, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<Unimplemented>, NoOverride>(finalImpl, customFilter: NoInner, typesToExclude: new[] { typeof(IAsyncDisposable), typeof(ImageCollectionPluginBaseTests.Unimplemented), typeof(PlayablePluginBaseTests.Unimplemented) });
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(finalImpl, customFilter: NoInner, expectedExceptions: new[] {
-                typeof(AccessedException<Unimplemented>),
-                typeof(AccessedException<ImageCollectionPluginBaseTests.Unimplemented>),
-                typeof(AccessedException<PlayablePluginBaseTests.Unimplemented>),
-            });
-        }
-
-        [TestMethod, Timeout(5000)]
-        public void PluginFullyCustomWith_Playable_UrlCollection()
-        {
-            var builder = new SdkModelPlugins().ArtistCollection;
-            var finalTestClass = new Unimplemented();
-            builder.Add(x => new NoOverride(x)
-            {
-                InnerUrlCollection = new UrlCollectionPluginBaseTests.Unimplemented(),
-                InnerPlayable = new PlayablePluginBaseTests.Unimplemented(),
-            });
-
-            var finalImpl = builder.Execute(finalTestClass);
-
-            Assert.AreNotSame(finalImpl, finalTestClass);
-            Assert.IsInstanceOfType(finalImpl, typeof(NoOverride));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<PlayablePluginBaseTests.Unimplemented>, PlayablePluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInner, typesToExclude: new[] { typeof(IAsyncDisposable), typeof(DownloadablePluginBaseTests.Unimplemented), typeof(ImageCollectionPluginBaseTests.Unimplemented), typeof(UrlCollectionPluginBaseTests.Unimplemented) });
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<UrlCollectionPluginBaseTests.Unimplemented>, UrlCollectionPluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInnerOrSources, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<Unimplemented>, NoOverride>(finalImpl, customFilter: NoInner, typesToExclude: new[] { typeof(IAsyncDisposable), typeof(UrlCollectionPluginBaseTests.Unimplemented), typeof(PlayablePluginBaseTests.Unimplemented) });
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(finalImpl, customFilter: NoInner, expectedExceptions: new[] {
-                typeof(AccessedException<Unimplemented>),
-                typeof(AccessedException<UrlCollectionPluginBaseTests.Unimplemented>),
-                typeof(AccessedException<PlayablePluginBaseTests.Unimplemented>),
-            });
-        }
-
-        [TestMethod, Timeout(5000)]
-        public void PluginFullyCustomWith_Playable_Downloadable_ImageCollection()
-        {
-            var builder = new SdkModelPlugins().ArtistCollection;
-            var finalTestClass = new Unimplemented();
-            builder.Add(x => new NoOverride(x)
-            {
-                InnerDownloadable = new DownloadablePluginBaseTests.Unimplemented(),
-                InnerImageCollection = new ImageCollectionPluginBaseTests.Unimplemented(),
-                InnerPlayable = new PlayablePluginBaseTests.Unimplemented(),
-            });
-
-            var finalImpl = builder.Execute(finalTestClass);
-
-            Assert.AreNotSame(finalImpl, finalTestClass);
-            Assert.IsInstanceOfType(finalImpl, typeof(NoOverride));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<PlayablePluginBaseTests.Unimplemented>, PlayablePluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInner, typesToExclude: new[] { typeof(IAsyncDisposable), typeof(DownloadablePluginBaseTests.Unimplemented), typeof(ImageCollectionPluginBaseTests.Unimplemented), typeof(UrlCollectionPluginBaseTests.Unimplemented) });
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<DownloadablePluginBaseTests.Unimplemented>, DownloadablePluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInner, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<ImageCollectionPluginBaseTests.Unimplemented>, ImageCollectionPluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInnerOrSources, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<Unimplemented>, NoOverride>(finalImpl, customFilter: NoInnerOrSources, typesToExclude: new[] { typeof(IAsyncDisposable), typeof(DownloadablePluginBaseTests.Unimplemented), typeof(ImageCollectionPluginBaseTests.Unimplemented), typeof(PlayablePluginBaseTests.Unimplemented) });
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(finalImpl, customFilter: NoInner, expectedExceptions: new[] {
-                typeof(AccessedException<Unimplemented>),
-                typeof(AccessedException<DownloadablePluginBaseTests.Unimplemented>),
-                typeof(AccessedException<ImageCollectionPluginBaseTests.Unimplemented>),
-                typeof(AccessedException<PlayablePluginBaseTests.Unimplemented>),
-            });
-        }
-
-        [TestMethod, Timeout(5000)]
-        public void PluginFullyCustomWith_Playable_Downloadable_UrlCollection()
-        {
-            var builder = new SdkModelPlugins().ArtistCollection;
-            var finalTestClass = new Unimplemented();
-            builder.Add(x => new NoOverride(x)
-            {
-                InnerDownloadable = new DownloadablePluginBaseTests.Unimplemented(),
-                InnerUrlCollection = new UrlCollectionPluginBaseTests.Unimplemented(),
-                InnerPlayable = new PlayablePluginBaseTests.Unimplemented(),
-            });
-
-            var finalImpl = builder.Execute(finalTestClass);
-
-            Assert.AreNotSame(finalImpl, finalTestClass);
-            Assert.IsInstanceOfType(finalImpl, typeof(NoOverride));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<PlayablePluginBaseTests.Unimplemented>, PlayablePluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInner, typesToExclude: new[] { typeof(IAsyncDisposable), typeof(DownloadablePluginBaseTests.Unimplemented), typeof(ImageCollectionPluginBaseTests.Unimplemented), typeof(UrlCollectionPluginBaseTests.Unimplemented) });
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<DownloadablePluginBaseTests.Unimplemented>, DownloadablePluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInner, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<UrlCollectionPluginBaseTests.Unimplemented>, UrlCollectionPluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInnerOrSources, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<Unimplemented>, NoOverride>(finalImpl, customFilter: NoInner, typesToExclude: new[] { typeof(IAsyncDisposable), typeof(DownloadablePluginBaseTests.Unimplemented), typeof(UrlCollectionPluginBaseTests.Unimplemented), typeof(PlayablePluginBaseTests.Unimplemented) });
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(finalImpl, customFilter: NoInner, expectedExceptions: new[] {
-                typeof(AccessedException<Unimplemented>),
-                typeof(AccessedException<DownloadablePluginBaseTests.Unimplemented>),
-                typeof(AccessedException<UrlCollectionPluginBaseTests.Unimplemented>),
-                typeof(AccessedException<PlayablePluginBaseTests.Unimplemented>),
-            });
-        }
-
-        [TestMethod, Timeout(5000)]
-        public void PluginFullyCustomWith_Playable_Downloadable_ImageCollection_UrlCollection()
-        {
-            var builder = new SdkModelPlugins().ArtistCollection;
-
-            var defaultImplementation = new Unimplemented();
-            builder.Add(x => new NoOverride(x)
-            {
-                InnerDownloadable = new DownloadablePluginBaseTests.Unimplemented(),
-                InnerImageCollection = new ImageCollectionPluginBaseTests.Unimplemented(),
-                InnerUrlCollection = new UrlCollectionPluginBaseTests.Unimplemented(),
-                InnerPlayable = new PlayablePluginBaseTests.Unimplemented(),
+                InnerDownloadable = data.HasFlag(PossiblePlugins.Downloadable) ? new DownloadablePluginBaseTests.NotBlockingDisposeAsync() : x,
+                InnerPlayable = data.HasFlag(PossiblePlugins.Playable) ? new PlayablePluginBaseTests.NotBlockingDisposeAsync() : x,
+                InnerImageCollection = data.HasFlag(PossiblePlugins.ImageCollection) ? new ImageCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
+                InnerUrlCollection = data.HasFlag(PossiblePlugins.UrlCollection) ? new UrlCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
             });
 
             var finalImpl = builder.Execute(defaultImplementation);
 
             Assert.AreNotSame(finalImpl, defaultImplementation);
             Assert.IsInstanceOfType(finalImpl, typeof(NoOverride));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<PlayablePluginBaseTests.Unimplemented>, PlayablePluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInner, typesToExclude: new[] { typeof(IAsyncDisposable), typeof(DownloadablePluginBaseTests.Unimplemented), typeof(ImageCollectionPluginBaseTests.Unimplemented), typeof(UrlCollectionPluginBaseTests.Unimplemented) });
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<DownloadablePluginBaseTests.Unimplemented>, DownloadablePluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInner, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<ImageCollectionPluginBaseTests.Unimplemented>, ImageCollectionPluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInnerOrSources, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<UrlCollectionPluginBaseTests.Unimplemented>, UrlCollectionPluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInnerOrSources, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<Unimplemented>, NoOverride>(finalImpl, customFilter: NoInnerOrSources, typesToExclude: new[] { typeof(IAsyncDisposable), typeof(DownloadablePluginBaseTests.Unimplemented), typeof(ImageCollectionPluginBaseTests.Unimplemented), typeof(UrlCollectionPluginBaseTests.Unimplemented), typeof(PlayablePluginBaseTests.Unimplemented) });
 
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(finalImpl, customFilter: NoInner, expectedExceptions: new[] {
-                typeof(AccessedException<Unimplemented>),
-                typeof(AccessedException<DownloadablePluginBaseTests.Unimplemented>),
-                typeof(AccessedException<ImageCollectionPluginBaseTests.Unimplemented>),
-                typeof(AccessedException<UrlCollectionPluginBaseTests.Unimplemented>),
-                typeof(AccessedException<PlayablePluginBaseTests.Unimplemented>),
-            });
+            await finalImpl.DisposeAsync();
         }
-
-        [TestMethod, Timeout(5000)]
-        public void PluginFullyCustomWith_Playable_ImageCollection_UrlCollection()
-        {
-            var builder = new SdkModelPlugins().ArtistCollection;
-            var finalTestClass = new Unimplemented();
-            builder.Add(x => new NoOverride(x)
-            {
-                InnerUrlCollection = new UrlCollectionPluginBaseTests.Unimplemented(),
-                InnerImageCollection = new ImageCollectionPluginBaseTests.Unimplemented(),
-                InnerPlayable = new PlayablePluginBaseTests.Unimplemented(),
-            });
-
-            var finalImpl = builder.Execute(finalTestClass);
-
-            Assert.AreNotSame(finalImpl, finalTestClass);
-            Assert.IsInstanceOfType(finalImpl, typeof(NoOverride));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<PlayablePluginBaseTests.Unimplemented>, PlayablePluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInner, typesToExclude: new[] { typeof(IAsyncDisposable), typeof(DownloadablePluginBaseTests.Unimplemented), typeof(ImageCollectionPluginBaseTests.Unimplemented), typeof(UrlCollectionPluginBaseTests.Unimplemented) });
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<UrlCollectionPluginBaseTests.Unimplemented>, UrlCollectionPluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInnerOrSources, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<ImageCollectionPluginBaseTests.Unimplemented>, ImageCollectionPluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInnerOrSources, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<Unimplemented>, NoOverride>(finalImpl, customFilter: NoInnerOrSources, typesToExclude: new[] { typeof(IAsyncDisposable), typeof(UrlCollectionPluginBaseTests.Unimplemented), typeof(ImageCollectionPluginBaseTests.Unimplemented), typeof(PlayablePluginBaseTests.Unimplemented) });
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(finalImpl, customFilter: NoInner, expectedExceptions: new[] {
-                typeof(AccessedException<Unimplemented>),
-                typeof(AccessedException<UrlCollectionPluginBaseTests.Unimplemented>),
-                typeof(AccessedException<ImageCollectionPluginBaseTests.Unimplemented>),
-                typeof(AccessedException<PlayablePluginBaseTests.Unimplemented>),
-            });
-        }
-
 
         internal class FullyCustom : ArtistCollectionPluginBase
         {
@@ -537,6 +280,17 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
                 : base(new ModelPluginMetadata("", nameof(NoOverride), "", new Version()), inner)
             {
             }
+        }
+
+        internal class NotBlockingDisposeAsync : ArtistCollectionPluginBase
+        {
+            public NotBlockingDisposeAsync()
+                : base(new ModelPluginMetadata("", nameof(NotBlockingDisposeAsync), "", new Version()), new Unimplemented())
+            {
+            }
+
+            /// <inheritdoc />
+            public override ValueTask DisposeAsync() => default;
         }
 
         internal class Unimplemented : IArtistCollection

--- a/src/Sdk/StrixMusic.Sdk.Tests/Plugins/Models/ArtistPluginBaseTests.cs
+++ b/src/Sdk/StrixMusic.Sdk.Tests/Plugins/Models/ArtistPluginBaseTests.cs
@@ -114,15 +114,15 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
             var builder = new SdkModelPlugins().Artist;
             var defaultImplementation = new Unimplemented();
             builder.Add(x => new NoOverride(x)
-                {
-                    InnerDownloadable = data.HasFlag(PossiblePlugins.Downloadable) ? new DownloadablePluginBaseTests.Unimplemented() : x,
-                    InnerPlayable = data.HasFlag(PossiblePlugins.Playable) ? new PlayablePluginBaseTests.Unimplemented() : x,
-                    InnerAlbumCollection = data.HasFlag(PossiblePlugins.AlbumCollection) ? new AlbumCollectionPluginBaseTests.Unimplemented() : x,
-                    InnerGenreCollection = data.HasFlag(PossiblePlugins.GenreCollection) ? new GenreCollectionPluginBaseTests.Unimplemented() : x,
-                    InnerTrackCollection = data.HasFlag(PossiblePlugins.TrackCollection) ? new TrackCollectionPluginBaseTests.Unimplemented() : x,
-                    InnerImageCollection = data.HasFlag(PossiblePlugins.ImageCollection) ? new ImageCollectionPluginBaseTests.Unimplemented() : x,
-                    InnerUrlCollection = data.HasFlag(PossiblePlugins.UrlCollection) ? new UrlCollectionPluginBaseTests.Unimplemented() : x,
-                }
+            {
+                InnerDownloadable = data.HasFlag(PossiblePlugins.Downloadable) ? new DownloadablePluginBaseTests.Unimplemented() : x,
+                InnerPlayable = data.HasFlag(PossiblePlugins.Playable) ? new PlayablePluginBaseTests.Unimplemented() : x,
+                InnerAlbumCollection = data.HasFlag(PossiblePlugins.AlbumCollection) ? new AlbumCollectionPluginBaseTests.Unimplemented() : x,
+                InnerGenreCollection = data.HasFlag(PossiblePlugins.GenreCollection) ? new GenreCollectionPluginBaseTests.Unimplemented() : x,
+                InnerTrackCollection = data.HasFlag(PossiblePlugins.TrackCollection) ? new TrackCollectionPluginBaseTests.Unimplemented() : x,
+                InnerImageCollection = data.HasFlag(PossiblePlugins.ImageCollection) ? new ImageCollectionPluginBaseTests.Unimplemented() : x,
+                InnerUrlCollection = data.HasFlag(PossiblePlugins.UrlCollection) ? new UrlCollectionPluginBaseTests.Unimplemented() : x,
+            }
             );
 
             var finalImpl = builder.Execute(defaultImplementation);
@@ -244,6 +244,31 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
                 customFilter: NoInnerOrSources,
                 expectedExceptions: expectedExceptionsWhenDisposing.ToArray()
             );
+        }
+
+        [TestMethod, Timeout(5000)]
+        [AllEnumFlagCombinations(typeof(PossiblePlugins))]
+        public async Task DisposeAsync_AllCombinations(PossiblePlugins data)
+        {
+            var builder = new SdkModelPlugins().Artist;
+            var defaultImplementation = new NotBlockingDisposeAsync();
+            builder.Add(x => new NoOverride(x)
+            {
+                InnerDownloadable = data.HasFlag(PossiblePlugins.Downloadable) ? new DownloadablePluginBaseTests.NotBlockingDisposeAsync() : x,
+                InnerPlayable = data.HasFlag(PossiblePlugins.Playable) ? new PlayablePluginBaseTests.NotBlockingDisposeAsync() : x,
+                InnerAlbumCollection = data.HasFlag(PossiblePlugins.AlbumCollection) ? new AlbumCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
+                InnerGenreCollection = data.HasFlag(PossiblePlugins.GenreCollection) ? new GenreCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
+                InnerTrackCollection = data.HasFlag(PossiblePlugins.TrackCollection) ? new TrackCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
+                InnerImageCollection = data.HasFlag(PossiblePlugins.ImageCollection) ? new ImageCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
+                InnerUrlCollection = data.HasFlag(PossiblePlugins.UrlCollection) ? new UrlCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
+            });
+
+            var finalImpl = builder.Execute(defaultImplementation);
+
+            Assert.AreNotSame(finalImpl, defaultImplementation);
+            Assert.IsInstanceOfType(finalImpl, typeof(NoOverride));
+
+            await finalImpl.DisposeAsync();
         }
 
         internal class FullyCustom : ArtistPluginBase
@@ -531,6 +556,17 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
                 : base(new ModelPluginMetadata("", nameof(NoOverride), "", new Version()), inner)
             {
             }
+        }
+
+        internal class NotBlockingDisposeAsync : ArtistPluginBase
+        {
+            public NotBlockingDisposeAsync()
+                : base(new ModelPluginMetadata("", nameof(NotBlockingDisposeAsync), "", new Version()), new Unimplemented())
+            {
+            }
+
+            /// <inheritdoc />
+            public override ValueTask DisposeAsync() => default;
         }
 
         internal class Unimplemented : IArtist

--- a/src/Sdk/StrixMusic.Sdk.Tests/Plugins/Models/DiscoverablesPluginBaseTests.cs
+++ b/src/Sdk/StrixMusic.Sdk.Tests/Plugins/Models/DiscoverablesPluginBaseTests.cs
@@ -268,6 +268,28 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
             );
         }
 
+        [TestMethod, Timeout(5000)]
+        [AllEnumFlagCombinations(typeof(PossiblePlugins))]
+        public async Task DisposeAsync_AllCombinations(PossiblePlugins data)
+        {
+            var builder = new SdkModelPlugins().Discoverables;
+            var defaultImplementation = new NotBlockingDisposeAsync();
+            builder.Add(x => new NoOverride(x)
+            {
+                InnerDownloadable = data.HasFlag(PossiblePlugins.Downloadable) ? new DownloadablePluginBaseTests.NotBlockingDisposeAsync() : x,
+                InnerPlayable = data.HasFlag(PossiblePlugins.Playable) ? new PlayablePluginBaseTests.NotBlockingDisposeAsync() : x,
+                InnerImageCollection = data.HasFlag(PossiblePlugins.ImageCollection) ? new ImageCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
+                InnerUrlCollection = data.HasFlag(PossiblePlugins.UrlCollection) ? new UrlCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
+            });
+
+            var finalImpl = builder.Execute(defaultImplementation);
+
+            Assert.AreNotSame(finalImpl, defaultImplementation);
+            Assert.IsInstanceOfType(finalImpl, typeof(NoOverride));
+
+            await finalImpl.DisposeAsync();
+        }
+
         internal class FullyCustom : DiscoverablesPluginBase
         {
             public FullyCustom(IDiscoverables inner)
@@ -409,6 +431,17 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
                 : base(new ModelPluginMetadata("", nameof(NoOverride), "", new Version()), inner)
             {
             }
+        }
+
+        internal class NotBlockingDisposeAsync : DiscoverablesPluginBase
+        {
+            public NotBlockingDisposeAsync()
+                : base(new ModelPluginMetadata("", nameof(NotBlockingDisposeAsync), "", new Version()), new Unimplemented())
+            {
+            }
+
+            /// <inheritdoc />
+            public override ValueTask DisposeAsync() => default;
         }
 
         internal class Unimplemented : IDiscoverables

--- a/src/Sdk/StrixMusic.Sdk.Tests/Plugins/Models/DownloadablePluginBaseTests.cs
+++ b/src/Sdk/StrixMusic.Sdk.Tests/Plugins/Models/DownloadablePluginBaseTests.cs
@@ -94,6 +94,17 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
             }
         }
 
+        internal class NotBlockingDisposeAsync : DownloadablePluginBase
+        {
+            public NotBlockingDisposeAsync()
+                : base(new ModelPluginMetadata("", nameof(NotBlockingDisposeAsync), "", new Version()), new Unimplemented())
+            {
+            }
+
+            /// <inheritdoc />
+            public override ValueTask DisposeAsync() => default;
+        }
+
         public class Unimplemented : IDownloadable
         {
             internal static AccessedException<Unimplemented> AccessedException { get; } = new();

--- a/src/Sdk/StrixMusic.Sdk.Tests/Plugins/Models/GenreCollectionPluginBaseTests.cs
+++ b/src/Sdk/StrixMusic.Sdk.Tests/Plugins/Models/GenreCollectionPluginBaseTests.cs
@@ -115,6 +115,17 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
             }
         }
 
+        internal class NotBlockingDisposeAsync : GenreCollectionPluginBase
+        {
+            public NotBlockingDisposeAsync()
+                : base(new ModelPluginMetadata("", nameof(NotBlockingDisposeAsync), "", new Version()), new Unimplemented())
+            {
+            }
+
+            /// <inheritdoc />
+            public override ValueTask DisposeAsync() => default;
+        }
+
         public class Unimplemented : IGenreCollection
         {
             internal static AccessedException<Unimplemented> AccessedException { get; } = new();

--- a/src/Sdk/StrixMusic.Sdk.Tests/Plugins/Models/ImageCollectionPluginBaseTests.cs
+++ b/src/Sdk/StrixMusic.Sdk.Tests/Plugins/Models/ImageCollectionPluginBaseTests.cs
@@ -115,6 +115,17 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
             }
         }
 
+        internal class NotBlockingDisposeAsync : ImageCollectionPluginBase
+        {
+            public NotBlockingDisposeAsync()
+                : base(new ModelPluginMetadata("", nameof(NotBlockingDisposeAsync), "", new Version()), new Unimplemented())
+            {
+            }
+
+            /// <inheritdoc />
+            public override ValueTask DisposeAsync() => default;
+        }
+
         public class Unimplemented : IImageCollection
         {
             internal static AccessedException<Unimplemented> AccessedException { get; } = new();

--- a/src/Sdk/StrixMusic.Sdk.Tests/Plugins/Models/ImagePluginBaseTests.cs
+++ b/src/Sdk/StrixMusic.Sdk.Tests/Plugins/Models/ImagePluginBaseTests.cs
@@ -105,6 +105,17 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
             }
         }
 
+        internal class NotBlockingDisposeAsync : ImagePluginBase
+        {
+            public NotBlockingDisposeAsync()
+                : base(new ModelPluginMetadata("", nameof(NotBlockingDisposeAsync), "", new Version()), new Unimplemented())
+            {
+            }
+
+            /// <inheritdoc />
+            public override ValueTask DisposeAsync() => default;
+        }
+
         public class Unimplemented : IImage
         {
             internal static AccessedException<Unimplemented> AccessedException { get; } = new();

--- a/src/Sdk/StrixMusic.Sdk.Tests/Plugins/Models/LibraryPluginBaseTests.cs
+++ b/src/Sdk/StrixMusic.Sdk.Tests/Plugins/Models/LibraryPluginBaseTests.cs
@@ -268,6 +268,32 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
             );
         }
 
+        [TestMethod, Timeout(5000)]
+        [AllEnumFlagCombinations(typeof(PossiblePlugins))]
+        public async Task DisposeAsync_AllCombinations(PossiblePlugins data)
+        {
+            var builder = new SdkModelPlugins().Library;
+            var defaultImplementation = new NotBlockingDisposeAsync();
+            builder.Add(x => new NoOverride(x)
+            {
+                InnerDownloadable = data.HasFlag(PossiblePlugins.Downloadable) ? new DownloadablePluginBaseTests.NotBlockingDisposeAsync() : x,
+                InnerPlayable = data.HasFlag(PossiblePlugins.Playable) ? new PlayablePluginBaseTests.NotBlockingDisposeAsync() : x,
+                InnerArtistCollection = data.HasFlag(PossiblePlugins.ArtistCollection) ? new ArtistCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
+                InnerAlbumCollection = data.HasFlag(PossiblePlugins.AlbumCollection) ? new AlbumCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
+                InnerTrackCollection = data.HasFlag(PossiblePlugins.TrackCollection) ? new TrackCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
+                InnerPlaylistCollection = data.HasFlag(PossiblePlugins.PlaylistCollection) ? new PlaylistCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
+                InnerImageCollection = data.HasFlag(PossiblePlugins.ImageCollection) ? new ImageCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
+                InnerUrlCollection = data.HasFlag(PossiblePlugins.UrlCollection) ? new UrlCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
+            });
+
+            var finalImpl = builder.Execute(defaultImplementation);
+
+            Assert.AreNotSame(finalImpl, defaultImplementation);
+            Assert.IsInstanceOfType(finalImpl, typeof(NoOverride));
+
+            await finalImpl.DisposeAsync();
+        }
+
         internal class FullyCustom : LibraryPluginBase
         {
             public FullyCustom(ILibrary inner)
@@ -409,6 +435,17 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
                 : base(new ModelPluginMetadata("", nameof(NoOverride), "", new Version()), inner)
             {
             }
+        }
+
+        internal class NotBlockingDisposeAsync : LibraryPluginBase
+        {
+            public NotBlockingDisposeAsync()
+                : base(new ModelPluginMetadata("", nameof(NotBlockingDisposeAsync), "", new Version()), new Unimplemented())
+            {
+            }
+
+            /// <inheritdoc />
+            public override ValueTask DisposeAsync() => default;
         }
 
         internal class Unimplemented : ILibrary

--- a/src/Sdk/StrixMusic.Sdk.Tests/Plugins/Models/PlayableCollectionGroupPluginBaseTests.cs
+++ b/src/Sdk/StrixMusic.Sdk.Tests/Plugins/Models/PlayableCollectionGroupPluginBaseTests.cs
@@ -116,8 +116,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
                 InnerPlaylistCollection = data.HasFlag(PossiblePlugins.PlaylistCollection) ? new PlaylistCollectionPluginBaseTests.Unimplemented() : x,
                 InnerImageCollection = data.HasFlag(PossiblePlugins.ImageCollection) ? new ImageCollectionPluginBaseTests.Unimplemented() : x,
                 InnerUrlCollection = data.HasFlag(PossiblePlugins.UrlCollection) ? new UrlCollectionPluginBaseTests.Unimplemented() : x,
-            }
-            );
+            });
 
             var finalImpl = builder.Execute(defaultImplementation);
 
@@ -268,6 +267,32 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
             );
         }
 
+        [TestMethod, Timeout(5000)]
+        [AllEnumFlagCombinations(typeof(PossiblePlugins))]
+        public async Task DisposeAsync_AllCombinations(PossiblePlugins data)
+        {
+            var builder = new SdkModelPlugins().PlayableCollectionGroup;
+            var defaultImplementation = new NotBlockingDisposeAsync();
+            builder.Add(x => new NoOverride(x)
+            {
+                InnerDownloadable = data.HasFlag(PossiblePlugins.Downloadable) ? new DownloadablePluginBaseTests.NotBlockingDisposeAsync() : x,
+                InnerPlayable = data.HasFlag(PossiblePlugins.Playable) ? new PlayablePluginBaseTests.NotBlockingDisposeAsync() : x,
+                InnerArtistCollection = data.HasFlag(PossiblePlugins.ArtistCollection) ? new ArtistCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
+                InnerAlbumCollection = data.HasFlag(PossiblePlugins.AlbumCollection) ? new AlbumCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
+                InnerTrackCollection = data.HasFlag(PossiblePlugins.TrackCollection) ? new TrackCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
+                InnerPlaylistCollection = data.HasFlag(PossiblePlugins.PlaylistCollection) ? new PlaylistCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
+                InnerImageCollection = data.HasFlag(PossiblePlugins.ImageCollection) ? new ImageCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
+                InnerUrlCollection = data.HasFlag(PossiblePlugins.UrlCollection) ? new UrlCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
+            });
+
+            var finalImpl = builder.Execute(defaultImplementation);
+
+            Assert.AreNotSame(finalImpl, defaultImplementation);
+            Assert.IsInstanceOfType(finalImpl, typeof(NoOverride));
+
+            await finalImpl.DisposeAsync();
+        }
+
         internal class FullyCustom : PlayableCollectionGroupPluginBase
         {
             public FullyCustom(IPlayableCollectionGroup inner)
@@ -408,6 +433,17 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
                 : base(new ModelPluginMetadata("", nameof(NoOverride), "", new Version()), inner)
             {
             }
+        }
+
+        internal class NotBlockingDisposeAsync : PlayableCollectionGroupPluginBase
+        {
+            public NotBlockingDisposeAsync()
+                : base(new ModelPluginMetadata("", nameof(NotBlockingDisposeAsync), "", new Version()), new Unimplemented())
+            {
+            }
+
+            /// <inheritdoc />
+            public override ValueTask DisposeAsync() => default;
         }
 
         internal class Unimplemented : IPlayableCollectionGroup

--- a/src/Sdk/StrixMusic.Sdk.Tests/Plugins/Models/PlayablePluginBaseTests.cs
+++ b/src/Sdk/StrixMusic.Sdk.Tests/Plugins/Models/PlayablePluginBaseTests.cs
@@ -18,6 +18,16 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
         private static bool NoInner(MemberInfo x) => !x.Name.Contains("Inner");
         private static bool NoInnerOrSources(MemberInfo x) => NoInner(x) && x.Name != "get_Sources" && x.Name != "get_SourceCores";
 
+        [Flags]
+        public enum PossiblePlugins
+        {
+            None = 0,
+            Playable = 1,
+            Downloadable = 2,
+            ImageCollection = 4,
+            UrlCollection = 8,
+        }
+
         [TestMethod, Timeout(1000)]
         public void NoPlugins()
         {
@@ -86,178 +96,86 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
         }
 
         [TestMethod, Timeout(5000)]
-        public void PluginFullyCustomWith_Downloadable()
+        [AllEnumFlagCombinations(typeof(PossiblePlugins))]
+        public void PluginFullyCustomWith_AllCombinations(PossiblePlugins data)
         {
             var builder = new SdkModelPlugins().Playable;
-            var finalTestClass = new Unimplemented();
-            builder.Add(x => new NoOverride(x) {InnerDownloadable = new DownloadablePluginBaseTests.Unimplemented()});
-
-            var finalImpl = builder.Execute(finalTestClass);
-
-            Assert.AreNotSame(finalImpl, finalTestClass);
-            Assert.IsInstanceOfType(finalImpl, typeof(NoOverride));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<DownloadablePluginBaseTests.Unimplemented>, DownloadablePluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInner, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<Unimplemented>, NoOverride>(finalImpl, customFilter: NoInner, typesToExclude: new[] {typeof(IAsyncDisposable), typeof(DownloadablePluginBaseTests.Unimplemented)});
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(finalImpl, customFilter: NoInner, expectedExceptions: new[]
-            {
-                typeof(AccessedException<Unimplemented>),
-                typeof(AccessedException<DownloadablePluginBaseTests.Unimplemented>),
-            });
-        }
-
-        [TestMethod, Timeout(5000)]
-        public void PluginFullyCustomWith_ImageCollection()
-        {
-            var builder = new SdkModelPlugins().Playable;
-            var finalTestClass = new Unimplemented();
-            builder.Add(x => new NoOverride(x) {InnerImageCollection = new ImageCollectionPluginBaseTests.Unimplemented()});
-
-            var finalImpl = builder.Execute(finalTestClass);
-
-            Assert.AreNotSame(finalImpl, finalTestClass);
-            Assert.IsInstanceOfType(finalImpl, typeof(NoOverride));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<ImageCollectionPluginBaseTests.Unimplemented>, ImageCollectionPluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInner, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<Unimplemented>, NoOverride>(finalImpl, customFilter: NoInner, typesToExclude: new[] {typeof(IAsyncDisposable), typeof(ImageCollectionPluginBaseTests.Unimplemented)});
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(finalImpl, customFilter: NoInner, expectedExceptions: new[]
-            {
-                typeof(AccessedException<Unimplemented>),
-                typeof(AccessedException<ImageCollectionPluginBaseTests.Unimplemented>),
-            });
-        }
-
-        [TestMethod, Timeout(5000)]
-        public void PluginFullyCustomWith_UrlCollection()
-        {
-            var builder = new SdkModelPlugins().Playable;
-            var finalTestClass = new Unimplemented();
-            builder.Add(x => new NoOverride(x) {InnerUrlCollection = new UrlCollectionPluginBaseTests.Unimplemented()});
-
-            var finalImpl = builder.Execute(finalTestClass);
-
-            Assert.AreNotSame(finalImpl, finalTestClass);
-            Assert.IsInstanceOfType(finalImpl, typeof(NoOverride));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<UrlCollectionPluginBaseTests.Unimplemented>, UrlCollectionPluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInner, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<Unimplemented>, NoOverride>(finalImpl, customFilter: NoInner, typesToExclude: new[] {typeof(IAsyncDisposable), typeof(UrlCollectionPluginBaseTests.Unimplemented)});
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(finalImpl, customFilter: NoInner, expectedExceptions: new[]
-            {
-                typeof(AccessedException<Unimplemented>),
-                typeof(AccessedException<UrlCollectionPluginBaseTests.Unimplemented>),
-            });
-        }
-
-        [TestMethod, Timeout(5000)]
-        public void PluginFullyCustomWith_Downloadable_ImageCollection()
-        {
-            var builder = new SdkModelPlugins().Playable;
-            var finalTestClass = new Unimplemented();
-            builder.Add(x => new NoOverride(x)
-            {
-                InnerDownloadable = new DownloadablePluginBaseTests.Unimplemented(),
-                InnerImageCollection = new ImageCollectionPluginBaseTests.Unimplemented()
-            });
-
-            var finalImpl = builder.Execute(finalTestClass);
-
-            Assert.AreNotSame(finalImpl, finalTestClass);
-            Assert.IsInstanceOfType(finalImpl, typeof(NoOverride));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<DownloadablePluginBaseTests.Unimplemented>, DownloadablePluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInner, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<ImageCollectionPluginBaseTests.Unimplemented>, ImageCollectionPluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInner, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<Unimplemented>, NoOverride>(finalImpl, customFilter: NoInner, typesToExclude: new[] {typeof(IAsyncDisposable), typeof(DownloadablePluginBaseTests.Unimplemented), typeof(ImageCollectionPluginBaseTests.Unimplemented)});
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(finalImpl, customFilter: NoInner, expectedExceptions: new[]
-            {
-                typeof(AccessedException<Unimplemented>),
-                typeof(AccessedException<DownloadablePluginBaseTests.Unimplemented>),
-                typeof(AccessedException<ImageCollectionPluginBaseTests.Unimplemented>),
-            });
-        }
-
-        [TestMethod, Timeout(5000)]
-        public void PluginFullyCustomWith_Downloadable_UrlCollection()
-        {
-            var builder = new SdkModelPlugins().Playable;
-            var finalTestClass = new Unimplemented();
-            builder.Add(x => new NoOverride(x)
-            {
-                InnerDownloadable = new DownloadablePluginBaseTests.Unimplemented(),
-                InnerUrlCollection = new UrlCollectionPluginBaseTests.Unimplemented()
-            });
-
-            var finalImpl = builder.Execute(finalTestClass);
-
-            Assert.AreNotSame(finalImpl, finalTestClass);
-            Assert.IsInstanceOfType(finalImpl, typeof(NoOverride));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<DownloadablePluginBaseTests.Unimplemented>, DownloadablePluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInner, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<UrlCollectionPluginBaseTests.Unimplemented>, UrlCollectionPluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInner, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<Unimplemented>, NoOverride>(finalImpl, customFilter: NoInner, typesToExclude: new[] {typeof(IAsyncDisposable), typeof(DownloadablePluginBaseTests.Unimplemented), typeof(UrlCollectionPluginBaseTests.Unimplemented)});
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(finalImpl, customFilter: NoInner, expectedExceptions: new[]
-            {
-                typeof(AccessedException<Unimplemented>),
-                typeof(AccessedException<DownloadablePluginBaseTests.Unimplemented>),
-                typeof(AccessedException<UrlCollectionPluginBaseTests.Unimplemented>),
-            });
-        }
-
-        [TestMethod, Timeout(5000)]
-        public void PluginFullyCustomWith_Downloadable_ImageCollection_UrlCollection()
-        {
-            var builder = new SdkModelPlugins().Playable;
-
             var defaultImplementation = new Unimplemented();
             builder.Add(x => new NoOverride(x)
             {
-                InnerDownloadable = new DownloadablePluginBaseTests.Unimplemented(),
-                InnerImageCollection = new ImageCollectionPluginBaseTests.Unimplemented(),
-                InnerUrlCollection = new UrlCollectionPluginBaseTests.Unimplemented(),
+                InnerDownloadable = data.HasFlag(PossiblePlugins.Downloadable) ? new DownloadablePluginBaseTests.Unimplemented() : x,
+                InnerImageCollection = data.HasFlag(PossiblePlugins.ImageCollection) ? new ImageCollectionPluginBaseTests.Unimplemented() : x,
+                InnerUrlCollection = data.HasFlag(PossiblePlugins.UrlCollection) ? new UrlCollectionPluginBaseTests.Unimplemented() : x,
             });
 
             var finalImpl = builder.Execute(defaultImplementation);
 
             Assert.AreNotSame(finalImpl, defaultImplementation);
             Assert.IsInstanceOfType(finalImpl, typeof(NoOverride));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<DownloadablePluginBaseTests.Unimplemented>, DownloadablePluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInner, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<ImageCollectionPluginBaseTests.Unimplemented>, ImageCollectionPluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInner, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<UrlCollectionPluginBaseTests.Unimplemented>, UrlCollectionPluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInner, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<Unimplemented>, NoOverride>(finalImpl, customFilter: NoInner, typesToExclude: new[] {typeof(IAsyncDisposable), typeof(DownloadablePluginBaseTests.Unimplemented), typeof(ImageCollectionPluginBaseTests.Unimplemented), typeof(UrlCollectionPluginBaseTests.Unimplemented)});
 
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(finalImpl, customFilter: NoInner, expectedExceptions: new[]
+            var expectedExceptionsWhenDisposing = new List<Type>
             {
                 typeof(AccessedException<Unimplemented>),
-                typeof(AccessedException<DownloadablePluginBaseTests.Unimplemented>),
-                typeof(AccessedException<ImageCollectionPluginBaseTests.Unimplemented>),
-                typeof(AccessedException<UrlCollectionPluginBaseTests.Unimplemented>),
-            });
-        }
+            };
 
-        [TestMethod, Timeout(5000)]
-        public void PluginFullyCustomWith_ImageCollection_UrlCollection()
-        {
-            var builder = new SdkModelPlugins().Playable;
-            var finalTestClass = new Unimplemented();
-            builder.Add(x => new NoOverride(x)
+            if (data.HasFlag(PossiblePlugins.Downloadable))
             {
-                InnerUrlCollection = new UrlCollectionPluginBaseTests.Unimplemented(),
-                InnerImageCollection = new ImageCollectionPluginBaseTests.Unimplemented()
-            });
+                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<DownloadablePluginBaseTests.Unimplemented>));
 
-            var finalImpl = builder.Execute(finalTestClass);
+                Helpers.AssertAllMembersThrowOnAccess<AccessedException<DownloadablePluginBaseTests.Unimplemented>,
+                    DownloadablePluginBaseTests.Unimplemented>(
+                    finalImpl,
+                    customFilter: NoInnerOrSources,
+                    typesToExclude: typeof(IAsyncDisposable)
+                );
+            }
 
-            Assert.AreNotSame(finalImpl, finalTestClass);
-            Assert.IsInstanceOfType(finalImpl, typeof(NoOverride));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<UrlCollectionPluginBaseTests.Unimplemented>, UrlCollectionPluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInner, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<ImageCollectionPluginBaseTests.Unimplemented>, ImageCollectionPluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInner, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<Unimplemented>, NoOverride>(finalImpl, customFilter: NoInner, typesToExclude: new[] {typeof(IAsyncDisposable), typeof(UrlCollectionPluginBaseTests.Unimplemented), typeof(ImageCollectionPluginBaseTests.Unimplemented)});
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(finalImpl, customFilter: NoInner, expectedExceptions: new[]
+            if (data.HasFlag(PossiblePlugins.Playable))
             {
-                typeof(AccessedException<Unimplemented>),
-                typeof(AccessedException<UrlCollectionPluginBaseTests.Unimplemented>),
-                typeof(AccessedException<ImageCollectionPluginBaseTests.Unimplemented>),
-            });
+                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<PlayablePluginBaseTests.Unimplemented>));
+
+                Helpers.AssertAllMembersThrowOnAccess<AccessedException<PlayablePluginBaseTests.Unimplemented>,
+                    PlayablePluginBaseTests.Unimplemented>(
+                    finalImpl,
+                    customFilter: NoInnerOrSources,
+                    typesToExclude: new[]
+                    {
+                        typeof(IAsyncDisposable),
+                        typeof(DownloadablePluginBaseTests.Unimplemented),
+                        typeof(ImageCollectionPluginBaseTests.Unimplemented),
+                        typeof(UrlCollectionPluginBaseTests.Unimplemented)
+                    }
+                );
+            }
+
+            if (data.HasFlag(PossiblePlugins.ImageCollection))
+            {
+                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<ImageCollectionPluginBaseTests.Unimplemented>));
+
+                Helpers.AssertAllMembersThrowOnAccess<AccessedException<ImageCollectionPluginBaseTests.Unimplemented>,
+                    ImageCollectionPluginBaseTests.Unimplemented>(
+                    finalImpl,
+                    customFilter: NoInnerOrSources,
+                    typesToExclude: typeof(IAsyncDisposable)
+                );
+            }
+
+            if (data.HasFlag(PossiblePlugins.UrlCollection))
+            {
+                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<UrlCollectionPluginBaseTests.Unimplemented>));
+
+                Helpers.AssertAllMembersThrowOnAccess<AccessedException<UrlCollectionPluginBaseTests.Unimplemented>, UrlCollectionPluginBaseTests.Unimplemented>(
+                    finalImpl,
+                    customFilter: NoInnerOrSources,
+                    typesToExclude: typeof(IAsyncDisposable)
+                );
+            }
+
+            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(
+                finalImpl,
+                customFilter: NoInnerOrSources,
+                expectedExceptions: expectedExceptionsWhenDisposing.ToArray()
+            );
         }
 
         internal class FullyCustom : PlayablePluginBase
@@ -321,6 +239,17 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
                 : base(new ModelPluginMetadata("", nameof(NoOverride), "", new Version()), inner)
             {
             }
+        }
+
+        internal class NotBlockingDisposeAsync : PlayablePluginBase
+        {
+            public NotBlockingDisposeAsync()
+                : base(new ModelPluginMetadata("", nameof(NotBlockingDisposeAsync), "", new Version()), new Unimplemented())
+            {
+            }
+
+            /// <inheritdoc />
+            public override ValueTask DisposeAsync() => default;
         }
 
         internal class Unimplemented : IPlayable

--- a/src/Sdk/StrixMusic.Sdk.Tests/Plugins/Models/PlaylistCollectionPluginBaseTests.cs
+++ b/src/Sdk/StrixMusic.Sdk.Tests/Plugins/Models/PlaylistCollectionPluginBaseTests.cs
@@ -18,6 +18,16 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
         private static bool NoInner(MemberInfo x) => !x.Name.Contains("Inner");
         private static bool NoInnerOrSources(MemberInfo x) => NoInner(x) && x.Name != "get_Sources" && x.Name != "get_SourceCores";
 
+        [Flags]
+        public enum PossiblePlugins
+        {
+            None = 0,
+            Playable = 1,
+            Downloadable = 2,
+            ImageCollection = 4,
+            UrlCollection = 8,
+        }
+
         [TestMethod, Timeout(1000)]
         public void NoPlugins()
         {
@@ -86,376 +96,109 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
         }
 
         [TestMethod, Timeout(5000)]
-        public void PluginFullyCustomWith_Downloadable()
+        [AllEnumFlagCombinations(typeof(PossiblePlugins))]
+        public void PluginFullyCustomWith_AllCombinations(PossiblePlugins data)
         {
             var builder = new SdkModelPlugins().PlaylistCollection;
-            var finalTestClass = new Unimplemented();
-            builder.Add(x => new NoOverride(x) { InnerDownloadable = new DownloadablePluginBaseTests.Unimplemented() });
-
-            var finalImpl = builder.Execute(finalTestClass);
-
-            Assert.AreNotSame(finalImpl, finalTestClass);
-            Assert.IsInstanceOfType(finalImpl, typeof(NoOverride));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<DownloadablePluginBaseTests.Unimplemented>, DownloadablePluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInner, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<Unimplemented>, NoOverride>(finalImpl, customFilter: NoInner, typesToExclude: new[] { typeof(IAsyncDisposable), typeof(DownloadablePluginBaseTests.Unimplemented) });
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(finalImpl, customFilter: NoInner, expectedExceptions: new[] {
-                typeof(AccessedException<Unimplemented>),
-                typeof(AccessedException<DownloadablePluginBaseTests.Unimplemented>),
-            });
-        }
-
-        [TestMethod, Timeout(5000)]
-        public void PluginFullyCustomWith_ImageCollection()
-        {
-            var builder = new SdkModelPlugins().PlaylistCollection;
-            var finalTestClass = new Unimplemented();
-            builder.Add(x => new NoOverride(x) { InnerImageCollection = new ImageCollectionPluginBaseTests.Unimplemented() });
-
-            var finalImpl = builder.Execute(finalTestClass);
-
-            Assert.AreNotSame(finalImpl, finalTestClass);
-            Assert.IsInstanceOfType(finalImpl, typeof(NoOverride));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<ImageCollectionPluginBaseTests.Unimplemented>, ImageCollectionPluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInnerOrSources, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<Unimplemented>, NoOverride>(finalImpl, customFilter: NoInner, typesToExclude: new[] { typeof(IAsyncDisposable), typeof(ImageCollectionPluginBaseTests.Unimplemented) });
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(finalImpl, customFilter: NoInner, expectedExceptions: new[] {
-                typeof(AccessedException<Unimplemented>),
-                typeof(AccessedException<ImageCollectionPluginBaseTests.Unimplemented>),
-            });
-        }
-
-        [TestMethod, Timeout(5000)]
-        public void PluginFullyCustomWith_UrlCollection()
-        {
-            var builder = new SdkModelPlugins().PlaylistCollection;
-            var finalTestClass = new Unimplemented();
-            builder.Add(x => new NoOverride(x) { InnerUrlCollection = new UrlCollectionPluginBaseTests.Unimplemented() });
-
-            var finalImpl = builder.Execute(finalTestClass);
-
-            Assert.AreNotSame(finalImpl, finalTestClass);
-            Assert.IsInstanceOfType(finalImpl, typeof(NoOverride));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<UrlCollectionPluginBaseTests.Unimplemented>, UrlCollectionPluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInnerOrSources, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<Unimplemented>, NoOverride>(finalImpl, customFilter: NoInner, typesToExclude: new[] { typeof(IAsyncDisposable), typeof(UrlCollectionPluginBaseTests.Unimplemented) });
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(finalImpl, customFilter: NoInner, expectedExceptions: new[] {
-                typeof(AccessedException<Unimplemented>),
-                typeof(AccessedException<UrlCollectionPluginBaseTests.Unimplemented>),
-            });
-        }
-
-        [TestMethod, Timeout(5000)]
-        public void PluginFullyCustomWith_Downloadable_ImageCollection()
-        {
-            var builder = new SdkModelPlugins().PlaylistCollection;
-            var finalTestClass = new Unimplemented();
-            builder.Add(x => new NoOverride(x)
-            {
-                InnerDownloadable = new DownloadablePluginBaseTests.Unimplemented(),
-                InnerImageCollection = new ImageCollectionPluginBaseTests.Unimplemented()
-            });
-
-            var finalImpl = builder.Execute(finalTestClass);
-
-            Assert.AreNotSame(finalImpl, finalTestClass);
-            Assert.IsInstanceOfType(finalImpl, typeof(NoOverride));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<DownloadablePluginBaseTests.Unimplemented>, DownloadablePluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInner, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<ImageCollectionPluginBaseTests.Unimplemented>, ImageCollectionPluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInnerOrSources, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<Unimplemented>, NoOverride>(finalImpl, customFilter: NoInnerOrSources, typesToExclude: new[] { typeof(IAsyncDisposable), typeof(DownloadablePluginBaseTests.Unimplemented), typeof(ImageCollectionPluginBaseTests.Unimplemented) });
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(finalImpl, customFilter: NoInner, expectedExceptions: new[] {
-                typeof(AccessedException<Unimplemented>),
-                typeof(AccessedException<DownloadablePluginBaseTests.Unimplemented>),
-                typeof(AccessedException<ImageCollectionPluginBaseTests.Unimplemented>),
-            });
-        }
-
-        [TestMethod, Timeout(5000)]
-        public void PluginFullyCustomWith_Downloadable_UrlCollection()
-        {
-            var builder = new SdkModelPlugins().PlaylistCollection;
-            var finalTestClass = new Unimplemented();
-            builder.Add(x => new NoOverride(x)
-            {
-                InnerDownloadable = new DownloadablePluginBaseTests.Unimplemented(),
-                InnerUrlCollection = new UrlCollectionPluginBaseTests.Unimplemented()
-            });
-
-            var finalImpl = builder.Execute(finalTestClass);
-
-            Assert.AreNotSame(finalImpl, finalTestClass);
-            Assert.IsInstanceOfType(finalImpl, typeof(NoOverride));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<DownloadablePluginBaseTests.Unimplemented>, DownloadablePluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInner, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<UrlCollectionPluginBaseTests.Unimplemented>, UrlCollectionPluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInnerOrSources, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<Unimplemented>, NoOverride>(finalImpl, customFilter: NoInner, typesToExclude: new[] { typeof(IAsyncDisposable), typeof(DownloadablePluginBaseTests.Unimplemented), typeof(UrlCollectionPluginBaseTests.Unimplemented) });
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(finalImpl, customFilter: NoInner, expectedExceptions: new[] {
-                typeof(AccessedException<Unimplemented>),
-                typeof(AccessedException<DownloadablePluginBaseTests.Unimplemented>),
-                typeof(AccessedException<UrlCollectionPluginBaseTests.Unimplemented>),
-            });
-        }
-
-        [TestMethod, Timeout(5000)]
-        public void PluginFullyCustomWith_Downloadable_ImageCollection_UrlCollection()
-        {
-            var builder = new SdkModelPlugins().PlaylistCollection;
-
             var defaultImplementation = new Unimplemented();
             builder.Add(x => new NoOverride(x)
             {
-                InnerDownloadable = new DownloadablePluginBaseTests.Unimplemented(),
-                InnerImageCollection = new ImageCollectionPluginBaseTests.Unimplemented(),
-                InnerUrlCollection = new UrlCollectionPluginBaseTests.Unimplemented(),
+                InnerDownloadable = data.HasFlag(PossiblePlugins.Downloadable) ? new DownloadablePluginBaseTests.Unimplemented() : x,
+                InnerPlayable = data.HasFlag(PossiblePlugins.Playable) ? new PlayablePluginBaseTests.Unimplemented() : x,
+                InnerImageCollection = data.HasFlag(PossiblePlugins.ImageCollection) ? new ImageCollectionPluginBaseTests.Unimplemented() : x,
+                InnerUrlCollection = data.HasFlag(PossiblePlugins.UrlCollection) ? new UrlCollectionPluginBaseTests.Unimplemented() : x,
             });
 
             var finalImpl = builder.Execute(defaultImplementation);
 
             Assert.AreNotSame(finalImpl, defaultImplementation);
             Assert.IsInstanceOfType(finalImpl, typeof(NoOverride));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<DownloadablePluginBaseTests.Unimplemented>, DownloadablePluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInner, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<ImageCollectionPluginBaseTests.Unimplemented>, ImageCollectionPluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInnerOrSources, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<UrlCollectionPluginBaseTests.Unimplemented>, UrlCollectionPluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInnerOrSources, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<Unimplemented>, NoOverride>(finalImpl, customFilter: NoInnerOrSources, typesToExclude: new[] { typeof(IAsyncDisposable), typeof(DownloadablePluginBaseTests.Unimplemented), typeof(ImageCollectionPluginBaseTests.Unimplemented), typeof(UrlCollectionPluginBaseTests.Unimplemented) });
 
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(finalImpl, customFilter: NoInner, expectedExceptions: new[] {
+            var expectedExceptionsWhenDisposing = new List<Type>
+            {
                 typeof(AccessedException<Unimplemented>),
-                typeof(AccessedException<DownloadablePluginBaseTests.Unimplemented>),
-                typeof(AccessedException<ImageCollectionPluginBaseTests.Unimplemented>),
-                typeof(AccessedException<UrlCollectionPluginBaseTests.Unimplemented>),
-            });
+            };
+
+            if (data.HasFlag(PossiblePlugins.Downloadable))
+            {
+                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<DownloadablePluginBaseTests.Unimplemented>));
+
+                Helpers.AssertAllMembersThrowOnAccess<AccessedException<DownloadablePluginBaseTests.Unimplemented>,
+                    DownloadablePluginBaseTests.Unimplemented>(
+                    finalImpl,
+                    customFilter: NoInnerOrSources,
+                    typesToExclude: typeof(IAsyncDisposable)
+                );
+            }
+
+            if (data.HasFlag(PossiblePlugins.Playable))
+            {
+                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<PlayablePluginBaseTests.Unimplemented>));
+
+                Helpers.AssertAllMembersThrowOnAccess<AccessedException<PlayablePluginBaseTests.Unimplemented>,
+                    PlayablePluginBaseTests.Unimplemented>(
+                    finalImpl,
+                    customFilter: NoInnerOrSources,
+                    typesToExclude: new[]
+                    {
+                        typeof(IAsyncDisposable),
+                        typeof(DownloadablePluginBaseTests.Unimplemented),
+                        typeof(ImageCollectionPluginBaseTests.Unimplemented),
+                        typeof(UrlCollectionPluginBaseTests.Unimplemented)
+                    }
+                );
+            }
+
+            if (data.HasFlag(PossiblePlugins.ImageCollection))
+            {
+                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<ImageCollectionPluginBaseTests.Unimplemented>));
+
+                Helpers.AssertAllMembersThrowOnAccess<AccessedException<ImageCollectionPluginBaseTests.Unimplemented>,
+                    ImageCollectionPluginBaseTests.Unimplemented>(
+                    finalImpl,
+                    customFilter: NoInnerOrSources,
+                    typesToExclude: typeof(IAsyncDisposable)
+                );
+            }
+
+            if (data.HasFlag(PossiblePlugins.UrlCollection))
+            {
+                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<UrlCollectionPluginBaseTests.Unimplemented>));
+
+                Helpers.AssertAllMembersThrowOnAccess<AccessedException<UrlCollectionPluginBaseTests.Unimplemented>, UrlCollectionPluginBaseTests.Unimplemented>(
+                    finalImpl,
+                    customFilter: NoInnerOrSources,
+                    typesToExclude: typeof(IAsyncDisposable)
+                );
+            }
+
+            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(
+                finalImpl,
+                customFilter: NoInnerOrSources,
+                expectedExceptions: expectedExceptionsWhenDisposing.ToArray()
+            );
         }
 
         [TestMethod, Timeout(5000)]
-        public void PluginFullyCustomWith_ImageCollection_UrlCollection()
+        [AllEnumFlagCombinations(typeof(PossiblePlugins))]
+        public async Task DisposeAsync_AllCombinations(PossiblePlugins data)
         {
             var builder = new SdkModelPlugins().PlaylistCollection;
-            var finalTestClass = new Unimplemented();
+            var defaultImplementation = new NotBlockingDisposeAsync();
             builder.Add(x => new NoOverride(x)
             {
-                InnerUrlCollection = new UrlCollectionPluginBaseTests.Unimplemented(),
-                InnerImageCollection = new ImageCollectionPluginBaseTests.Unimplemented()
-            });
-
-            var finalImpl = builder.Execute(finalTestClass);
-
-            Assert.AreNotSame(finalImpl, finalTestClass);
-            Assert.IsInstanceOfType(finalImpl, typeof(NoOverride));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<UrlCollectionPluginBaseTests.Unimplemented>, UrlCollectionPluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInnerOrSources, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<ImageCollectionPluginBaseTests.Unimplemented>, ImageCollectionPluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInnerOrSources, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<Unimplemented>, NoOverride>(finalImpl, customFilter: NoInnerOrSources, typesToExclude: new[] { typeof(IAsyncDisposable), typeof(UrlCollectionPluginBaseTests.Unimplemented), typeof(ImageCollectionPluginBaseTests.Unimplemented) });
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(finalImpl, customFilter: NoInner, expectedExceptions: new[] {
-                typeof(AccessedException<Unimplemented>),
-                typeof(AccessedException<UrlCollectionPluginBaseTests.Unimplemented>),
-                typeof(AccessedException<ImageCollectionPluginBaseTests.Unimplemented>),
-            });
-        }
-
-
-        [TestMethod, Timeout(5000)]
-        public void PluginFullyCustomWith_Playable_Downloadable()
-        {
-            var builder = new SdkModelPlugins().PlaylistCollection;
-            var finalTestClass = new Unimplemented();
-            builder.Add(x => new NoOverride(x)
-            {
-                InnerDownloadable = new DownloadablePluginBaseTests.Unimplemented(),
-                InnerPlayable = new PlayablePluginBaseTests.Unimplemented(),
-            });
-
-            var finalImpl = builder.Execute(finalTestClass);
-
-            Assert.AreNotSame(finalImpl, finalTestClass);
-            Assert.IsInstanceOfType(finalImpl, typeof(NoOverride));
-
-            // Testing InnerPlayable
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<PlayablePluginBaseTests.Unimplemented>, PlayablePluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInner, typesToExclude: new[] { typeof(IAsyncDisposable), typeof(DownloadablePluginBaseTests.Unimplemented), typeof(ImageCollectionPluginBaseTests.Unimplemented), typeof(UrlCollectionPluginBaseTests.Unimplemented) });
-
-            // Testing InnerDownloadable
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<DownloadablePluginBaseTests.Unimplemented>, DownloadablePluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInner, typesToExclude: typeof(IAsyncDisposable));
-
-            // Testing all other properties
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<Unimplemented>, NoOverride>(finalImpl, customFilter: NoInner, typesToExclude: new[] { typeof(IAsyncDisposable), typeof(DownloadablePluginBaseTests.Unimplemented), typeof(PlayablePluginBaseTests.Unimplemented) });
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(finalImpl, customFilter: NoInner, expectedExceptions: new[] {
-                typeof(AccessedException<Unimplemented>),
-                typeof(AccessedException<DownloadablePluginBaseTests.Unimplemented>),
-                typeof(AccessedException<PlayablePluginBaseTests.Unimplemented>),
-            });
-        }
-
-        [TestMethod, Timeout(5000)]
-        public void PluginFullyCustomWith_Playable_ImageCollection()
-        {
-            var builder = new SdkModelPlugins().PlaylistCollection;
-            var finalTestClass = new Unimplemented();
-            builder.Add(x => new NoOverride(x)
-            {
-                InnerImageCollection = new ImageCollectionPluginBaseTests.Unimplemented(),
-                InnerPlayable = new PlayablePluginBaseTests.Unimplemented(),
-            });
-
-            var finalImpl = builder.Execute(finalTestClass);
-
-            Assert.AreNotSame(finalImpl, finalTestClass);
-            Assert.IsInstanceOfType(finalImpl, typeof(NoOverride));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<PlayablePluginBaseTests.Unimplemented>, PlayablePluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInner, typesToExclude: new[] { typeof(IAsyncDisposable), typeof(DownloadablePluginBaseTests.Unimplemented), typeof(ImageCollectionPluginBaseTests.Unimplemented), typeof(UrlCollectionPluginBaseTests.Unimplemented) });
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<ImageCollectionPluginBaseTests.Unimplemented>, ImageCollectionPluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInnerOrSources, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<Unimplemented>, NoOverride>(finalImpl, customFilter: NoInner, typesToExclude: new[] { typeof(IAsyncDisposable), typeof(ImageCollectionPluginBaseTests.Unimplemented), typeof(PlayablePluginBaseTests.Unimplemented) });
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(finalImpl, customFilter: NoInner, expectedExceptions: new[] {
-                typeof(AccessedException<Unimplemented>),
-                typeof(AccessedException<ImageCollectionPluginBaseTests.Unimplemented>),
-                typeof(AccessedException<PlayablePluginBaseTests.Unimplemented>),
-            });
-        }
-
-        [TestMethod, Timeout(5000)]
-        public void PluginFullyCustomWith_Playable_UrlCollection()
-        {
-            var builder = new SdkModelPlugins().PlaylistCollection;
-            var finalTestClass = new Unimplemented();
-            builder.Add(x => new NoOverride(x)
-            {
-                InnerUrlCollection = new UrlCollectionPluginBaseTests.Unimplemented(),
-                InnerPlayable = new PlayablePluginBaseTests.Unimplemented(),
-            });
-
-            var finalImpl = builder.Execute(finalTestClass);
-
-            Assert.AreNotSame(finalImpl, finalTestClass);
-            Assert.IsInstanceOfType(finalImpl, typeof(NoOverride));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<PlayablePluginBaseTests.Unimplemented>, PlayablePluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInner, typesToExclude: new[] { typeof(IAsyncDisposable), typeof(DownloadablePluginBaseTests.Unimplemented), typeof(ImageCollectionPluginBaseTests.Unimplemented), typeof(UrlCollectionPluginBaseTests.Unimplemented) });
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<UrlCollectionPluginBaseTests.Unimplemented>, UrlCollectionPluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInnerOrSources, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<Unimplemented>, NoOverride>(finalImpl, customFilter: NoInner, typesToExclude: new[] { typeof(IAsyncDisposable), typeof(UrlCollectionPluginBaseTests.Unimplemented), typeof(PlayablePluginBaseTests.Unimplemented) });
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(finalImpl, customFilter: NoInner, expectedExceptions: new[] {
-                typeof(AccessedException<Unimplemented>),
-                typeof(AccessedException<UrlCollectionPluginBaseTests.Unimplemented>),
-                typeof(AccessedException<PlayablePluginBaseTests.Unimplemented>),
-            });
-        }
-
-        [TestMethod, Timeout(5000)]
-        public void PluginFullyCustomWith_Playable_Downloadable_ImageCollection()
-        {
-            var builder = new SdkModelPlugins().PlaylistCollection;
-            var finalTestClass = new Unimplemented();
-            builder.Add(x => new NoOverride(x)
-            {
-                InnerDownloadable = new DownloadablePluginBaseTests.Unimplemented(),
-                InnerImageCollection = new ImageCollectionPluginBaseTests.Unimplemented(),
-                InnerPlayable = new PlayablePluginBaseTests.Unimplemented(),
-            });
-
-            var finalImpl = builder.Execute(finalTestClass);
-
-            Assert.AreNotSame(finalImpl, finalTestClass);
-            Assert.IsInstanceOfType(finalImpl, typeof(NoOverride));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<PlayablePluginBaseTests.Unimplemented>, PlayablePluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInner, typesToExclude: new[] { typeof(IAsyncDisposable), typeof(DownloadablePluginBaseTests.Unimplemented), typeof(ImageCollectionPluginBaseTests.Unimplemented), typeof(UrlCollectionPluginBaseTests.Unimplemented) });
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<DownloadablePluginBaseTests.Unimplemented>, DownloadablePluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInner, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<ImageCollectionPluginBaseTests.Unimplemented>, ImageCollectionPluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInnerOrSources, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<Unimplemented>, NoOverride>(finalImpl, customFilter: NoInnerOrSources, typesToExclude: new[] { typeof(IAsyncDisposable), typeof(DownloadablePluginBaseTests.Unimplemented), typeof(ImageCollectionPluginBaseTests.Unimplemented), typeof(PlayablePluginBaseTests.Unimplemented) });
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(finalImpl, customFilter: NoInner, expectedExceptions: new[] {
-                typeof(AccessedException<Unimplemented>),
-                typeof(AccessedException<DownloadablePluginBaseTests.Unimplemented>),
-                typeof(AccessedException<ImageCollectionPluginBaseTests.Unimplemented>),
-                typeof(AccessedException<PlayablePluginBaseTests.Unimplemented>),
-            });
-        }
-
-        [TestMethod, Timeout(5000)]
-        public void PluginFullyCustomWith_Playable_Downloadable_UrlCollection()
-        {
-            var builder = new SdkModelPlugins().PlaylistCollection;
-            var finalTestClass = new Unimplemented();
-            builder.Add(x => new NoOverride(x)
-            {
-                InnerDownloadable = new DownloadablePluginBaseTests.Unimplemented(),
-                InnerUrlCollection = new UrlCollectionPluginBaseTests.Unimplemented(),
-                InnerPlayable = new PlayablePluginBaseTests.Unimplemented(),
-            });
-
-            var finalImpl = builder.Execute(finalTestClass);
-
-            Assert.AreNotSame(finalImpl, finalTestClass);
-            Assert.IsInstanceOfType(finalImpl, typeof(NoOverride));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<PlayablePluginBaseTests.Unimplemented>, PlayablePluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInner, typesToExclude: new[] { typeof(IAsyncDisposable), typeof(DownloadablePluginBaseTests.Unimplemented), typeof(ImageCollectionPluginBaseTests.Unimplemented), typeof(UrlCollectionPluginBaseTests.Unimplemented) });
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<DownloadablePluginBaseTests.Unimplemented>, DownloadablePluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInner, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<UrlCollectionPluginBaseTests.Unimplemented>, UrlCollectionPluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInnerOrSources, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<Unimplemented>, NoOverride>(finalImpl, customFilter: NoInner, typesToExclude: new[] { typeof(IAsyncDisposable), typeof(DownloadablePluginBaseTests.Unimplemented), typeof(UrlCollectionPluginBaseTests.Unimplemented), typeof(PlayablePluginBaseTests.Unimplemented) });
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(finalImpl, customFilter: NoInner, expectedExceptions: new[] {
-                typeof(AccessedException<Unimplemented>),
-                typeof(AccessedException<DownloadablePluginBaseTests.Unimplemented>),
-                typeof(AccessedException<UrlCollectionPluginBaseTests.Unimplemented>),
-                typeof(AccessedException<PlayablePluginBaseTests.Unimplemented>),
-            });
-        }
-
-        [TestMethod, Timeout(5000)]
-        public void PluginFullyCustomWith_Playable_Downloadable_ImageCollection_UrlCollection()
-        {
-            var builder = new SdkModelPlugins().PlaylistCollection;
-
-            var defaultImplementation = new Unimplemented();
-            builder.Add(x => new NoOverride(x)
-            {
-                InnerDownloadable = new DownloadablePluginBaseTests.Unimplemented(),
-                InnerImageCollection = new ImageCollectionPluginBaseTests.Unimplemented(),
-                InnerUrlCollection = new UrlCollectionPluginBaseTests.Unimplemented(),
-                InnerPlayable = new PlayablePluginBaseTests.Unimplemented(),
+                InnerDownloadable = data.HasFlag(PossiblePlugins.Downloadable) ? new DownloadablePluginBaseTests.NotBlockingDisposeAsync() : x,
+                InnerPlayable = data.HasFlag(PossiblePlugins.Playable) ? new PlayablePluginBaseTests.NotBlockingDisposeAsync() : x,
+                InnerImageCollection = data.HasFlag(PossiblePlugins.ImageCollection) ? new ImageCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
+                InnerUrlCollection = data.HasFlag(PossiblePlugins.UrlCollection) ? new UrlCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
             });
 
             var finalImpl = builder.Execute(defaultImplementation);
 
             Assert.AreNotSame(finalImpl, defaultImplementation);
             Assert.IsInstanceOfType(finalImpl, typeof(NoOverride));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<PlayablePluginBaseTests.Unimplemented>, PlayablePluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInner, typesToExclude: new[] { typeof(IAsyncDisposable), typeof(DownloadablePluginBaseTests.Unimplemented), typeof(ImageCollectionPluginBaseTests.Unimplemented), typeof(UrlCollectionPluginBaseTests.Unimplemented) });
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<DownloadablePluginBaseTests.Unimplemented>, DownloadablePluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInner, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<ImageCollectionPluginBaseTests.Unimplemented>, ImageCollectionPluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInnerOrSources, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<UrlCollectionPluginBaseTests.Unimplemented>, UrlCollectionPluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInnerOrSources, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<Unimplemented>, NoOverride>(finalImpl, customFilter: NoInnerOrSources, typesToExclude: new[] { typeof(IAsyncDisposable), typeof(DownloadablePluginBaseTests.Unimplemented), typeof(ImageCollectionPluginBaseTests.Unimplemented), typeof(UrlCollectionPluginBaseTests.Unimplemented), typeof(PlayablePluginBaseTests.Unimplemented) });
 
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(finalImpl, customFilter: NoInner, expectedExceptions: new[] {
-                typeof(AccessedException<Unimplemented>),
-                typeof(AccessedException<DownloadablePluginBaseTests.Unimplemented>),
-                typeof(AccessedException<ImageCollectionPluginBaseTests.Unimplemented>),
-                typeof(AccessedException<UrlCollectionPluginBaseTests.Unimplemented>),
-                typeof(AccessedException<PlayablePluginBaseTests.Unimplemented>),
-            });
-        }
-
-        [TestMethod, Timeout(5000)]
-        public void PluginFullyCustomWith_Playable_ImageCollection_UrlCollection()
-        {
-            var builder = new SdkModelPlugins().PlaylistCollection;
-            var finalTestClass = new Unimplemented();
-            builder.Add(x => new NoOverride(x)
-            {
-                InnerUrlCollection = new UrlCollectionPluginBaseTests.Unimplemented(),
-                InnerImageCollection = new ImageCollectionPluginBaseTests.Unimplemented(),
-                InnerPlayable = new PlayablePluginBaseTests.Unimplemented(),
-            });
-
-            var finalImpl = builder.Execute(finalTestClass);
-
-            Assert.AreNotSame(finalImpl, finalTestClass);
-            Assert.IsInstanceOfType(finalImpl, typeof(NoOverride));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<PlayablePluginBaseTests.Unimplemented>, PlayablePluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInner, typesToExclude: new[] { typeof(IAsyncDisposable), typeof(DownloadablePluginBaseTests.Unimplemented), typeof(ImageCollectionPluginBaseTests.Unimplemented), typeof(UrlCollectionPluginBaseTests.Unimplemented) });
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<UrlCollectionPluginBaseTests.Unimplemented>, UrlCollectionPluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInnerOrSources, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<ImageCollectionPluginBaseTests.Unimplemented>, ImageCollectionPluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInnerOrSources, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<Unimplemented>, NoOverride>(finalImpl, customFilter: NoInnerOrSources, typesToExclude: new[] { typeof(IAsyncDisposable), typeof(UrlCollectionPluginBaseTests.Unimplemented), typeof(ImageCollectionPluginBaseTests.Unimplemented), typeof(PlayablePluginBaseTests.Unimplemented) });
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(finalImpl, customFilter: NoInner, expectedExceptions: new[] {
-                typeof(AccessedException<Unimplemented>),
-                typeof(AccessedException<UrlCollectionPluginBaseTests.Unimplemented>),
-                typeof(AccessedException<ImageCollectionPluginBaseTests.Unimplemented>),
-                typeof(AccessedException<PlayablePluginBaseTests.Unimplemented>),
-            });
+            await finalImpl.DisposeAsync();
         }
 
 
@@ -538,6 +281,17 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
                 : base(new ModelPluginMetadata("", nameof(NoOverride), "", new Version()), inner)
             {
             }
+        }
+
+        internal class NotBlockingDisposeAsync : PlaylistCollectionPluginBase
+        {
+            public NotBlockingDisposeAsync()
+                : base(new ModelPluginMetadata("", nameof(NotBlockingDisposeAsync), "", new Version()), new Unimplemented())
+            {
+            }
+
+            /// <inheritdoc />
+            public override ValueTask DisposeAsync() => default;
         }
 
         internal class Unimplemented : IPlaylistCollection

--- a/src/Sdk/StrixMusic.Sdk.Tests/Plugins/Models/RecentlyPlayedPluginBaseTests.cs
+++ b/src/Sdk/StrixMusic.Sdk.Tests/Plugins/Models/RecentlyPlayedPluginBaseTests.cs
@@ -268,6 +268,32 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
             );
         }
 
+        [TestMethod, Timeout(5000)]
+        [AllEnumFlagCombinations(typeof(PossiblePlugins))]
+        public async Task DisposeAsync_AllCombinations(PossiblePlugins data)
+        {
+            var builder = new SdkModelPlugins().RecentlyPlayed;
+            var defaultImplementation = new NotBlockingDisposeAsync();
+            builder.Add(x => new NoOverride(x)
+            {
+                InnerDownloadable = data.HasFlag(PossiblePlugins.Downloadable) ? new DownloadablePluginBaseTests.NotBlockingDisposeAsync() : x,
+                InnerPlayable = data.HasFlag(PossiblePlugins.Playable) ? new PlayablePluginBaseTests.NotBlockingDisposeAsync() : x,
+                InnerArtistCollection = data.HasFlag(PossiblePlugins.ArtistCollection) ? new ArtistCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
+                InnerAlbumCollection = data.HasFlag(PossiblePlugins.AlbumCollection) ? new AlbumCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
+                InnerTrackCollection = data.HasFlag(PossiblePlugins.TrackCollection) ? new TrackCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
+                InnerPlaylistCollection = data.HasFlag(PossiblePlugins.PlaylistCollection) ? new PlaylistCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
+                InnerImageCollection = data.HasFlag(PossiblePlugins.ImageCollection) ? new ImageCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
+                InnerUrlCollection = data.HasFlag(PossiblePlugins.UrlCollection) ? new UrlCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
+            });
+
+            var finalImpl = builder.Execute(defaultImplementation);
+
+            Assert.AreNotSame(finalImpl, defaultImplementation);
+            Assert.IsInstanceOfType(finalImpl, typeof(NoOverride));
+
+            await finalImpl.DisposeAsync();
+        }
+
         internal class FullyCustom : RecentlyPlayedPluginBase
         {
             public FullyCustom(IRecentlyPlayed inner)
@@ -409,6 +435,17 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
                 : base(new ModelPluginMetadata("", nameof(NoOverride), "", new Version()), inner)
             {
             }
+        }
+
+        internal class NotBlockingDisposeAsync : RecentlyPlayedPluginBase
+        {
+            public NotBlockingDisposeAsync()
+                : base(new ModelPluginMetadata("", nameof(NotBlockingDisposeAsync), "", new Version()), new Unimplemented())
+            {
+            }
+
+            /// <inheritdoc />
+            public override ValueTask DisposeAsync() => default;
         }
 
         internal class Unimplemented : IRecentlyPlayed

--- a/src/Sdk/StrixMusic.Sdk.Tests/Plugins/Models/SearchHistoryPluginBaseTests.cs
+++ b/src/Sdk/StrixMusic.Sdk.Tests/Plugins/Models/SearchHistoryPluginBaseTests.cs
@@ -268,6 +268,32 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
             );
         }
 
+        [TestMethod, Timeout(5000)]
+        [AllEnumFlagCombinations(typeof(PossiblePlugins))]
+        public async Task DisposeAsync_AllCombinations(PossiblePlugins data)
+        {
+            var builder = new SdkModelPlugins().SearchHistory;
+            var defaultImplementation = new NotBlockingDisposeAsync();
+            builder.Add(x => new NoOverride(x)
+            {
+                InnerDownloadable = data.HasFlag(PossiblePlugins.Downloadable) ? new DownloadablePluginBaseTests.NotBlockingDisposeAsync() : x,
+                InnerPlayable = data.HasFlag(PossiblePlugins.Playable) ? new PlayablePluginBaseTests.NotBlockingDisposeAsync() : x,
+                InnerArtistCollection = data.HasFlag(PossiblePlugins.ArtistCollection) ? new ArtistCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
+                InnerAlbumCollection = data.HasFlag(PossiblePlugins.AlbumCollection) ? new AlbumCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
+                InnerTrackCollection = data.HasFlag(PossiblePlugins.TrackCollection) ? new TrackCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
+                InnerPlaylistCollection = data.HasFlag(PossiblePlugins.PlaylistCollection) ? new PlaylistCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
+                InnerImageCollection = data.HasFlag(PossiblePlugins.ImageCollection) ? new ImageCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
+                InnerUrlCollection = data.HasFlag(PossiblePlugins.UrlCollection) ? new UrlCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
+            });
+
+            var finalImpl = builder.Execute(defaultImplementation);
+
+            Assert.AreNotSame(finalImpl, defaultImplementation);
+            Assert.IsInstanceOfType(finalImpl, typeof(NoOverride));
+
+            await finalImpl.DisposeAsync();
+        }
+
         internal class FullyCustom : SearchHistoryPluginBase
         {
             public FullyCustom(ISearchHistory inner)
@@ -409,6 +435,17 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
                 : base(new ModelPluginMetadata("", nameof(NoOverride), "", new Version()), inner)
             {
             }
+        }
+
+        internal class NotBlockingDisposeAsync : SearchHistoryPluginBase
+        {
+            public NotBlockingDisposeAsync()
+                : base(new ModelPluginMetadata("", nameof(NotBlockingDisposeAsync), "", new Version()), new Unimplemented())
+            {
+            }
+
+            /// <inheritdoc />
+            public override ValueTask DisposeAsync() => default;
         }
 
         internal class Unimplemented : ISearchHistory

--- a/src/Sdk/StrixMusic.Sdk.Tests/Plugins/Models/SearchResultsPluginBaseTests.cs
+++ b/src/Sdk/StrixMusic.Sdk.Tests/Plugins/Models/SearchResultsPluginBaseTests.cs
@@ -268,6 +268,32 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
             );
         }
 
+        [TestMethod, Timeout(5000)]
+        [AllEnumFlagCombinations(typeof(PossiblePlugins))]
+        public async Task DisposeAsync_AllCombinations(PossiblePlugins data)
+        {
+            var builder = new SdkModelPlugins().SearchResults;
+            var defaultImplementation = new NotBlockingDisposeAsync();
+            builder.Add(x => new NoOverride(x)
+            {
+                InnerDownloadable = data.HasFlag(PossiblePlugins.Downloadable) ? new DownloadablePluginBaseTests.NotBlockingDisposeAsync() : x,
+                InnerPlayable = data.HasFlag(PossiblePlugins.Playable) ? new PlayablePluginBaseTests.NotBlockingDisposeAsync() : x,
+                InnerArtistCollection = data.HasFlag(PossiblePlugins.ArtistCollection) ? new ArtistCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
+                InnerAlbumCollection = data.HasFlag(PossiblePlugins.AlbumCollection) ? new AlbumCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
+                InnerTrackCollection = data.HasFlag(PossiblePlugins.TrackCollection) ? new TrackCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
+                InnerPlaylistCollection = data.HasFlag(PossiblePlugins.PlaylistCollection) ? new PlaylistCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
+                InnerImageCollection = data.HasFlag(PossiblePlugins.ImageCollection) ? new ImageCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
+                InnerUrlCollection = data.HasFlag(PossiblePlugins.UrlCollection) ? new UrlCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
+            });
+
+            var finalImpl = builder.Execute(defaultImplementation);
+
+            Assert.AreNotSame(finalImpl, defaultImplementation);
+            Assert.IsInstanceOfType(finalImpl, typeof(NoOverride));
+
+            await finalImpl.DisposeAsync();
+        }
+
         internal class FullyCustom : SearchResultsPluginBase
         {
             public FullyCustom(ISearchResults inner)
@@ -409,6 +435,17 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
                 : base(new ModelPluginMetadata("", nameof(NoOverride), "", new Version()), inner)
             {
             }
+        }
+
+        internal class NotBlockingDisposeAsync : SearchResultsPluginBase
+        {
+            public NotBlockingDisposeAsync()
+                : base(new ModelPluginMetadata("", nameof(NotBlockingDisposeAsync), "", new Version()), new Unimplemented())
+            {
+            }
+
+            /// <inheritdoc />
+            public override ValueTask DisposeAsync() => default;
         }
 
         internal class Unimplemented : ISearchResults

--- a/src/Sdk/StrixMusic.Sdk.Tests/Plugins/Models/TrackCollectionPluginBaseTests.cs
+++ b/src/Sdk/StrixMusic.Sdk.Tests/Plugins/Models/TrackCollectionPluginBaseTests.cs
@@ -18,6 +18,16 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
         private static bool NoInner(MemberInfo x) => !x.Name.Contains("Inner");
         private static bool NoInnerOrSources(MemberInfo x) => NoInner(x) && x.Name != "get_Sources" && x.Name != "get_SourceCores";
 
+        [Flags]
+        public enum PossiblePlugins
+        {
+            None = 0,
+            Playable = 1,
+            Downloadable = 2,
+            ImageCollection = 4,
+            UrlCollection = 8,
+        }
+
         [TestMethod, Timeout(1000)]
         public void NoPlugins()
         {
@@ -86,377 +96,110 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
         }
 
         [TestMethod, Timeout(5000)]
-        public void PluginFullyCustomWith_Downloadable()
+        [AllEnumFlagCombinations(typeof(PossiblePlugins))]
+        public void PluginFullyCustomWith_AllCombinations(PossiblePlugins data)
         {
             var builder = new SdkModelPlugins().TrackCollection;
-            var finalTestClass = new Unimplemented();
-            builder.Add(x => new NoOverride(x) { InnerDownloadable = new DownloadablePluginBaseTests.Unimplemented() });
-
-            var finalImpl = builder.Execute(finalTestClass);
-
-            Assert.AreNotSame(finalImpl, finalTestClass);
-            Assert.IsInstanceOfType(finalImpl, typeof(NoOverride));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<DownloadablePluginBaseTests.Unimplemented>, DownloadablePluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInner, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<Unimplemented>, NoOverride>(finalImpl, customFilter: NoInner, typesToExclude: new[] { typeof(IAsyncDisposable), typeof(DownloadablePluginBaseTests.Unimplemented) });
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(finalImpl, customFilter: NoInner, expectedExceptions: new[] {
-                typeof(AccessedException<Unimplemented>),
-                typeof(AccessedException<DownloadablePluginBaseTests.Unimplemented>),
-            });
-        }
-
-        [TestMethod, Timeout(5000)]
-        public void PluginFullyCustomWith_ImageCollection()
-        {
-            var builder = new SdkModelPlugins().TrackCollection;
-            var finalTestClass = new Unimplemented();
-            builder.Add(x => new NoOverride(x) { InnerImageCollection = new ImageCollectionPluginBaseTests.Unimplemented() });
-
-            var finalImpl = builder.Execute(finalTestClass);
-
-            Assert.AreNotSame(finalImpl, finalTestClass);
-            Assert.IsInstanceOfType(finalImpl, typeof(NoOverride));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<ImageCollectionPluginBaseTests.Unimplemented>, ImageCollectionPluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInnerOrSources, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<Unimplemented>, NoOverride>(finalImpl, customFilter: NoInner, typesToExclude: new[] { typeof(IAsyncDisposable), typeof(ImageCollectionPluginBaseTests.Unimplemented) });
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(finalImpl, customFilter: NoInner, expectedExceptions: new[] {
-                typeof(AccessedException<Unimplemented>),
-                typeof(AccessedException<ImageCollectionPluginBaseTests.Unimplemented>),
-            });
-        }
-
-        [TestMethod, Timeout(5000)]
-        public void PluginFullyCustomWith_UrlCollection()
-        {
-            var builder = new SdkModelPlugins().TrackCollection;
-            var finalTestClass = new Unimplemented();
-            builder.Add(x => new NoOverride(x) { InnerUrlCollection = new UrlCollectionPluginBaseTests.Unimplemented() });
-
-            var finalImpl = builder.Execute(finalTestClass);
-
-            Assert.AreNotSame(finalImpl, finalTestClass);
-            Assert.IsInstanceOfType(finalImpl, typeof(NoOverride));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<UrlCollectionPluginBaseTests.Unimplemented>, UrlCollectionPluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInnerOrSources, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<Unimplemented>, NoOverride>(finalImpl, customFilter: NoInner, typesToExclude: new[] { typeof(IAsyncDisposable), typeof(UrlCollectionPluginBaseTests.Unimplemented) });
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(finalImpl, customFilter: NoInner, expectedExceptions: new[] {
-                typeof(AccessedException<Unimplemented>),
-                typeof(AccessedException<UrlCollectionPluginBaseTests.Unimplemented>),
-            });
-        }
-
-        [TestMethod, Timeout(5000)]
-        public void PluginFullyCustomWith_Downloadable_ImageCollection()
-        {
-            var builder = new SdkModelPlugins().TrackCollection;
-            var finalTestClass = new Unimplemented();
-            builder.Add(x => new NoOverride(x)
-            {
-                InnerDownloadable = new DownloadablePluginBaseTests.Unimplemented(),
-                InnerImageCollection = new ImageCollectionPluginBaseTests.Unimplemented()
-            });
-
-            var finalImpl = builder.Execute(finalTestClass);
-
-            Assert.AreNotSame(finalImpl, finalTestClass);
-            Assert.IsInstanceOfType(finalImpl, typeof(NoOverride));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<DownloadablePluginBaseTests.Unimplemented>, DownloadablePluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInner, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<ImageCollectionPluginBaseTests.Unimplemented>, ImageCollectionPluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInnerOrSources, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<Unimplemented>, NoOverride>(finalImpl, customFilter: NoInnerOrSources, typesToExclude: new[] { typeof(IAsyncDisposable), typeof(DownloadablePluginBaseTests.Unimplemented), typeof(ImageCollectionPluginBaseTests.Unimplemented) });
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(finalImpl, customFilter: NoInner, expectedExceptions: new[] {
-                typeof(AccessedException<Unimplemented>),
-                typeof(AccessedException<DownloadablePluginBaseTests.Unimplemented>),
-                typeof(AccessedException<ImageCollectionPluginBaseTests.Unimplemented>),
-            });
-        }
-
-        [TestMethod, Timeout(5000)]
-        public void PluginFullyCustomWith_Downloadable_UrlCollection()
-        {
-            var builder = new SdkModelPlugins().TrackCollection;
-            var finalTestClass = new Unimplemented();
-            builder.Add(x => new NoOverride(x)
-            {
-                InnerDownloadable = new DownloadablePluginBaseTests.Unimplemented(),
-                InnerUrlCollection = new UrlCollectionPluginBaseTests.Unimplemented()
-            });
-
-            var finalImpl = builder.Execute(finalTestClass);
-
-            Assert.AreNotSame(finalImpl, finalTestClass);
-            Assert.IsInstanceOfType(finalImpl, typeof(NoOverride));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<DownloadablePluginBaseTests.Unimplemented>, DownloadablePluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInner, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<UrlCollectionPluginBaseTests.Unimplemented>, UrlCollectionPluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInnerOrSources, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<Unimplemented>, NoOverride>(finalImpl, customFilter: NoInner, typesToExclude: new[] { typeof(IAsyncDisposable), typeof(DownloadablePluginBaseTests.Unimplemented), typeof(UrlCollectionPluginBaseTests.Unimplemented) });
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(finalImpl, customFilter: NoInner, expectedExceptions: new[] {
-                typeof(AccessedException<Unimplemented>),
-                typeof(AccessedException<DownloadablePluginBaseTests.Unimplemented>),
-                typeof(AccessedException<UrlCollectionPluginBaseTests.Unimplemented>),
-            });
-        }
-
-        [TestMethod, Timeout(5000)]
-        public void PluginFullyCustomWith_Downloadable_ImageCollection_UrlCollection()
-        {
-            var builder = new SdkModelPlugins().TrackCollection;
-
             var defaultImplementation = new Unimplemented();
             builder.Add(x => new NoOverride(x)
             {
-                InnerDownloadable = new DownloadablePluginBaseTests.Unimplemented(),
-                InnerImageCollection = new ImageCollectionPluginBaseTests.Unimplemented(),
-                InnerUrlCollection = new UrlCollectionPluginBaseTests.Unimplemented(),
+                InnerDownloadable = data.HasFlag(PossiblePlugins.Downloadable) ? new DownloadablePluginBaseTests.Unimplemented() : x,
+                InnerPlayable = data.HasFlag(PossiblePlugins.Playable) ? new PlayablePluginBaseTests.Unimplemented() : x,
+                InnerImageCollection = data.HasFlag(PossiblePlugins.ImageCollection) ? new ImageCollectionPluginBaseTests.Unimplemented() : x,
+                InnerUrlCollection = data.HasFlag(PossiblePlugins.UrlCollection) ? new UrlCollectionPluginBaseTests.Unimplemented() : x,
             });
 
             var finalImpl = builder.Execute(defaultImplementation);
 
             Assert.AreNotSame(finalImpl, defaultImplementation);
             Assert.IsInstanceOfType(finalImpl, typeof(NoOverride));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<DownloadablePluginBaseTests.Unimplemented>, DownloadablePluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInner, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<ImageCollectionPluginBaseTests.Unimplemented>, ImageCollectionPluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInnerOrSources, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<UrlCollectionPluginBaseTests.Unimplemented>, UrlCollectionPluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInnerOrSources, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<Unimplemented>, NoOverride>(finalImpl, customFilter: NoInnerOrSources, typesToExclude: new[] { typeof(IAsyncDisposable), typeof(DownloadablePluginBaseTests.Unimplemented), typeof(ImageCollectionPluginBaseTests.Unimplemented), typeof(UrlCollectionPluginBaseTests.Unimplemented) });
 
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(finalImpl, customFilter: NoInner, expectedExceptions: new[] {
+            var expectedExceptionsWhenDisposing = new List<Type>
+            {
                 typeof(AccessedException<Unimplemented>),
-                typeof(AccessedException<DownloadablePluginBaseTests.Unimplemented>),
-                typeof(AccessedException<ImageCollectionPluginBaseTests.Unimplemented>),
-                typeof(AccessedException<UrlCollectionPluginBaseTests.Unimplemented>),
-            });
+            };
+
+            if (data.HasFlag(PossiblePlugins.Downloadable))
+            {
+                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<DownloadablePluginBaseTests.Unimplemented>));
+
+                Helpers.AssertAllMembersThrowOnAccess<AccessedException<DownloadablePluginBaseTests.Unimplemented>,
+                    DownloadablePluginBaseTests.Unimplemented>(
+                    finalImpl,
+                    customFilter: NoInnerOrSources,
+                    typesToExclude: typeof(IAsyncDisposable)
+                );
+            }
+
+            if (data.HasFlag(PossiblePlugins.Playable))
+            {
+                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<PlayablePluginBaseTests.Unimplemented>));
+
+                Helpers.AssertAllMembersThrowOnAccess<AccessedException<PlayablePluginBaseTests.Unimplemented>,
+                    PlayablePluginBaseTests.Unimplemented>(
+                    finalImpl,
+                    customFilter: NoInnerOrSources,
+                    typesToExclude: new[]
+                    {
+                        typeof(IAsyncDisposable),
+                        typeof(DownloadablePluginBaseTests.Unimplemented),
+                        typeof(ImageCollectionPluginBaseTests.Unimplemented),
+                        typeof(UrlCollectionPluginBaseTests.Unimplemented)
+                    }
+                );
+            }
+
+            if (data.HasFlag(PossiblePlugins.ImageCollection))
+            {
+                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<ImageCollectionPluginBaseTests.Unimplemented>));
+
+                Helpers.AssertAllMembersThrowOnAccess<AccessedException<ImageCollectionPluginBaseTests.Unimplemented>,
+                    ImageCollectionPluginBaseTests.Unimplemented>(
+                    finalImpl,
+                    customFilter: NoInnerOrSources,
+                    typesToExclude: typeof(IAsyncDisposable)
+                );
+            }
+
+            if (data.HasFlag(PossiblePlugins.UrlCollection))
+            {
+                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<UrlCollectionPluginBaseTests.Unimplemented>));
+
+                Helpers.AssertAllMembersThrowOnAccess<AccessedException<UrlCollectionPluginBaseTests.Unimplemented>, UrlCollectionPluginBaseTests.Unimplemented>(
+                    finalImpl,
+                    customFilter: NoInnerOrSources,
+                    typesToExclude: typeof(IAsyncDisposable)
+                );
+            }
+
+            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(
+                finalImpl,
+                customFilter: NoInnerOrSources,
+                expectedExceptions: expectedExceptionsWhenDisposing.ToArray()
+            );
         }
 
         [TestMethod, Timeout(5000)]
-        public void PluginFullyCustomWith_ImageCollection_UrlCollection()
+        [AllEnumFlagCombinations(typeof(PossiblePlugins))]
+        public async Task DisposeAsync_AllCombinations(PossiblePlugins data)
         {
             var builder = new SdkModelPlugins().TrackCollection;
-            var finalTestClass = new Unimplemented();
+            var defaultImplementation = new NotBlockingDisposeAsync();
             builder.Add(x => new NoOverride(x)
             {
-                InnerUrlCollection = new UrlCollectionPluginBaseTests.Unimplemented(),
-                InnerImageCollection = new ImageCollectionPluginBaseTests.Unimplemented()
-            });
-
-            var finalImpl = builder.Execute(finalTestClass);
-
-            Assert.AreNotSame(finalImpl, finalTestClass);
-            Assert.IsInstanceOfType(finalImpl, typeof(NoOverride));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<UrlCollectionPluginBaseTests.Unimplemented>, UrlCollectionPluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInnerOrSources, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<ImageCollectionPluginBaseTests.Unimplemented>, ImageCollectionPluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInnerOrSources, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<Unimplemented>, NoOverride>(finalImpl, customFilter: NoInnerOrSources, typesToExclude: new[] { typeof(IAsyncDisposable), typeof(UrlCollectionPluginBaseTests.Unimplemented), typeof(ImageCollectionPluginBaseTests.Unimplemented) });
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(finalImpl, customFilter: NoInner, expectedExceptions: new[] {
-                typeof(AccessedException<Unimplemented>),
-                typeof(AccessedException<UrlCollectionPluginBaseTests.Unimplemented>),
-                typeof(AccessedException<ImageCollectionPluginBaseTests.Unimplemented>),
-            });
-        }
-
-        [TestMethod, Timeout(5000)]
-        public void PluginFullyCustomWith_Playable_Downloadable()
-        {
-            var builder = new SdkModelPlugins().TrackCollection;
-            var finalTestClass = new Unimplemented();
-            builder.Add(x => new NoOverride(x)
-            {
-                InnerDownloadable = new DownloadablePluginBaseTests.Unimplemented(),
-                InnerPlayable = new PlayablePluginBaseTests.Unimplemented(),
-            });
-
-            var finalImpl = builder.Execute(finalTestClass);
-
-            Assert.AreNotSame(finalImpl, finalTestClass);
-            Assert.IsInstanceOfType(finalImpl, typeof(NoOverride));
-
-            // Testing InnerPlayable
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<PlayablePluginBaseTests.Unimplemented>, PlayablePluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInner, typesToExclude: new[] { typeof(IAsyncDisposable), typeof(DownloadablePluginBaseTests.Unimplemented), typeof(ImageCollectionPluginBaseTests.Unimplemented), typeof(UrlCollectionPluginBaseTests.Unimplemented) });
-            
-            // Testing InnerDownloadable
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<DownloadablePluginBaseTests.Unimplemented>, DownloadablePluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInner, typesToExclude: typeof(IAsyncDisposable));
-            
-            // Testing all other properties
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<Unimplemented>, NoOverride>(finalImpl, customFilter: NoInner, typesToExclude: new[] { typeof(IAsyncDisposable), typeof(DownloadablePluginBaseTests.Unimplemented), typeof(PlayablePluginBaseTests.Unimplemented) });
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(finalImpl, customFilter: NoInner, expectedExceptions: new[] {
-                typeof(AccessedException<Unimplemented>),
-                typeof(AccessedException<DownloadablePluginBaseTests.Unimplemented>),
-                typeof(AccessedException<PlayablePluginBaseTests.Unimplemented>),
-            });
-        }
-
-        [TestMethod, Timeout(5000)]
-        public void PluginFullyCustomWith_Playable_ImageCollection()
-        {
-            var builder = new SdkModelPlugins().TrackCollection;
-            var finalTestClass = new Unimplemented();
-            builder.Add(x => new NoOverride(x)
-            {
-                InnerImageCollection = new ImageCollectionPluginBaseTests.Unimplemented(),
-                InnerPlayable = new PlayablePluginBaseTests.Unimplemented(),
-            });
-
-            var finalImpl = builder.Execute(finalTestClass);
-
-            Assert.AreNotSame(finalImpl, finalTestClass);
-            Assert.IsInstanceOfType(finalImpl, typeof(NoOverride));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<PlayablePluginBaseTests.Unimplemented>, PlayablePluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInner, typesToExclude: new[] { typeof(IAsyncDisposable), typeof(DownloadablePluginBaseTests.Unimplemented), typeof(ImageCollectionPluginBaseTests.Unimplemented), typeof(UrlCollectionPluginBaseTests.Unimplemented) });
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<ImageCollectionPluginBaseTests.Unimplemented>, ImageCollectionPluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInnerOrSources, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<Unimplemented>, NoOverride>(finalImpl, customFilter: NoInner, typesToExclude: new[] { typeof(IAsyncDisposable), typeof(ImageCollectionPluginBaseTests.Unimplemented), typeof(PlayablePluginBaseTests.Unimplemented) });
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(finalImpl, customFilter: NoInner, expectedExceptions: new[] {
-                typeof(AccessedException<Unimplemented>),
-                typeof(AccessedException<ImageCollectionPluginBaseTests.Unimplemented>),
-                typeof(AccessedException<PlayablePluginBaseTests.Unimplemented>),
-            });
-        }
-
-        [TestMethod, Timeout(5000)]
-        public void PluginFullyCustomWith_Playable_UrlCollection()
-        {
-            var builder = new SdkModelPlugins().TrackCollection;
-            var finalTestClass = new Unimplemented();
-            builder.Add(x => new NoOverride(x)
-            {
-                InnerUrlCollection = new UrlCollectionPluginBaseTests.Unimplemented(),
-                InnerPlayable = new PlayablePluginBaseTests.Unimplemented(),
-            });
-
-            var finalImpl = builder.Execute(finalTestClass);
-
-            Assert.AreNotSame(finalImpl, finalTestClass);
-            Assert.IsInstanceOfType(finalImpl, typeof(NoOverride));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<PlayablePluginBaseTests.Unimplemented>, PlayablePluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInner, typesToExclude: new[] { typeof(IAsyncDisposable), typeof(DownloadablePluginBaseTests.Unimplemented), typeof(ImageCollectionPluginBaseTests.Unimplemented), typeof(UrlCollectionPluginBaseTests.Unimplemented) });
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<UrlCollectionPluginBaseTests.Unimplemented>, UrlCollectionPluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInnerOrSources, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<Unimplemented>, NoOverride>(finalImpl, customFilter: NoInner, typesToExclude: new[] { typeof(IAsyncDisposable), typeof(UrlCollectionPluginBaseTests.Unimplemented), typeof(PlayablePluginBaseTests.Unimplemented) });
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(finalImpl, customFilter: NoInner, expectedExceptions: new[] {
-                typeof(AccessedException<Unimplemented>),
-                typeof(AccessedException<UrlCollectionPluginBaseTests.Unimplemented>),
-                typeof(AccessedException<PlayablePluginBaseTests.Unimplemented>),
-            });
-        }
-
-        [TestMethod, Timeout(5000)]
-        public void PluginFullyCustomWith_Playable_Downloadable_ImageCollection()
-        {
-            var builder = new SdkModelPlugins().TrackCollection;
-            var finalTestClass = new Unimplemented();
-            builder.Add(x => new NoOverride(x)
-            {
-                InnerDownloadable = new DownloadablePluginBaseTests.Unimplemented(),
-                InnerImageCollection = new ImageCollectionPluginBaseTests.Unimplemented(),
-                InnerPlayable = new PlayablePluginBaseTests.Unimplemented(),
-            });
-
-            var finalImpl = builder.Execute(finalTestClass);
-
-            Assert.AreNotSame(finalImpl, finalTestClass);
-            Assert.IsInstanceOfType(finalImpl, typeof(NoOverride));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<PlayablePluginBaseTests.Unimplemented>, PlayablePluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInner, typesToExclude: new[] { typeof(IAsyncDisposable), typeof(DownloadablePluginBaseTests.Unimplemented), typeof(ImageCollectionPluginBaseTests.Unimplemented), typeof(UrlCollectionPluginBaseTests.Unimplemented) });
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<DownloadablePluginBaseTests.Unimplemented>, DownloadablePluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInner, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<ImageCollectionPluginBaseTests.Unimplemented>, ImageCollectionPluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInnerOrSources, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<Unimplemented>, NoOverride>(finalImpl, customFilter: NoInnerOrSources, typesToExclude: new[] { typeof(IAsyncDisposable), typeof(DownloadablePluginBaseTests.Unimplemented), typeof(ImageCollectionPluginBaseTests.Unimplemented), typeof(PlayablePluginBaseTests.Unimplemented) });
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(finalImpl, customFilter: NoInner, expectedExceptions: new[] {
-                typeof(AccessedException<Unimplemented>),
-                typeof(AccessedException<DownloadablePluginBaseTests.Unimplemented>),
-                typeof(AccessedException<ImageCollectionPluginBaseTests.Unimplemented>),
-                typeof(AccessedException<PlayablePluginBaseTests.Unimplemented>),
-            });
-        }
-
-        [TestMethod, Timeout(5000)]
-        public void PluginFullyCustomWith_Playable_Downloadable_UrlCollection()
-        {
-            var builder = new SdkModelPlugins().TrackCollection;
-            var finalTestClass = new Unimplemented();
-            builder.Add(x => new NoOverride(x)
-            {
-                InnerDownloadable = new DownloadablePluginBaseTests.Unimplemented(),
-                InnerUrlCollection = new UrlCollectionPluginBaseTests.Unimplemented(),
-                InnerPlayable = new PlayablePluginBaseTests.Unimplemented(),
-            });
-
-            var finalImpl = builder.Execute(finalTestClass);
-
-            Assert.AreNotSame(finalImpl, finalTestClass);
-            Assert.IsInstanceOfType(finalImpl, typeof(NoOverride));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<PlayablePluginBaseTests.Unimplemented>, PlayablePluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInner, typesToExclude: new[] { typeof(IAsyncDisposable), typeof(DownloadablePluginBaseTests.Unimplemented), typeof(ImageCollectionPluginBaseTests.Unimplemented), typeof(UrlCollectionPluginBaseTests.Unimplemented) });
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<DownloadablePluginBaseTests.Unimplemented>, DownloadablePluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInner, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<UrlCollectionPluginBaseTests.Unimplemented>, UrlCollectionPluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInnerOrSources, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<Unimplemented>, NoOverride>(finalImpl, customFilter: NoInner, typesToExclude: new[] { typeof(IAsyncDisposable), typeof(DownloadablePluginBaseTests.Unimplemented), typeof(UrlCollectionPluginBaseTests.Unimplemented), typeof(PlayablePluginBaseTests.Unimplemented) });
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(finalImpl, customFilter: NoInner, expectedExceptions: new[] {
-                typeof(AccessedException<Unimplemented>),
-                typeof(AccessedException<DownloadablePluginBaseTests.Unimplemented>),
-                typeof(AccessedException<UrlCollectionPluginBaseTests.Unimplemented>),
-                typeof(AccessedException<PlayablePluginBaseTests.Unimplemented>),
-            });
-        }
-
-        [TestMethod, Timeout(5000)]
-        public void PluginFullyCustomWith_Playable_Downloadable_ImageCollection_UrlCollection()
-        {
-            var builder = new SdkModelPlugins().TrackCollection;
-
-            var defaultImplementation = new Unimplemented();
-            builder.Add(x => new NoOverride(x)
-            {
-                InnerDownloadable = new DownloadablePluginBaseTests.Unimplemented(),
-                InnerImageCollection = new ImageCollectionPluginBaseTests.Unimplemented(),
-                InnerUrlCollection = new UrlCollectionPluginBaseTests.Unimplemented(),
-                InnerPlayable = new PlayablePluginBaseTests.Unimplemented(),
+                InnerDownloadable = data.HasFlag(PossiblePlugins.Downloadable) ? new DownloadablePluginBaseTests.NotBlockingDisposeAsync() : x,
+                InnerPlayable = data.HasFlag(PossiblePlugins.Playable) ? new PlayablePluginBaseTests.NotBlockingDisposeAsync() : x,
+                InnerImageCollection = data.HasFlag(PossiblePlugins.ImageCollection) ? new ImageCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
+                InnerUrlCollection = data.HasFlag(PossiblePlugins.UrlCollection) ? new UrlCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
             });
 
             var finalImpl = builder.Execute(defaultImplementation);
 
             Assert.AreNotSame(finalImpl, defaultImplementation);
             Assert.IsInstanceOfType(finalImpl, typeof(NoOverride));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<PlayablePluginBaseTests.Unimplemented>, PlayablePluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInner, typesToExclude: new[] { typeof(IAsyncDisposable), typeof(DownloadablePluginBaseTests.Unimplemented), typeof(ImageCollectionPluginBaseTests.Unimplemented), typeof(UrlCollectionPluginBaseTests.Unimplemented) });
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<DownloadablePluginBaseTests.Unimplemented>, DownloadablePluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInner, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<ImageCollectionPluginBaseTests.Unimplemented>, ImageCollectionPluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInnerOrSources, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<UrlCollectionPluginBaseTests.Unimplemented>, UrlCollectionPluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInnerOrSources, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<Unimplemented>, NoOverride>(finalImpl, customFilter: NoInnerOrSources, typesToExclude: new[] { typeof(IAsyncDisposable), typeof(DownloadablePluginBaseTests.Unimplemented), typeof(ImageCollectionPluginBaseTests.Unimplemented), typeof(UrlCollectionPluginBaseTests.Unimplemented), typeof(PlayablePluginBaseTests.Unimplemented) });
 
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(finalImpl, customFilter: NoInner, expectedExceptions: new[] {
-                typeof(AccessedException<Unimplemented>),
-                typeof(AccessedException<DownloadablePluginBaseTests.Unimplemented>),
-                typeof(AccessedException<ImageCollectionPluginBaseTests.Unimplemented>),
-                typeof(AccessedException<UrlCollectionPluginBaseTests.Unimplemented>),
-                typeof(AccessedException<PlayablePluginBaseTests.Unimplemented>),
-            });
+            await finalImpl.DisposeAsync();
         }
-
-        [TestMethod, Timeout(5000)]
-        public void PluginFullyCustomWith_Playable_ImageCollection_UrlCollection()
-        {
-            var builder = new SdkModelPlugins().TrackCollection;
-            var finalTestClass = new Unimplemented();
-            builder.Add(x => new NoOverride(x)
-            {
-                InnerUrlCollection = new UrlCollectionPluginBaseTests.Unimplemented(),
-                InnerImageCollection = new ImageCollectionPluginBaseTests.Unimplemented(),
-                InnerPlayable = new PlayablePluginBaseTests.Unimplemented(),
-            });
-
-            var finalImpl = builder.Execute(finalTestClass);
-
-            Assert.AreNotSame(finalImpl, finalTestClass);
-            Assert.IsInstanceOfType(finalImpl, typeof(NoOverride));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<PlayablePluginBaseTests.Unimplemented>, PlayablePluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInner, typesToExclude: new[] { typeof(IAsyncDisposable), typeof(DownloadablePluginBaseTests.Unimplemented), typeof(ImageCollectionPluginBaseTests.Unimplemented), typeof(UrlCollectionPluginBaseTests.Unimplemented) });
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<UrlCollectionPluginBaseTests.Unimplemented>, UrlCollectionPluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInnerOrSources, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<ImageCollectionPluginBaseTests.Unimplemented>, ImageCollectionPluginBaseTests.Unimplemented>(finalImpl, customFilter: NoInnerOrSources, typesToExclude: typeof(IAsyncDisposable));
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<Unimplemented>, NoOverride>(finalImpl, customFilter: NoInnerOrSources, typesToExclude: new[] { typeof(IAsyncDisposable), typeof(UrlCollectionPluginBaseTests.Unimplemented), typeof(ImageCollectionPluginBaseTests.Unimplemented), typeof(PlayablePluginBaseTests.Unimplemented) });
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(finalImpl, customFilter: NoInner, expectedExceptions: new[] {
-                typeof(AccessedException<Unimplemented>),
-                typeof(AccessedException<UrlCollectionPluginBaseTests.Unimplemented>),
-                typeof(AccessedException<ImageCollectionPluginBaseTests.Unimplemented>),
-                typeof(AccessedException<PlayablePluginBaseTests.Unimplemented>),
-            });
-        }
-
 
         internal class FullyCustom : TrackCollectionPluginBase
         {
@@ -534,6 +277,17 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
                 : base(new ModelPluginMetadata("", nameof(NoOverride), "", new Version()), inner)
             {
             }
+        }
+
+        internal class NotBlockingDisposeAsync : TrackCollectionPluginBase
+        {
+            public NotBlockingDisposeAsync()
+                : base(new ModelPluginMetadata("", nameof(NotBlockingDisposeAsync), "", new Version()), new Unimplemented())
+            {
+            }
+
+            /// <inheritdoc />
+            public override ValueTask DisposeAsync() => default;
         }
 
         internal class Unimplemented : ITrackCollection

--- a/src/Sdk/StrixMusic.Sdk.Tests/Plugins/Models/TrackPluginBaseTests.cs
+++ b/src/Sdk/StrixMusic.Sdk.Tests/Plugins/Models/TrackPluginBaseTests.cs
@@ -226,6 +226,29 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
             );
         }
 
+        [TestMethod, Timeout(5000)]
+        [AllEnumFlagCombinations(typeof(PossiblePlugins))]
+        public async Task DisposeAsync_AllCombinations(PossiblePlugins data)
+        {
+            var builder = new SdkModelPlugins().Track;
+            var defaultImplementation = new NotBlockingDisposeAsync();
+            builder.Add(x => new NoOverride(x)
+            {
+                InnerDownloadable = data.HasFlag(PossiblePlugins.Downloadable) ? new DownloadablePluginBaseTests.NotBlockingDisposeAsync() : x,
+                InnerPlayable = data.HasFlag(PossiblePlugins.Playable) ? new PlayablePluginBaseTests.NotBlockingDisposeAsync() : x,
+                InnerArtistCollection = data.HasFlag(PossiblePlugins.ArtistCollection) ? new ArtistCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
+                InnerImageCollection = data.HasFlag(PossiblePlugins.ImageCollection) ? new ImageCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
+                InnerUrlCollection = data.HasFlag(PossiblePlugins.UrlCollection) ? new UrlCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
+            });
+
+            var finalImpl = builder.Execute(defaultImplementation);
+
+            Assert.AreNotSame(finalImpl, defaultImplementation);
+            Assert.IsInstanceOfType(finalImpl, typeof(NoOverride));
+
+            await finalImpl.DisposeAsync();
+        }
+
         internal class FullyCustom : TrackPluginBase
         {
             public FullyCustom(ITrack inner)
@@ -336,6 +359,17 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
                 : base(new ModelPluginMetadata("", nameof(NoOverride), "", new Version()), inner)
             {
             }
+        }
+
+        internal class NotBlockingDisposeAsync : TrackPluginBase
+        {
+            public NotBlockingDisposeAsync()
+                : base(new ModelPluginMetadata("", nameof(NotBlockingDisposeAsync), "", new Version()), new Unimplemented())
+            {
+            }
+
+            /// <inheritdoc />
+            public override ValueTask DisposeAsync() => default;
         }
 
         internal class Unimplemented : ITrack

--- a/src/Sdk/StrixMusic.Sdk.Tests/Plugins/Models/UrlCollectionPluginBaseTests.cs
+++ b/src/Sdk/StrixMusic.Sdk.Tests/Plugins/Models/UrlCollectionPluginBaseTests.cs
@@ -92,7 +92,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
             public override event CollectionChangedEventHandler<IUrl>? UrlsChanged { add => throw AccessedException; remove => throw AccessedException; }
             public override event EventHandler<int>? UrlsCountChanged { add => throw AccessedException; remove => throw AccessedException; }
 
-            public override Task AddUrlAsync(IUrl Url, int index) => throw AccessedException;
+            public override Task AddUrlAsync(IUrl url, int index) => throw AccessedException;
 
             public override ValueTask DisposeAsync() => throw AccessedException;
 
@@ -115,6 +115,17 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
             }
         }
 
+        internal class NotBlockingDisposeAsync : UrlCollectionPluginBase
+        {
+            public NotBlockingDisposeAsync()
+                : base(new ModelPluginMetadata("", nameof(NotBlockingDisposeAsync), "", new Version()), new Unimplemented())
+            {
+            }
+
+            /// <inheritdoc />
+            public override ValueTask DisposeAsync() => default;
+        }
+
         public class Unimplemented : IUrlCollection
         {
             internal static AccessedException<Unimplemented> AccessedException { get; } = new();
@@ -128,7 +139,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
             public event CollectionChangedEventHandler<IUrl>? UrlsChanged { add => throw AccessedException; remove => throw AccessedException; }
             public event EventHandler<int>? UrlsCountChanged { add => throw AccessedException; remove => throw AccessedException; }
 
-            public Task AddUrlAsync(IUrl Url, int index) => throw AccessedException;
+            public Task AddUrlAsync(IUrl url, int index) => throw AccessedException;
 
             public ValueTask DisposeAsync() => throw AccessedException;
 


### PR DESCRIPTION
Significantly cleaned up plugin combo tests. Added tests for fully awaiting DisposeAsync under all combinations.