### PR TITLE
Remove OwlCore.Threading dependency in ViewModels

### DIFF
--- a/src/Sdk/StrixMusic.Sdk/MediaPlayback/PlaybackItem.cs
+++ b/src/Sdk/StrixMusic.Sdk/MediaPlayback/PlaybackItem.cs
@@ -7,7 +7,7 @@ using StrixMusic.Sdk.Models;
 namespace StrixMusic.Sdk.MediaPlayback
 {
     /// <summary>
-    /// Holds data that uniquely identifies an item played from an<see cref="IAudioPlayerService"/>.
+    /// Holds data that uniquely identifies an item played from an <see cref="IAudioPlayerService"/>.
     /// </summary>
     public record PlaybackItem
     {

--- a/src/Sdk/StrixMusic.Sdk/ViewModels/AlbumCollectionViewModel.cs
+++ b/src/Sdk/StrixMusic.Sdk/ViewModels/AlbumCollectionViewModel.cs
@@ -30,9 +30,10 @@ namespace StrixMusic.Sdk.ViewModels
     {
         private readonly IAlbumCollection _collection;
 
-        private readonly SemaphoreSlim _populateAlbumsMutex = new SemaphoreSlim(1, 1);
-        private readonly SemaphoreSlim _populateImagesMutex = new SemaphoreSlim(1, 1);
-        private readonly SemaphoreSlim _populateUrlsMutex = new SemaphoreSlim(1, 1);
+        private readonly SemaphoreSlim _populateAlbumsMutex = new(1, 1);
+        private readonly SemaphoreSlim _populateImagesMutex = new(1, 1);
+        private readonly SemaphoreSlim _populateUrlsMutex = new(1, 1);
+        private readonly SynchronizationContext _syncContext;
 
         /// <summary>
         /// Creates a new instance of <see cref="AlbumCollectionViewModel"/>.
@@ -41,16 +42,14 @@ namespace StrixMusic.Sdk.ViewModels
         /// <param name="collection">The <see cref="IAlbumCollection"/> to wrap around.</param>
         public AlbumCollectionViewModel(MainViewModel root, IAlbumCollection collection)
         {
+            _syncContext = SynchronizationContext.Current;
             Root = root;
             _collection = root.Plugins.ModelPlugins.AlbumCollection.Execute(collection);
 
-            using (Threading.PrimaryContext)
-            {
-                Albums = new ObservableCollection<IAlbumCollectionItem>();
-                UnsortedAlbums = new ObservableCollection<IAlbumCollectionItem>();
-                Images = new ObservableCollection<IImage>();
-                Urls = new ObservableCollection<IUrl>();
-            }
+            Albums = new ObservableCollection<IAlbumCollectionItem>();
+            UnsortedAlbums = new ObservableCollection<IAlbumCollectionItem>();
+            Images = new ObservableCollection<IImage>();
+            Urls = new ObservableCollection<IUrl>();
 
             SourceCores = _collection.GetSourceCores<ICoreAlbumCollection>().Select(root.GetLoadedCore).ToList();
 
@@ -118,43 +117,43 @@ namespace StrixMusic.Sdk.ViewModels
             ImagesChanged -= AlbumCollectionViewModel_ImagesChanged;
         }
 
-        private void OnNameChanged(object sender, string e) => _ = Threading.OnPrimaryThread(() => OnPropertyChanged(nameof(Name)));
+        private void OnNameChanged(object sender, string e) => _syncContext.Post(_ => OnPropertyChanged(nameof(Name)), null);
 
-        private void OnDescriptionChanged(object sender, string? e) => _ = Threading.OnPrimaryThread(() => OnPropertyChanged(nameof(Description)));
+        private void OnDescriptionChanged(object sender, string? e) => _syncContext.Post(_ => OnPropertyChanged(nameof(Description)), null);
 
-        private void OnPlaybackStateChanged(object sender, PlaybackState e) => _ = Threading.OnPrimaryThread(() => OnPropertyChanged(nameof(PlaybackState)));
+        private void OnPlaybackStateChanged(object sender, PlaybackState e) => _syncContext.Post(_ => OnPropertyChanged(nameof(PlaybackState)), null);
 
-        private void OnDownloadInfoChanged(object sender, DownloadInfo e) => _ = Threading.OnPrimaryThread(() => OnPropertyChanged(nameof(DownloadInfo)));
+        private void OnDownloadInfoChanged(object sender, DownloadInfo e) => _syncContext.Post(_ => OnPropertyChanged(nameof(DownloadInfo)), null);
 
-        private void OnAlbumItemsCountChanged(object sender, int e) => _ = Threading.OnPrimaryThread(() => OnPropertyChanged(nameof(TotalAlbumItemsCount)));
+        private void OnAlbumItemsCountChanged(object sender, int e) => _syncContext.Post(_ => OnPropertyChanged(nameof(TotalAlbumItemsCount)), null);
 
-        private void OnImagesCountChanged(object sender, int e) => _ = Threading.OnPrimaryThread(() => OnPropertyChanged(nameof(TotalImageCount)));
+        private void OnImagesCountChanged(object sender, int e) => _syncContext.Post(_ => OnPropertyChanged(nameof(TotalImageCount)), null);
 
-        private void OnUrlsCountChanged(object sender, int e) => _ = Threading.OnPrimaryThread(() => OnPropertyChanged(nameof(TotalUrlCount)));
+        private void OnUrlsCountChanged(object sender, int e) => _syncContext.Post(_ => OnPropertyChanged(nameof(TotalUrlCount)), null);
 
-        private void OnLastPlayedChanged(object sender, DateTime? e) => _ = Threading.OnPrimaryThread(() => OnPropertyChanged(nameof(LastPlayed)));
+        private void OnLastPlayedChanged(object sender, DateTime? e) => _syncContext.Post(_ => OnPropertyChanged(nameof(LastPlayed)), null);
 
-        private void OnIsChangeDescriptionAsyncAvailableChanged(object sender, bool e) => _ = Threading.OnPrimaryThread(() => OnPropertyChanged(nameof(IsChangeDescriptionAsyncAvailable)));
+        private void OnIsChangeDescriptionAsyncAvailableChanged(object sender, bool e) => _syncContext.Post(_ => OnPropertyChanged(nameof(IsChangeDescriptionAsyncAvailable)), null);
 
-        private void OnIsChangeDurationAsyncAvailableChanged(object sender, bool e) => _ = Threading.OnPrimaryThread(() => OnPropertyChanged(nameof(IsChangeDurationAsyncAvailable)));
+        private void OnIsChangeDurationAsyncAvailableChanged(object sender, bool e) => _syncContext.Post(_ => OnPropertyChanged(nameof(IsChangeDurationAsyncAvailable)), null);
 
-        private void OnIsChangeNameAsyncAvailableChanged(object sender, bool e) => _ = Threading.OnPrimaryThread(() => OnPropertyChanged(nameof(IsChangeNameAsyncAvailable)));
+        private void OnIsChangeNameAsyncAvailableChanged(object sender, bool e) => _syncContext.Post(_ => OnPropertyChanged(nameof(IsChangeNameAsyncAvailable)), null);
 
-        private void OnIsPauseAlbumCollectionAsyncAvailableChanged(object sender, bool e) => _ = Threading.OnPrimaryThread(() => OnPropertyChanged(nameof(IsPauseAlbumCollectionAsyncAvailable)));
+        private void OnIsPauseAlbumCollectionAsyncAvailableChanged(object sender, bool e) => _syncContext.Post(_ => OnPropertyChanged(nameof(IsPauseAlbumCollectionAsyncAvailable)), null);
 
-        private void OnIsPlayAlbumCollectionAsyncAvailableChanged(object sender, bool e) => _ = Threading.OnPrimaryThread(() => OnPropertyChanged(nameof(IsPlayAlbumCollectionAsyncAvailable)));
+        private void OnIsPlayAlbumCollectionAsyncAvailableChanged(object sender, bool e) => _syncContext.Post(_ => OnPropertyChanged(nameof(IsPlayAlbumCollectionAsyncAvailable)), null);
 
-        private void AlbumCollectionViewModel_ImagesChanged(object sender, IReadOnlyList<CollectionChangedItem<IImage>> addedItems, IReadOnlyList<CollectionChangedItem<IImage>> removedItems) => _ = Threading.OnPrimaryThread(() =>
+        private void AlbumCollectionViewModel_ImagesChanged(object sender, IReadOnlyList<CollectionChangedItem<IImage>> addedItems, IReadOnlyList<CollectionChangedItem<IImage>> removedItems) => _syncContext.Post(_ =>
         {
             Images.ChangeCollection(addedItems, removedItems);
-        });
+        }, null);
 
-        private void AlbumCollectionViewModel_UrlsChanged(object sender, IReadOnlyList<CollectionChangedItem<IUrl>> addedItems, IReadOnlyList<CollectionChangedItem<IUrl>> removedItems) => _ = Threading.OnPrimaryThread(() =>
+        private void AlbumCollectionViewModel_UrlsChanged(object sender, IReadOnlyList<CollectionChangedItem<IUrl>> addedItems, IReadOnlyList<CollectionChangedItem<IUrl>> removedItems) => _syncContext.Post(_ =>
         {
             Urls.ChangeCollection(addedItems, removedItems);
-        });
+        }, null);
 
-        private void AlbumCollectionViewModel_AlbumItemsChanged(object sender, IReadOnlyList<CollectionChangedItem<IAlbumCollectionItem>> addedItems, IReadOnlyList<CollectionChangedItem<IAlbumCollectionItem>> removedItems) => _ = Threading.OnPrimaryThread(() =>
+        private void AlbumCollectionViewModel_AlbumItemsChanged(object sender, IReadOnlyList<CollectionChangedItem<IAlbumCollectionItem>> addedItems, IReadOnlyList<CollectionChangedItem<IAlbumCollectionItem>> removedItems) => _syncContext.Post(_ =>
         {
             if (CurrentAlbumSortingType == AlbumSortingType.Unsorted)
             {
@@ -176,8 +175,7 @@ namespace StrixMusic.Sdk.ViewModels
                     _ => ThrowHelper.ThrowNotSupportedException<IAlbumCollectionItem>(
                         $"{item.Data.GetType()} not supported for adding to {GetType()}")
                 });
-
-                // Avoiding direct assignment to prevent effect on UI.
+                
                 foreach (var item in UnsortedAlbums)
                 {
                     if (!Albums.Contains(item))
@@ -192,7 +190,7 @@ namespace StrixMusic.Sdk.ViewModels
 
                 SortAlbumCollection(CurrentAlbumSortingType, CurrentAlbumSortingDirection);
             }
-        });
+        }, null);
 
         /// <inheritdoc />
         public event EventHandler<PlaybackState>? PlaybackStateChanged
@@ -320,7 +318,7 @@ namespace StrixMusic.Sdk.ViewModels
             {
                 var items = await _collection.GetAlbumItemsAsync(limit, Albums.Count);
 
-                _ = Threading.OnPrimaryThread(() =>
+                _syncContext.Post(_ =>
                 {
                     foreach (var item in items)
                     {
@@ -334,7 +332,7 @@ namespace StrixMusic.Sdk.ViewModels
                                 break;
                         }
                     }
-                });
+                }, null);
             }
         }
 
@@ -345,13 +343,11 @@ namespace StrixMusic.Sdk.ViewModels
             {
                 var items = await _collection.GetImagesAsync(limit, Images.Count);
 
-                _ = Threading.OnPrimaryThread(() =>
+                _syncContext.Post(_ =>
                 {
                     foreach (var item in items)
-                    {
                         Images.Add(item);
-                    }
-                });
+                }, null);
             }
         }
 
@@ -362,13 +358,13 @@ namespace StrixMusic.Sdk.ViewModels
             {
                 var items = await _collection.GetUrlsAsync(limit, Urls.Count);
 
-                _ = Threading.OnPrimaryThread(() =>
+                _syncContext.Post(_ =>
                 {
                     foreach (var item in items)
                     {
                         Urls.Add(item);
                     }
-                });
+                }, null);
             }
         }
 
@@ -382,7 +378,7 @@ namespace StrixMusic.Sdk.ViewModels
         }
 
         /// <inheritdoc />
-        public ObservableCollection<IAlbumCollectionItem> Albums { get; set; }
+        public ObservableCollection<IAlbumCollectionItem> Albums { get; }
 
         ///<inheritdoc />
         public ObservableCollection<IAlbumCollectionItem> UnsortedAlbums { get; }

--- a/src/Sdk/StrixMusic.Sdk/ViewModels/AlbumViewModel.cs
+++ b/src/Sdk/StrixMusic.Sdk/ViewModels/AlbumViewModel.cs
@@ -24,17 +24,18 @@ using StrixMusic.Sdk.ViewModels.Helpers;
 namespace StrixMusic.Sdk.ViewModels
 {
     /// <summary>
-    /// Contains bindable information about an <see cref="IAlbum"/>.
+    /// A ViewModel for <see cref="IAlbum"/>.
     /// </summary>
     public sealed class AlbumViewModel : ObservableObject, ISdkViewModel, IAlbum, IArtistCollectionViewModel, ITrackCollectionViewModel, IImageCollectionViewModel, IUrlCollectionViewModel, IGenreCollectionViewModel
     {
         private readonly IAlbum _album;
-        
-        private readonly SemaphoreSlim _populateTracksMutex = new SemaphoreSlim(1, 1);
-        private readonly SemaphoreSlim _populateArtistsMutex = new SemaphoreSlim(1, 1);
-        private readonly SemaphoreSlim _populateImagesMutex = new SemaphoreSlim(1, 1);
-        private readonly SemaphoreSlim _populateUrlsMutex = new SemaphoreSlim(1, 1);
-        private readonly SemaphoreSlim _populateGenresMutex = new SemaphoreSlim(1, 1);
+
+        private readonly SemaphoreSlim _populateTracksMutex = new(1, 1);
+        private readonly SemaphoreSlim _populateArtistsMutex = new(1, 1);
+        private readonly SemaphoreSlim _populateImagesMutex = new(1, 1);
+        private readonly SemaphoreSlim _populateUrlsMutex = new(1, 1);
+        private readonly SemaphoreSlim _populateGenresMutex = new(1, 1);
+        private readonly SynchronizationContext _syncContext;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AlbumViewModel"/> class.
@@ -43,22 +44,21 @@ namespace StrixMusic.Sdk.ViewModels
         /// <param name="album"><inheritdoc cref="IAlbum"/></param>
         internal AlbumViewModel(MainViewModel root, IAlbum album)
         {
+            _syncContext = SynchronizationContext.Current;
+
             Root = root;
             _album = root.Plugins.ModelPlugins.Album.Execute(album);
 
             SourceCores = _album.GetSourceCores<ICoreAlbum>().Select(root.GetLoadedCore).ToList();
-            
-            using (Threading.PrimaryContext)
-            {
-                Tracks = new ObservableCollection<TrackViewModel>();
-                Artists = new ObservableCollection<IArtistCollectionItem>();
-                UnsortedTracks = new ObservableCollection<TrackViewModel>();
-                UnsortedArtists = new ObservableCollection<IArtistCollectionItem>();
 
-                Images = new ObservableCollection<IImage>();
-                Genres = new ObservableCollection<IGenre>();
-                Urls = new ObservableCollection<IUrl>();
-            }
+            Tracks = new ObservableCollection<TrackViewModel>();
+            Artists = new ObservableCollection<IArtistCollectionItem>();
+            UnsortedTracks = new ObservableCollection<TrackViewModel>();
+            UnsortedArtists = new ObservableCollection<IArtistCollectionItem>();
+
+            Images = new ObservableCollection<IImage>();
+            Genres = new ObservableCollection<IGenre>();
+            Urls = new ObservableCollection<IUrl>();
 
             if (album.RelatedItems != null)
                 RelatedItems = new PlayableCollectionGroupViewModel(root, album.RelatedItems);
@@ -326,45 +326,45 @@ namespace StrixMusic.Sdk.ViewModels
             remove => _album.GenresCountChanged -= value;
         }
 
-        private void AlbumNameChanged(object sender, string e) => _ = Threading.OnPrimaryThread(() => OnPropertyChanged(nameof(Name)));
+        private void AlbumNameChanged(object sender, string e) => _syncContext.Post(_ => OnPropertyChanged(nameof(Name)), null);
 
-        private void AlbumDescriptionChanged(object sender, string? e) => _ = Threading.OnPrimaryThread(() => OnPropertyChanged(nameof(Description)));
+        private void AlbumDescriptionChanged(object sender, string? e) => _syncContext.Post(_ => OnPropertyChanged(nameof(Description)), null);
 
-        private void AlbumPlaybackStateChanged(object sender, PlaybackState e) => _ = Threading.OnPrimaryThread(() => OnPropertyChanged(nameof(PlaybackState)));
+        private void AlbumPlaybackStateChanged(object sender, PlaybackState e) => _syncContext.Post(_ => OnPropertyChanged(nameof(PlaybackState)), null);
 
-        private void OnDownloadInfoChanged(object sender, DownloadInfo e) => _ = Threading.OnPrimaryThread(() => OnPropertyChanged(nameof(DownloadInfo)));
+        private void OnDownloadInfoChanged(object sender, DownloadInfo e) => _syncContext.Post(_ => OnPropertyChanged(nameof(DownloadInfo)), null);
 
-        private void AlbumDatePublishedChanged(object sender, DateTime? e) => _ = Threading.OnPrimaryThread(() => OnPropertyChanged(nameof(DatePublished)));
+        private void AlbumDatePublishedChanged(object sender, DateTime? e) => _syncContext.Post(_ => OnPropertyChanged(nameof(DatePublished)), null);
 
-        private void OnTrackItemsCountChanged(object sender, int e) => _ = Threading.OnPrimaryThread(() => OnPropertyChanged(nameof(TotalTrackCount)));
+        private void OnTrackItemsCountChanged(object sender, int e) => _syncContext.Post(_ => OnPropertyChanged(nameof(TotalTrackCount)), null);
 
-        private void OnImagesCountChanged(object sender, int e) => _ = Threading.OnPrimaryThread(() => OnPropertyChanged(nameof(TotalImageCount)));
+        private void OnImagesCountChanged(object sender, int e) => _syncContext.Post(_ => OnPropertyChanged(nameof(TotalImageCount)), null);
 
-        private void OnUrlsCountChanged(object sender, int e) => _ = Threading.OnPrimaryThread(() => OnPropertyChanged(nameof(TotalUrlCount)));
+        private void OnUrlsCountChanged(object sender, int e) => _syncContext.Post(_ => OnPropertyChanged(nameof(TotalUrlCount)), null);
 
-        private void OnArtistItemsCountChanged(object sender, int e) => _ = Threading.OnPrimaryThread(() => OnPropertyChanged(nameof(TotalArtistItemsCount)));
+        private void OnArtistItemsCountChanged(object sender, int e) => _syncContext.Post(_ => OnPropertyChanged(nameof(TotalArtistItemsCount)), null);
 
-        private void OnGenresItemsCountChanged(object sender, int e) => _ = Threading.OnPrimaryThread(() => OnPropertyChanged(nameof(TotalGenreCount)));
+        private void OnGenresItemsCountChanged(object sender, int e) => _syncContext.Post(_ => OnPropertyChanged(nameof(TotalGenreCount)), null);
 
-        private void OnLastPlayedChanged(object sender, DateTime? e) => _ = Threading.OnPrimaryThread(() => OnPropertyChanged(nameof(LastPlayed)));
+        private void OnLastPlayedChanged(object sender, DateTime? e) => _syncContext.Post(_ => OnPropertyChanged(nameof(LastPlayed)), null);
 
-        private void OnIsChangeDescriptionAsyncAvailableChanged(object sender, bool e) => _ = Threading.OnPrimaryThread(() => OnPropertyChanged(nameof(IsChangeDescriptionAsyncAvailable)));
+        private void OnIsChangeDescriptionAsyncAvailableChanged(object sender, bool e) => _syncContext.Post(_ => OnPropertyChanged(nameof(IsChangeDescriptionAsyncAvailable)), null);
 
-        private void OnIsChangeDurationAsyncAvailableChanged(object sender, bool e) => _ = Threading.OnPrimaryThread(() => OnPropertyChanged(nameof(IsChangeDurationAsyncAvailable)));
+        private void OnIsChangeDurationAsyncAvailableChanged(object sender, bool e) => _syncContext.Post(_ => OnPropertyChanged(nameof(IsChangeDurationAsyncAvailable)), null);
 
-        private void OnIsChangeNameAsyncAvailableChanged(object sender, bool e) => _ = Threading.OnPrimaryThread(() => OnPropertyChanged(nameof(IsChangeNameAsyncAvailable)));
+        private void OnIsChangeNameAsyncAvailableChanged(object sender, bool e) => _syncContext.Post(_ => OnPropertyChanged(nameof(IsChangeNameAsyncAvailable)), null);
 
-        private void OnIsPauseTrackCollectionAsyncAvailableChanged(object sender, bool e) => _ = Threading.OnPrimaryThread(() => OnPropertyChanged(nameof(IsPauseTrackCollectionAsyncAvailable)));
+        private void OnIsPauseTrackCollectionAsyncAvailableChanged(object sender, bool e) => _syncContext.Post(_ => OnPropertyChanged(nameof(IsPauseTrackCollectionAsyncAvailable)), null);
 
-        private void OnIsPlayTrackCollectionAsyncAvailableChanged(object sender, bool e) => _ = Threading.OnPrimaryThread(() => OnPropertyChanged(nameof(IsPlayTrackCollectionAsyncAvailable)));
+        private void OnIsPlayTrackCollectionAsyncAvailableChanged(object sender, bool e) => _syncContext.Post(_ => OnPropertyChanged(nameof(IsPlayTrackCollectionAsyncAvailable)), null);
 
-        private void OnIsPauseArtistCollectionAsyncAvailableChanged(object sender, bool e) => _ = Threading.OnPrimaryThread(() => OnPropertyChanged(nameof(IsPauseArtistCollectionAsyncAvailable)));
+        private void OnIsPauseArtistCollectionAsyncAvailableChanged(object sender, bool e) => _syncContext.Post(_ => OnPropertyChanged(nameof(IsPauseArtistCollectionAsyncAvailable)), null);
 
-        private void OnIsPlayArtistCollectionAsyncAvailableChanged(object sender, bool e) => _ = Threading.OnPrimaryThread(() => OnPropertyChanged(nameof(IsPlayArtistCollectionAsyncAvailable)));
+        private void OnIsPlayArtistCollectionAsyncAvailableChanged(object sender, bool e) => _syncContext.Post(_ => OnPropertyChanged(nameof(IsPlayArtistCollectionAsyncAvailable)), null);
 
-        private void OnIsChangeDatePublishedAsyncAvailableChanged(object sender, bool e) => _ = Threading.OnPrimaryThread(() => OnPropertyChanged(nameof(IsChangeDatePublishedAsyncAvailableChanged)));
+        private void OnIsChangeDatePublishedAsyncAvailableChanged(object sender, bool e) => _syncContext.Post(_ => OnPropertyChanged(nameof(IsChangeDatePublishedAsyncAvailableChanged)), null);
 
-        private void AlbumViewModel_TrackItemsChanged(object sender, IReadOnlyList<CollectionChangedItem<ITrack>> addedItems, IReadOnlyList<CollectionChangedItem<ITrack>> removedItems) => _ = Threading.OnPrimaryThread(() =>
+        private void AlbumViewModel_TrackItemsChanged(object sender, IReadOnlyList<CollectionChangedItem<ITrack>> addedItems, IReadOnlyList<CollectionChangedItem<ITrack>> removedItems) => _syncContext.Post(_ =>
         {
             if (CurrentTracksSortingType == TrackSortingType.Unsorted)
             {
@@ -372,10 +372,9 @@ namespace StrixMusic.Sdk.ViewModels
             }
             else
             {
-                // Preventing index issues during tracks emission from the core, also making sure that unordered tracks updated. 
+                // Make sure both ordered and unordered tracks are updated. 
                 UnsortedTracks.ChangeCollection(addedItems, removedItems, x => new TrackViewModel(Root, x.Data));
 
-                // Avoiding direct assignment to prevent effect on UI.
                 foreach (var item in UnsortedTracks)
                 {
                     if (!Tracks.Contains(item))
@@ -390,9 +389,9 @@ namespace StrixMusic.Sdk.ViewModels
 
                 SortTrackCollection(CurrentTracksSortingType, CurrentTracksSortingDirection);
             }
-        });
+        }, null);
 
-        private void OnArtistItemsChanged(object sender, IReadOnlyList<CollectionChangedItem<IArtistCollectionItem>> addedItems, IReadOnlyList<CollectionChangedItem<IArtistCollectionItem>> removedItems) => _ = Threading.OnPrimaryThread(() =>
+        private void OnArtistItemsChanged(object sender, IReadOnlyList<CollectionChangedItem<IArtistCollectionItem>> addedItems, IReadOnlyList<CollectionChangedItem<IArtistCollectionItem>> removedItems) => _syncContext.Post(_ =>
         {
             if (CurrentArtistSortingType == ArtistSortingType.Unsorted)
             {
@@ -406,7 +405,7 @@ namespace StrixMusic.Sdk.ViewModels
             }
             else
             {
-                // Preventing index issues during artists emission from the core, also making sure that unordered artists updated. 
+                // Make sure both ordered and unordered artists are updated. 
                 UnsortedArtists.ChangeCollection(addedItems, removedItems, item => item.Data switch
                 {
                     IArtist artist => new ArtistViewModel(Root, artist),
@@ -415,7 +414,6 @@ namespace StrixMusic.Sdk.ViewModels
                         $"{item.Data.GetType()} not supported for adding to {GetType()}")
                 });
 
-                // Avoiding direct assignment to prevent effect on UI.
                 foreach (var item in UnsortedArtists)
                 {
                     if (!Artists.Contains(item))
@@ -430,22 +428,16 @@ namespace StrixMusic.Sdk.ViewModels
 
                 SortArtistCollection(CurrentArtistSortingType, CurrentArtistSortingDirection);
             }
-        });
+        }, null);
 
-        private void AlbumViewModel_ImagesChanged(object sender, IReadOnlyList<CollectionChangedItem<IImage>> addedItems, IReadOnlyList<CollectionChangedItem<IImage>> removedItems) => _ = Threading.OnPrimaryThread(() =>
-        {
-            Images.ChangeCollection(addedItems, removedItems);
-        });
+        private void AlbumViewModel_ImagesChanged(object sender, IReadOnlyList<CollectionChangedItem<IImage>> addedItems, IReadOnlyList<CollectionChangedItem<IImage>> removedItems)
+            => _syncContext.Post(_ => Images.ChangeCollection(addedItems, removedItems), null);
 
-        private void OnGenresChanged(object sender, IReadOnlyList<CollectionChangedItem<IGenre>> addedItems, IReadOnlyList<CollectionChangedItem<IGenre>> removedItems) => _ = Threading.OnPrimaryThread(() =>
-        {
-            Genres.ChangeCollection(addedItems, removedItems);
-        });
+        private void OnGenresChanged(object sender, IReadOnlyList<CollectionChangedItem<IGenre>> addedItems, IReadOnlyList<CollectionChangedItem<IGenre>> removedItems)
+            => _syncContext.Post(_ => Genres.ChangeCollection(addedItems, removedItems), null);
 
-        private void OnUrlsChanged(object sender, IReadOnlyList<CollectionChangedItem<IUrl>> addedItems, IReadOnlyList<CollectionChangedItem<IUrl>> removedItems) => _ = Threading.OnPrimaryThread(() =>
-        {
-            Urls.ChangeCollection(addedItems, removedItems);
-        });
+        private void OnUrlsChanged(object sender, IReadOnlyList<CollectionChangedItem<IUrl>> addedItems, IReadOnlyList<CollectionChangedItem<IUrl>> removedItems)
+            => _syncContext.Post(_ => Urls.ChangeCollection(addedItems, removedItems), null);
 
         /// <inheritdoc />
         public string Id => _album.Id;
@@ -502,7 +494,7 @@ namespace StrixMusic.Sdk.ViewModels
         /// <summary>
         /// The tracks for this album.
         /// </summary>
-        public ObservableCollection<TrackViewModel> Tracks { get; set; }
+        public ObservableCollection<TrackViewModel> Tracks { get; }
 
         /// <inheritdoc />
         public ObservableCollection<TrackViewModel> UnsortedTracks { get; }
@@ -719,16 +711,12 @@ namespace StrixMusic.Sdk.ViewModels
             {
                 var items = await _album.GetArtistItemsAsync(limit, Artists.Count);
 
-                await Threading.OnPrimaryThread(() =>
+                _syncContext.Post(_ =>
                 {
                     foreach (var item in items)
-                    {
                         if (item is IArtist artist)
-                        {
                             Artists.Add(new ArtistViewModel(Root, artist));
-                        }
-                    }
-                });
+                }, null);
             }
         }
 
@@ -739,13 +727,11 @@ namespace StrixMusic.Sdk.ViewModels
             {
                 var items = await _album.GetImagesAsync(limit, Images.Count);
 
-                await Threading.OnPrimaryThread(() =>
+                _syncContext.Post(_ =>
                 {
                     foreach (var item in items)
-                    {
                         Images.Add(item);
-                    }
-                });
+                }, null);
             }
         }
 
@@ -756,13 +742,11 @@ namespace StrixMusic.Sdk.ViewModels
             {
                 var items = await _album.GetUrlsAsync(limit, Urls.Count);
 
-                await Threading.OnPrimaryThread(() =>
+                _syncContext.Post(_ =>
                 {
                     foreach (var item in items)
-                    {
                         Urls.Add(item);
-                    }
-                });
+                }, null);
             }
         }
 
@@ -773,13 +757,11 @@ namespace StrixMusic.Sdk.ViewModels
             {
                 var items = await _album.GetGenresAsync(limit, Genres.Count);
 
-                await Threading.OnPrimaryThread(() =>
+                _syncContext.Post(_ =>
                 {
                     foreach (var item in items)
-                    {
                         Genres.Add(item);
-                    }
-                });
+                }, null);
             }
         }
 

--- a/src/Sdk/StrixMusic.Sdk/ViewModels/ArtistViewModel.cs
+++ b/src/Sdk/StrixMusic.Sdk/ViewModels/ArtistViewModel.cs
@@ -25,17 +25,18 @@ using StrixMusic.Sdk.ViewModels.Helpers;
 namespace StrixMusic.Sdk.ViewModels
 {
     /// <summary>
-    /// Contains bindable information about an <see cref="ICoreArtist"/>.
+    /// A ViewModel for <see cref="IArtist"/>.
     /// </summary>
     public sealed class ArtistViewModel : ObservableObject, IArtist, ISdkViewModel, IAlbumCollectionViewModel, ITrackCollectionViewModel, IImageCollectionViewModel, IGenreCollectionViewModel, IUrlCollectionViewModel
     {
         private readonly IArtist _artist;
 
-        private readonly SemaphoreSlim _populateTracksMutex = new SemaphoreSlim(1, 1);
-        private readonly SemaphoreSlim _populateAlbumsMutex = new SemaphoreSlim(1, 1);
-        private readonly SemaphoreSlim _populateImagesMutex = new SemaphoreSlim(1, 1);
-        private readonly SemaphoreSlim _populateGenresMutex = new SemaphoreSlim(1, 1);
-        private readonly SemaphoreSlim _populateUrlsMutex = new SemaphoreSlim(1, 1);
+        private readonly SemaphoreSlim _populateTracksMutex = new(1, 1);
+        private readonly SemaphoreSlim _populateAlbumsMutex = new(1, 1);
+        private readonly SemaphoreSlim _populateImagesMutex = new(1, 1);
+        private readonly SemaphoreSlim _populateGenresMutex = new(1, 1);
+        private readonly SemaphoreSlim _populateUrlsMutex = new(1, 1);
+        private readonly SynchronizationContext _syncContext;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ArtistViewModel"/> class.
@@ -44,6 +45,8 @@ namespace StrixMusic.Sdk.ViewModels
         /// <param name="artist">The <see cref="IArtist"/> to wrap.</param>
         internal ArtistViewModel(MainViewModel root, IArtist artist)
         {
+            _syncContext = SynchronizationContext.Current;
+
             _artist = root.Plugins.ModelPlugins.Artist.Execute(artist);
             Root = root;
 
@@ -52,16 +55,13 @@ namespace StrixMusic.Sdk.ViewModels
             if (_artist.RelatedItems != null)
                 RelatedItems = new PlayableCollectionGroupViewModel(root, _artist.RelatedItems);
 
-            using (Threading.PrimaryContext)
-            {
-                UnsortedTracks = new ObservableCollection<TrackViewModel>();
-                UnsortedAlbums = new ObservableCollection<IAlbumCollectionItem>();
-                Tracks = new ObservableCollection<TrackViewModel>();
-                Albums = new ObservableCollection<IAlbumCollectionItem>();
-                Images = new ObservableCollection<IImage>();
-                Genres = new ObservableCollection<IGenre>();
-                Urls = new ObservableCollection<IUrl>();
-            }
+            UnsortedTracks = new ObservableCollection<TrackViewModel>();
+            UnsortedAlbums = new ObservableCollection<IAlbumCollectionItem>();
+            Tracks = new ObservableCollection<TrackViewModel>();
+            Albums = new ObservableCollection<IAlbumCollectionItem>();
+            Images = new ObservableCollection<IImage>();
+            Genres = new ObservableCollection<IGenre>();
+            Urls = new ObservableCollection<IUrl>();
 
             PlayTrackCollectionAsyncCommand = new AsyncRelayCommand(PlayTrackCollectionAsync);
             PauseTrackCollectionAsyncCommand = new AsyncRelayCommand(PauseTrackCollectionAsync);
@@ -313,51 +313,51 @@ namespace StrixMusic.Sdk.ViewModels
             remove => _artist.UrlsCountChanged -= value;
         }
 
-        private void ArtistNameChanged(object sender, string e) => _ = Threading.OnPrimaryThread(() => OnPropertyChanged(nameof(Name)));
+        private void ArtistNameChanged(object sender, string e) => _syncContext.Post(_ => OnPropertyChanged(nameof(Name)), null);
 
-        private void ArtistDescriptionChanged(object sender, string? e) => _ = Threading.OnPrimaryThread(() => OnPropertyChanged(nameof(Description)));
+        private void ArtistDescriptionChanged(object sender, string? e) => _syncContext.Post(_ => OnPropertyChanged(nameof(Description)), null);
 
-        private void ArtistPlaybackStateChanged(object sender, PlaybackState e) => _ = Threading.OnPrimaryThread(() => OnPropertyChanged(nameof(PlaybackState)));
+        private void ArtistPlaybackStateChanged(object sender, PlaybackState e) => _syncContext.Post(_ => OnPropertyChanged(nameof(PlaybackState)), null);
 
-        private void OnDownloadInfoChanged(object sender, DownloadInfo e) => _ = Threading.OnPrimaryThread(() => OnPropertyChanged(nameof(DownloadInfo)));
+        private void OnDownloadInfoChanged(object sender, DownloadInfo e) => _syncContext.Post(_ => OnPropertyChanged(nameof(DownloadInfo)), null);
 
-        private void ArtistOnTrackItemsCountChanged(object sender, int e) => _ = Threading.OnPrimaryThread(() => OnPropertyChanged(nameof(TotalTrackCount)));
+        private void ArtistOnTrackItemsCountChanged(object sender, int e) => _syncContext.Post(_ => OnPropertyChanged(nameof(TotalTrackCount)), null);
 
-        private void Artist_AlbumItemsCountChanged(object sender, int e) => _ = Threading.OnPrimaryThread(() => OnPropertyChanged(nameof(TotalAlbumItemsCount)));
+        private void Artist_AlbumItemsCountChanged(object sender, int e) => _syncContext.Post(_ => OnPropertyChanged(nameof(TotalAlbumItemsCount)), null);
 
-        private void ArtistViewModel_ImagesCountChanged(object sender, int e) => _ = Threading.OnPrimaryThread(() => OnPropertyChanged(nameof(TotalImageCount)));
+        private void ArtistViewModel_ImagesCountChanged(object sender, int e) => _syncContext.Post(_ => OnPropertyChanged(nameof(TotalImageCount)), null);
 
-        private void ArtistViewModel_UrlsCountChanged(object sender, int e) => _ = Threading.OnPrimaryThread(() => OnPropertyChanged(nameof(TotalUrlCount)));
+        private void ArtistViewModel_UrlsCountChanged(object sender, int e) => _syncContext.Post(_ => OnPropertyChanged(nameof(TotalUrlCount)), null);
 
-        private void ArtistViewModel_GenresCountChanged(object sender, int e) => _ = Threading.OnPrimaryThread(() => OnPropertyChanged(nameof(TotalGenreCount)));
+        private void ArtistViewModel_GenresCountChanged(object sender, int e) => _syncContext.Post(_ => OnPropertyChanged(nameof(TotalGenreCount)), null);
 
-        private void OnLastPlayedChanged(object sender, DateTime? e) => _ = Threading.OnPrimaryThread(() => OnPropertyChanged(nameof(LastPlayed)));
+        private void OnLastPlayedChanged(object sender, DateTime? e) => _syncContext.Post(_ => OnPropertyChanged(nameof(LastPlayed)), null);
 
-        private void OnIsChangeDescriptionAsyncAvailableChanged(object sender, bool e) => _ = Threading.OnPrimaryThread(() => OnPropertyChanged(nameof(IsChangeDescriptionAsyncAvailable)));
+        private void OnIsChangeDescriptionAsyncAvailableChanged(object sender, bool e) => _syncContext.Post(_ => OnPropertyChanged(nameof(IsChangeDescriptionAsyncAvailable)), null);
 
-        private void OnIsChangeDurationAsyncAvailableChanged(object sender, bool e) => _ = Threading.OnPrimaryThread(() => OnPropertyChanged(nameof(IsChangeDurationAsyncAvailable)));
+        private void OnIsChangeDurationAsyncAvailableChanged(object sender, bool e) => _syncContext.Post(_ => OnPropertyChanged(nameof(IsChangeDurationAsyncAvailable)), null);
 
-        private void OnIsChangeNameAsyncAvailableChanged(object sender, bool e) => _ = Threading.OnPrimaryThread(() => OnPropertyChanged(nameof(IsChangeNameAsyncAvailable)));
+        private void OnIsChangeNameAsyncAvailableChanged(object sender, bool e) => _syncContext.Post(_ => OnPropertyChanged(nameof(IsChangeNameAsyncAvailable)), null);
 
-        private void OnIsPauseTrackCollectionAsyncAvailableChanged(object sender, bool e) => _ = Threading.OnPrimaryThread(() => OnPropertyChanged(nameof(IsPauseTrackCollectionAsyncAvailable)));
+        private void OnIsPauseTrackCollectionAsyncAvailableChanged(object sender, bool e) => _syncContext.Post(_ => OnPropertyChanged(nameof(IsPauseTrackCollectionAsyncAvailable)), null);
 
-        private void OnIsPlayTrackCollectionAsyncAvailableChanged(object sender, bool e) => _ = Threading.OnPrimaryThread(() => OnPropertyChanged(nameof(IsPlayTrackCollectionAsyncAvailable)));
+        private void OnIsPlayTrackCollectionAsyncAvailableChanged(object sender, bool e) => _syncContext.Post(_ => OnPropertyChanged(nameof(IsPlayTrackCollectionAsyncAvailable)), null);
 
-        private void OnIsPauseAlbumCollectionAsyncAvailableChanged(object sender, bool e) => _ = Threading.OnPrimaryThread(() => OnPropertyChanged(nameof(IsPauseAlbumCollectionAsyncAvailable)));
+        private void OnIsPauseAlbumCollectionAsyncAvailableChanged(object sender, bool e) => _syncContext.Post(_ => OnPropertyChanged(nameof(IsPauseAlbumCollectionAsyncAvailable)), null);
 
-        private void OnIsPlayAlbumCollectionAsyncAvailableChanged(object sender, bool e) => _ = Threading.OnPrimaryThread(() => OnPropertyChanged(nameof(IsPlayAlbumCollectionAsyncAvailable)));
+        private void OnIsPlayAlbumCollectionAsyncAvailableChanged(object sender, bool e) => _syncContext.Post(_ => OnPropertyChanged(nameof(IsPlayAlbumCollectionAsyncAvailable)), null);
 
-        private async void ArtistViewModel_ImagesChanged(object sender, IReadOnlyList<CollectionChangedItem<IImage>> addedItems, IReadOnlyList<CollectionChangedItem<IImage>> removedItems) => await Threading.OnPrimaryThread(() =>
+        private void ArtistViewModel_ImagesChanged(object sender, IReadOnlyList<CollectionChangedItem<IImage>> addedItems, IReadOnlyList<CollectionChangedItem<IImage>> removedItems) => _syncContext.Post(_ =>
         {
             Images.ChangeCollection(addedItems, removedItems);
-        });
+        }, null);
 
-        private async void ArtistViewModel_GenresChanged(object sender, IReadOnlyList<CollectionChangedItem<IGenre>> addedItems, IReadOnlyList<CollectionChangedItem<IGenre>> removedItems) => await Threading.OnPrimaryThread(() =>
+        private void ArtistViewModel_GenresChanged(object sender, IReadOnlyList<CollectionChangedItem<IGenre>> addedItems, IReadOnlyList<CollectionChangedItem<IGenre>> removedItems) => _syncContext.Post(_ =>
         {
             Genres.ChangeCollection(addedItems, removedItems);
-        });
+        }, null);
 
-        private async void ArtistViewModel_TrackItemsChanged(object sender, IReadOnlyList<CollectionChangedItem<ITrack>> addedItems, IReadOnlyList<CollectionChangedItem<ITrack>> removedItems) => await Threading.OnPrimaryThread(() =>
+        private void ArtistViewModel_TrackItemsChanged(object sender, IReadOnlyList<CollectionChangedItem<ITrack>> addedItems, IReadOnlyList<CollectionChangedItem<ITrack>> removedItems) => _syncContext.Post(_ =>
         {
             if (CurrentTracksSortingType == TrackSortingType.Unsorted)
             {
@@ -365,10 +365,9 @@ namespace StrixMusic.Sdk.ViewModels
             }
             else
             {
-                // Preventing index issues during tracks emission from the core, also making sure that unordered tracks updated. 
+                // Make sure both ordered and unordered tracks are updated. 
                 UnsortedTracks.ChangeCollection(addedItems, removedItems, x => new TrackViewModel(Root, x.Data));
 
-                // Avoiding direct assignment to prevent effect on UI.
                 foreach (var item in UnsortedTracks)
                 {
                     if (!Tracks.Contains(item))
@@ -383,47 +382,46 @@ namespace StrixMusic.Sdk.ViewModels
 
                 SortTrackCollection(CurrentTracksSortingType, CurrentTracksSortingDirection);
             }
-        });
+        }, null);
 
-        private async void ArtistViewModel_AlbumItemsChanged(object sender, IReadOnlyList<CollectionChangedItem<IAlbumCollectionItem>> addedItems, IReadOnlyList<CollectionChangedItem<IAlbumCollectionItem>> removedItems) => await Threading.OnPrimaryThread(() =>
-        {
-            if (CurrentAlbumSortingType == AlbumSortingType.Unsorted)
-            {
-                Albums.ChangeCollection(addedItems, removedItems, item => item.Data switch
-                {
-                    IAlbum album => new AlbumViewModel(Root, album),
-                    IAlbumCollection collection => new AlbumCollectionViewModel(Root, collection),
-                    _ => ThrowHelper.ThrowNotSupportedException<IAlbumCollectionItem>(
-                        $"{item.Data.GetType()} not supported for adding to {GetType()}")
-                });
-            }
-            else
-            {
-                // Preventing index issues during albums emission from the core, also making sure that unordered albums updated. 
-                UnsortedAlbums.ChangeCollection(addedItems, removedItems, item => item.Data switch
-                {
-                    IAlbum album => new AlbumViewModel(Root, album),
-                    IAlbumCollection collection => new AlbumCollectionViewModel(Root, collection),
-                    _ => ThrowHelper.ThrowNotSupportedException<IAlbumCollectionItem>(
-                        $"{item.Data.GetType()} not supported for adding to {GetType()}")
-                });
+        private void ArtistViewModel_AlbumItemsChanged(object sender, IReadOnlyList<CollectionChangedItem<IAlbumCollectionItem>> addedItems, IReadOnlyList<CollectionChangedItem<IAlbumCollectionItem>> removedItems) => _syncContext.Post(_ =>
+         {
+             if (CurrentAlbumSortingType == AlbumSortingType.Unsorted)
+             {
+                 Albums.ChangeCollection(addedItems, removedItems, item => item.Data switch
+                 {
+                     IAlbum album => new AlbumViewModel(Root, album),
+                     IAlbumCollection collection => new AlbumCollectionViewModel(Root, collection),
+                     _ => ThrowHelper.ThrowNotSupportedException<IAlbumCollectionItem>(
+                         $"{item.Data.GetType()} not supported for adding to {GetType()}")
+                 });
+             }
+             else
+             {
+                 // Make sure both ordered and unordered albums are updated. 
+                 UnsortedAlbums.ChangeCollection(addedItems, removedItems, item => item.Data switch
+                  {
+                      IAlbum album => new AlbumViewModel(Root, album),
+                      IAlbumCollection collection => new AlbumCollectionViewModel(Root, collection),
+                      _ => ThrowHelper.ThrowNotSupportedException<IAlbumCollectionItem>(
+                          $"{item.Data.GetType()} not supported for adding to {GetType()}")
+                  });
 
-                // Avoiding direct assignment to prevent effect on UI.
-                foreach (var item in UnsortedAlbums)
-                {
-                    if (!Albums.Contains(item))
-                        Albums.Add(item);
-                }
+                 foreach (var item in UnsortedAlbums)
+                 {
+                     if (!Albums.Contains(item))
+                         Albums.Add(item);
+                 }
 
-                foreach (var item in Albums)
-                {
-                    if (!UnsortedAlbums.Contains(item))
-                        Albums.Remove(item);
-                }
+                 foreach (var item in Albums)
+                 {
+                     if (!UnsortedAlbums.Contains(item))
+                         Albums.Remove(item);
+                 }
 
-                SortAlbumCollection(CurrentAlbumSortingType, CurrentAlbumSortingDirection);
-            }
-        });
+                 SortAlbumCollection(CurrentAlbumSortingType, CurrentAlbumSortingDirection);
+             }
+         }, null);
 
         /// <inheritdoc cref="IMerged{T}.SourceCores" />
         public IReadOnlyList<ICore> SourceCores { get; }
@@ -659,7 +657,7 @@ namespace StrixMusic.Sdk.ViewModels
             {
                 var items = await _artist.GetAlbumItemsAsync(limit, Albums.Count);
 
-                await Threading.OnPrimaryThread(() =>
+                _syncContext.Post(_ =>
                 {
                     foreach (var item in items)
                     {
@@ -668,7 +666,7 @@ namespace StrixMusic.Sdk.ViewModels
                             Albums.Add(new AlbumViewModel(Root, album));
                         }
                     }
-                });
+                }, null);
             }
         }
 
@@ -679,13 +677,11 @@ namespace StrixMusic.Sdk.ViewModels
             {
                 var items = await GetTracksAsync(limit, Tracks.Count);
 
-                await Threading.OnPrimaryThread(() =>
+                _syncContext.Post(_ =>
                 {
                     foreach (var item in items)
-                    {
                         Tracks.Add(new TrackViewModel(Root, item));
-                    }
-                });
+                }, null);
             }
         }
 
@@ -696,13 +692,13 @@ namespace StrixMusic.Sdk.ViewModels
             {
                 var items = await _artist.GetImagesAsync(limit, Images.Count);
 
-                await Threading.OnPrimaryThread(() =>
+                _syncContext.Post(_ =>
                 {
                     foreach (var item in items)
                     {
                         Images.Add(item);
                     }
-                });
+                }, null);
             }
         }
 
@@ -713,13 +709,13 @@ namespace StrixMusic.Sdk.ViewModels
             {
                 var items = await _artist.GetGenresAsync(limit, Genres.Count);
 
-                await Threading.OnPrimaryThread(() =>
+                _syncContext.Post(_ =>
                 {
                     foreach (var item in items)
                     {
                         Genres.Add(item);
                     }
-                });
+                }, null);
             }
         }
 
@@ -730,13 +726,13 @@ namespace StrixMusic.Sdk.ViewModels
             {
                 var items = await _artist.GetUrlsAsync(limit, Urls.Count);
 
-                await Threading.OnPrimaryThread(() =>
+                _syncContext.Post(_ =>
                 {
                     foreach (var item in items)
                     {
                         Urls.Add(item);
                     }
-                });
+                }, null);
             }
         }
 

--- a/src/Sdk/StrixMusic.Sdk/ViewModels/DeviceViewModel.cs
+++ b/src/Sdk/StrixMusic.Sdk/ViewModels/DeviceViewModel.cs
@@ -3,11 +3,11 @@
 // See the LICENSE, LICENSE.LESSER and LICENSE.ADDITIONAL files in the project root for more information.
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Toolkit.Diagnostics;
 using Microsoft.Toolkit.Mvvm.ComponentModel;
 using Microsoft.Toolkit.Mvvm.Input;
-using OwlCore;
 using StrixMusic.Sdk.MediaPlayback;
 using StrixMusic.Sdk.Models;
 using StrixMusic.Sdk.Models.Base;
@@ -16,10 +16,11 @@ using StrixMusic.Sdk.Models.Core;
 namespace StrixMusic.Sdk.ViewModels
 {
     /// <summary>
-    /// Contains information about a <see cref="IImage"/>
+    /// A ViewModel for <see cref="IDevice"/>.
     /// </summary>
     public sealed class DeviceViewModel : ObservableObject, ISdkViewModel, IDevice
     {
+        private readonly SynchronizationContext _syncContext;
         private PlaybackItem? _nowPlaying;
 
         /// <summary>
@@ -29,6 +30,8 @@ namespace StrixMusic.Sdk.ViewModels
         /// <param name="device">The <see cref="IDevice"/> to wrap around.</param>
         internal DeviceViewModel(MainViewModel root, IDevice device)
         {
+            _syncContext = SynchronizationContext.Current;
+
             Model = device ?? throw new ArgumentNullException(nameof(device));
             Root = root;
 
@@ -82,27 +85,27 @@ namespace StrixMusic.Sdk.ViewModels
             Model.VolumeChanged -= Device_VolumeChanged;
         }
 
-        private void Device_VolumeChanged(object sender, double e) => _ = Threading.OnPrimaryThread(() => OnPropertyChanged(nameof(Volume)));
+        private void Device_VolumeChanged(object sender, double e) => _syncContext.Post(_ => OnPropertyChanged(nameof(Volume)), null);
 
-        private void Device_ShuffleStateChanged(object sender, bool e) => _ = Threading.OnPrimaryThread(() => OnPropertyChanged(nameof(ShuffleState)));
+        private void Device_ShuffleStateChanged(object sender, bool e) => _syncContext.Post(_ => OnPropertyChanged(nameof(ShuffleState)), null);
 
-        private void Device_RepeatStateChanged(object sender, RepeatState e) => _ = Threading.OnPrimaryThread(() => OnPropertyChanged(nameof(RepeatState)));
+        private void Device_RepeatStateChanged(object sender, RepeatState e) => _syncContext.Post(_ => OnPropertyChanged(nameof(RepeatState)), null);
 
-        private void Device_PositionChanged(object sender, TimeSpan e) => _ = Threading.OnPrimaryThread(() => OnPropertyChanged(nameof(Position)));
+        private void Device_PositionChanged(object sender, TimeSpan e) => _syncContext.Post(_ => OnPropertyChanged(nameof(Position)), null);
 
-        private void Device_PlaybackSpeedChanged(object sender, double e) => _ = Threading.OnPrimaryThread(() => OnPropertyChanged(nameof(PlaybackSpeed)));
+        private void Device_PlaybackSpeedChanged(object sender, double e) => _syncContext.Post(_ => OnPropertyChanged(nameof(PlaybackSpeed)), null);
 
-        private void Device_PlaybackContextChanged(object sender, IPlayableBase e) => _ = Threading.OnPrimaryThread(() => OnPropertyChanged(nameof(PlaybackContext)));
+        private void Device_PlaybackContextChanged(object sender, IPlayableBase e) => _syncContext.Post(_ => OnPropertyChanged(nameof(PlaybackContext)), null);
 
-        private void Device_IsActiveChanged(object sender, bool e) => _ = Threading.OnPrimaryThread(() => OnPropertyChanged(nameof(IsActive)));
+        private void Device_IsActiveChanged(object sender, bool e) => _syncContext.Post(_ => OnPropertyChanged(nameof(IsActive)), null);
 
-        private void Device_StateChanged(object sender, PlaybackState e) => _ = Threading.OnPrimaryThread(() =>
+        private void Device_StateChanged(object sender, PlaybackState e) => _syncContext.Post(_ =>
         {
             OnPropertyChanged(nameof(PlaybackState));
             OnPropertyChanged(nameof(IsPlaying));
-        });
+        }, null);
 
-        private void Device_NowPlayingChanged(object sender, PlaybackItem e) => _ = Threading.OnPrimaryThread(() =>
+        private void Device_NowPlayingChanged(object sender, PlaybackItem e) => _syncContext.Post(_ =>
         {
             Guard.IsNotNull(e.Track, nameof(e.Track));
 
@@ -113,7 +116,7 @@ namespace StrixMusic.Sdk.ViewModels
             };
 
             NowPlayingChanged?.Invoke(sender, e);
-        });
+        }, null);
 
         /// <summary>
         /// The wrapped model for this <see cref="DeviceViewModel"/>.

--- a/src/Sdk/StrixMusic.Sdk/ViewModels/DiscoverablesViewModel.cs
+++ b/src/Sdk/StrixMusic.Sdk/ViewModels/DiscoverablesViewModel.cs
@@ -11,7 +11,7 @@ using StrixMusic.Sdk.Models.Merged;
 namespace StrixMusic.Sdk.ViewModels
 {
     /// <summary>
-    /// A bindable wrapper of the <see cref="IDiscoverables"/>.
+    /// A ViewModel for <see cref="IDiscoverables"/>.
     /// </summary>
     public class DiscoverablesViewModel : PlayableCollectionGroupViewModel, ISdkViewModel, IDiscoverables
     {

--- a/src/Sdk/StrixMusic.Sdk/ViewModels/IAlbumCollectionViewModel.cs
+++ b/src/Sdk/StrixMusic.Sdk/ViewModels/IAlbumCollectionViewModel.cs
@@ -12,7 +12,7 @@ using StrixMusic.Sdk.Models.Base;
 namespace StrixMusic.Sdk.ViewModels
 {
     /// <summary>
-    /// An interfaced ViewModel for <see cref="IAlbumCollection" />
+    /// An interfaced ViewModel for <see cref="IAlbumCollection" />.
     /// This is needed so because multiple view models implement <see cref="IAlbumCollection"/>,
     /// and the UI needs to create controls that handle only the ViewModels properties for an <see cref="IAlbumCollection"/>.
     /// </summary>

--- a/src/Sdk/StrixMusic.Sdk/ViewModels/LibraryViewModel.cs
+++ b/src/Sdk/StrixMusic.Sdk/ViewModels/LibraryViewModel.cs
@@ -13,7 +13,7 @@ using StrixMusic.Sdk.Models.Merged;
 namespace StrixMusic.Sdk.ViewModels
 {
     /// <summary>
-    /// A bindable wrapper of the <see cref="ILibraryBase"/>.
+    /// A ViewModel for <see cref="ILibrary"/>.
     /// </summary>
     public sealed class LibraryViewModel : PlayableCollectionGroupViewModel, ISdkViewModel, ILibrary
     {

--- a/src/Sdk/StrixMusic.Sdk/ViewModels/RecentlyPlayedViewModel.cs
+++ b/src/Sdk/StrixMusic.Sdk/ViewModels/RecentlyPlayedViewModel.cs
@@ -11,7 +11,7 @@ using StrixMusic.Sdk.Models.Merged;
 namespace StrixMusic.Sdk.ViewModels
 {
     /// <summary>
-    /// Used to bind to recently played items across multiple cores.
+    /// A ViewModel for <see cref="IRecentlyPlayed"/>.
     /// </summary>
     public sealed class RecentlyPlayedViewModel : PlayableCollectionGroupViewModel, ISdkViewModel, IRecentlyPlayed
     {

--- a/src/Sdk/StrixMusic.Sdk/ViewModels/SearchHistoryViewModel.cs
+++ b/src/Sdk/StrixMusic.Sdk/ViewModels/SearchHistoryViewModel.cs
@@ -11,7 +11,7 @@ using StrixMusic.Sdk.Models.Merged;
 namespace StrixMusic.Sdk.ViewModels
 {
     /// <summary>
-    /// Used to bind to search history across multiple cores.
+    /// A ViewModel for <see cref="ISearchHistory"/>.
     /// </summary>
     public sealed class SearchHistoryViewModel : PlayableCollectionGroupViewModel, ISdkViewModel, ISearchHistory
     {

--- a/src/Sdk/StrixMusic.Sdk/ViewModels/SearchResultsViewModel.cs
+++ b/src/Sdk/StrixMusic.Sdk/ViewModels/SearchResultsViewModel.cs
@@ -11,7 +11,7 @@ using StrixMusic.Sdk.Models.Merged;
 namespace StrixMusic.Sdk.ViewModels
 {
     /// <summary>
-    /// Used to bind to search results across multiple cores.
+    /// A ViewModel for <see cref="ISearchResults"/>.
     /// </summary>
     public sealed class SearchResultsViewModel : PlayableCollectionGroupViewModel, ISdkViewModel, ISearchResults
     {

--- a/src/Sdk/StrixMusic.Sdk/ViewModels/SearchViewModel.cs
+++ b/src/Sdk/StrixMusic.Sdk/ViewModels/SearchViewModel.cs
@@ -12,7 +12,7 @@ using StrixMusic.Sdk.Models.Core;
 namespace StrixMusic.Sdk.ViewModels
 {
     /// <summary>
-    /// A view model wrapper for <see cref="ISearch"/>.
+    /// A ViewModel for <see cref="ISearch"/>.
     /// </summary>
     public sealed class SearchViewModel : ObservableObject, ISdkViewModel, ISearch
     {

--- a/src/Sdk/StrixMusic.Sdk/ViewModels/TrackViewModel.cs
+++ b/src/Sdk/StrixMusic.Sdk/ViewModels/TrackViewModel.cs
@@ -25,22 +25,25 @@ using StrixMusic.Sdk.ViewModels.Helpers;
 namespace StrixMusic.Sdk.ViewModels
 {
     /// <summary>
-    /// Contains bindable information about an <see cref="ITrack"/>
+    /// A ViewModel for <see cref="ITrack"/>.
     /// </summary>
     public sealed class TrackViewModel : ObservableObject, ISdkViewModel, ITrack, IArtistCollectionViewModel, IImageCollectionViewModel, IGenreCollectionViewModel
     {
-        private readonly SemaphoreSlim _populateArtistsMutex = new SemaphoreSlim(1, 1);
-        private readonly SemaphoreSlim _populateImagesMutex = new SemaphoreSlim(1, 1);
-        private readonly SemaphoreSlim _populateGenresMutex = new SemaphoreSlim(1, 1);
-        private readonly SemaphoreSlim _populateUrlsMutex = new SemaphoreSlim(1, 1);
+        private readonly SemaphoreSlim _populateArtistsMutex = new(1, 1);
+        private readonly SemaphoreSlim _populateImagesMutex = new(1, 1);
+        private readonly SemaphoreSlim _populateGenresMutex = new(1, 1);
+        private readonly SemaphoreSlim _populateUrlsMutex = new(1, 1);
+        private readonly SynchronizationContext _syncContext;
 
         /// <summary>
-        /// Creates a bindable wrapper around an <see cref="ITrack"/>.
+        /// Creates a new instance of <see cref="TrackViewModel"/>.
         /// </summary>
         /// <param name="root">The <see cref="MainViewModel"/> that this or the object that created this originated from.</param>
         /// <param name="track">The <see cref="ITrack"/> to wrap.</param>
         internal TrackViewModel(MainViewModel root, ITrack track)
         {
+            _syncContext = SynchronizationContext.Current;
+
             Root = root;
             Model = root.Plugins.ModelPlugins.Track.Execute(track);
 
@@ -52,14 +55,11 @@ namespace StrixMusic.Sdk.ViewModels
             if (Model.RelatedItems != null)
                 RelatedItems = new PlayableCollectionGroupViewModel(root, Model.RelatedItems);
 
-            using (Threading.PrimaryContext)
-            {
-                Artists = new ObservableCollection<IArtistCollectionItem>();
-                UnsortedArtists = new ObservableCollection<IArtistCollectionItem>();
-                Images = new ObservableCollection<IImage>();
-                Urls = new ObservableCollection<IUrl>();
-                Genres = new ObservableCollection<IGenre>();
-            }
+            Artists = new ObservableCollection<IArtistCollectionItem>();
+            UnsortedArtists = new ObservableCollection<IArtistCollectionItem>();
+            Images = new ObservableCollection<IImage>();
+            Urls = new ObservableCollection<IUrl>();
+            Genres = new ObservableCollection<IGenre>();
 
             PlayArtistCollectionAsyncCommand = new AsyncRelayCommand(PlayArtistCollectionAsync);
             PauseArtistCollectionAsyncCommand = new AsyncRelayCommand(PauseArtistCollectionAsync);
@@ -313,64 +313,64 @@ namespace StrixMusic.Sdk.ViewModels
             remove => Model.UrlsChanged -= value;
         }
 
-        private void Track_TrackNumberChanged(object sender, int? e) => _ = Threading.OnPrimaryThread(() => OnPropertyChanged(nameof(TrackNumber)));
+        private void Track_TrackNumberChanged(object sender, int? e) => _syncContext.Post(_ => OnPropertyChanged(nameof(TrackNumber)), null);
 
-        private void Track_PlaybackStateChanged(object sender, PlaybackState e) => _ = Threading.OnPrimaryThread(() => OnPropertyChanged(nameof(PlaybackState)));
+        private void Track_PlaybackStateChanged(object sender, PlaybackState e) => _syncContext.Post(_ => OnPropertyChanged(nameof(PlaybackState)), null);
 
-        private void OnDownloadInfoChanged(object sender, DownloadInfo e) => _ = Threading.OnPrimaryThread(() => OnPropertyChanged(nameof(DownloadInfo)));
+        private void OnDownloadInfoChanged(object sender, DownloadInfo e) => _syncContext.Post(_ => OnPropertyChanged(nameof(DownloadInfo)), null);
 
-        private void Track_NameChanged(object sender, string e) => _ = Threading.OnPrimaryThread(() => OnPropertyChanged(nameof(Name)));
+        private void Track_NameChanged(object sender, string e) => _syncContext.Post(_ => OnPropertyChanged(nameof(Name)), null);
 
-        private void Track_LyricsChanged(object sender, ILyrics? e) => _ = Threading.OnPrimaryThread(() => OnPropertyChanged(nameof(Lyrics)));
+        private void Track_LyricsChanged(object sender, ILyrics? e) => _syncContext.Post(_ => OnPropertyChanged(nameof(Lyrics)), null);
 
-        private void Track_LanguageChanged(object sender, CultureInfo? e) => _ = Threading.OnPrimaryThread(() => OnPropertyChanged(nameof(Language)));
+        private void Track_LanguageChanged(object sender, CultureInfo? e) => _syncContext.Post(_ => OnPropertyChanged(nameof(Language)), null);
 
-        private void Track_IsExplicitChanged(object sender, bool e) => _ = Threading.OnPrimaryThread(() => OnPropertyChanged(nameof(IsExplicit)));
+        private void Track_IsExplicitChanged(object sender, bool e) => _syncContext.Post(_ => OnPropertyChanged(nameof(IsExplicit)), null);
 
-        private void Track_DescriptionChanged(object sender, string? e) => _ = Threading.OnPrimaryThread(() => OnPropertyChanged(nameof(Description)));
+        private void Track_DescriptionChanged(object sender, string? e) => _syncContext.Post(_ => OnPropertyChanged(nameof(Description)), null);
 
-        private void OnLastPlayedChanged(object sender, DateTime? e) => _ = Threading.OnPrimaryThread(() => OnPropertyChanged(nameof(LastPlayed)));
+        private void OnLastPlayedChanged(object sender, DateTime? e) => _syncContext.Post(_ => OnPropertyChanged(nameof(LastPlayed)), null);
 
-        private void OnIsChangeDescriptionAsyncAvailableChanged(object sender, bool e) => _ = Threading.OnPrimaryThread(() => OnPropertyChanged(nameof(IsChangeDescriptionAsyncAvailable)));
+        private void OnIsChangeDescriptionAsyncAvailableChanged(object sender, bool e) => _syncContext.Post(_ => OnPropertyChanged(nameof(IsChangeDescriptionAsyncAvailable)), null);
 
-        private void OnIsChangeDurationAsyncAvailableChanged(object sender, bool e) => _ = Threading.OnPrimaryThread(() => OnPropertyChanged(nameof(IsChangeDurationAsyncAvailable)));
+        private void OnIsChangeDurationAsyncAvailableChanged(object sender, bool e) => _syncContext.Post(_ => OnPropertyChanged(nameof(IsChangeDurationAsyncAvailable)), null);
 
-        private void OnIsChangeNameAsyncAvailableChanged(object sender, bool e) => _ = Threading.OnPrimaryThread(() => OnPropertyChanged(nameof(IsChangeNameAsyncAvailable)));
+        private void OnIsChangeNameAsyncAvailableChanged(object sender, bool e) => _syncContext.Post(_ => OnPropertyChanged(nameof(IsChangeNameAsyncAvailable)), null);
 
-        private void OnIsPauseArtistCollectionAsyncAvailableChanged(object sender, bool e) => _ = Threading.OnPrimaryThread(() => OnPropertyChanged(nameof(IsPauseArtistCollectionAsyncAvailable)));
+        private void OnIsPauseArtistCollectionAsyncAvailableChanged(object sender, bool e) => _syncContext.Post(_ => OnPropertyChanged(nameof(IsPauseArtistCollectionAsyncAvailable)), null);
 
-        private void OnIsPlayArtistCollectionAsyncAvailableChanged(object sender, bool e) => _ = Threading.OnPrimaryThread(() => OnPropertyChanged(nameof(IsPlayArtistCollectionAsyncAvailable)));
+        private void OnIsPlayArtistCollectionAsyncAvailableChanged(object sender, bool e) => _syncContext.Post(_ => OnPropertyChanged(nameof(IsPlayArtistCollectionAsyncAvailable)), null);
 
         private void Track_AlbumChanged(object sender, IAlbum? e)
         {
             Album = e is null ? null : new AlbumViewModel(Root, e);
-            _ = Threading.OnPrimaryThread(() => OnPropertyChanged(nameof(Album)));
+            _syncContext.Post(_ => OnPropertyChanged(nameof(Album)), null);
         }
 
-        private void OnArtistItemsCountChanged(object sender, int e) => _ = Threading.OnPrimaryThread(() => OnPropertyChanged(nameof(TotalArtistItemsCount)));
+        private void OnArtistItemsCountChanged(object sender, int e) => _syncContext.Post(_ => OnPropertyChanged(nameof(TotalArtistItemsCount)), null);
 
-        private void OnImagesCountChanged(object sender, int e) => _ = Threading.OnPrimaryThread(() => OnPropertyChanged(nameof(TotalImageCount)));
+        private void OnImagesCountChanged(object sender, int e) => _syncContext.Post(_ => OnPropertyChanged(nameof(TotalImageCount)), null);
 
-        private void OnGenresCountChanged(object sender, int e) => _ = Threading.OnPrimaryThread(() => OnPropertyChanged(nameof(TotalGenreCount)));
+        private void OnGenresCountChanged(object sender, int e) => _syncContext.Post(_ => OnPropertyChanged(nameof(TotalGenreCount)), null);
 
-        private void OnUrlsCountChanged(object sender, int e) => _ = Threading.OnPrimaryThread(() => OnPropertyChanged(nameof(TotalUrlCount)));
+        private void OnUrlsCountChanged(object sender, int e) => _syncContext.Post(_ => OnPropertyChanged(nameof(TotalUrlCount)), null);
 
-        private void TrackViewModel_ImagesChanged(object sender, IReadOnlyList<CollectionChangedItem<IImage>> addedItems, IReadOnlyList<CollectionChangedItem<IImage>> removedItems) => _ = Threading.OnPrimaryThread(() =>
+        private void TrackViewModel_ImagesChanged(object sender, IReadOnlyList<CollectionChangedItem<IImage>> addedItems, IReadOnlyList<CollectionChangedItem<IImage>> removedItems) => _syncContext.Post(_ =>
         {
             Images.ChangeCollection(addedItems, removedItems);
-        });
+        }, null);
 
-        private void TrackViewModel_GenresChanged(object sender, IReadOnlyList<CollectionChangedItem<IGenre>> addedItems, IReadOnlyList<CollectionChangedItem<IGenre>> removedItems) => _ = Threading.OnPrimaryThread(() =>
+        private void TrackViewModel_GenresChanged(object sender, IReadOnlyList<CollectionChangedItem<IGenre>> addedItems, IReadOnlyList<CollectionChangedItem<IGenre>> removedItems) => _syncContext.Post(_ =>
         {
             Genres.ChangeCollection(addedItems, removedItems);
-        });
+        }, null);
 
-        private void TrackViewModel_UrlsChanged(object sender, IReadOnlyList<CollectionChangedItem<IUrl>> addedItems, IReadOnlyList<CollectionChangedItem<IUrl>> removedItems) => _ = Threading.OnPrimaryThread(() =>
+        private void TrackViewModel_UrlsChanged(object sender, IReadOnlyList<CollectionChangedItem<IUrl>> addedItems, IReadOnlyList<CollectionChangedItem<IUrl>> removedItems) => _syncContext.Post(_ =>
         {
             Urls.ChangeCollection(addedItems, removedItems);
-        });
+        }, null);
 
-        private void TrackViewModel_ArtistItemsChanged(object sender, IReadOnlyList<CollectionChangedItem<IArtistCollectionItem>> addedItems, IReadOnlyList<CollectionChangedItem<IArtistCollectionItem>> removedItems) => _ = Threading.OnPrimaryThread(() =>
+        private void TrackViewModel_ArtistItemsChanged(object sender, IReadOnlyList<CollectionChangedItem<IArtistCollectionItem>> addedItems, IReadOnlyList<CollectionChangedItem<IArtistCollectionItem>> removedItems) => _syncContext.Post(_ =>
         {
             if (CurrentArtistSortingType == ArtistSortingType.Unsorted)
             {
@@ -408,13 +408,13 @@ namespace StrixMusic.Sdk.ViewModels
 
                 SortArtistCollection(CurrentArtistSortingType, CurrentArtistSortingDirection);
             }
-        });
+        }, null);
 
-        private void OnPlaybackStateChanged(object sender, PlaybackState e) => _ = Threading.OnPrimaryThread(() =>
+        private void OnPlaybackStateChanged(object sender, PlaybackState e) => _syncContext.Post(_ =>
         {
             PlaybackStateChanged?.Invoke(this, PlaybackState);
             OnPropertyChanged(nameof(PlaybackState));
-        });
+        }, null);
 
         ///<inheritdoc />
         public void SortArtistCollection(ArtistSortingType artistSorting, SortDirection sortDirection)
@@ -678,21 +678,17 @@ namespace StrixMusic.Sdk.ViewModels
             {
                 var items = await GetArtistItemsAsync(limit, Artists.Count);
 
-                await Threading.OnPrimaryThread(() =>
+                _syncContext.Post(_ =>
                 {
                     foreach (var item in items)
                     {
                         if (item is IArtist artist)
-                        {
                             Artists.Add(new ArtistViewModel(Root, artist));
-                        }
 
                         if (item is IArtistCollection collection)
-                        {
                             Artists.Add(new ArtistCollectionViewModel(Root, collection));
-                        }
                     }
-                });
+                }, null);
             }
         }
 
@@ -703,13 +699,11 @@ namespace StrixMusic.Sdk.ViewModels
             {
                 var items = await GetImagesAsync(limit, Images.Count);
 
-                await Threading.OnPrimaryThread(() =>
+                _syncContext.Post(_ =>
                 {
                     foreach (var item in items)
-                    {
                         Images.Add(item);
-                    }
-                });
+                }, null);
             }
         }
 
@@ -720,13 +714,11 @@ namespace StrixMusic.Sdk.ViewModels
             {
                 var items = await GetGenresAsync(limit, Genres.Count);
 
-                await Threading.OnPrimaryThread(() =>
+                _syncContext.Post(_ =>
                 {
                     foreach (var item in items)
-                    {
                         Genres.Add(item);
-                    }
-                });
+                }, null);
             }
         }
 
@@ -737,13 +729,11 @@ namespace StrixMusic.Sdk.ViewModels
             {
                 var items = await GetUrlsAsync(limit, Urls.Count);
 
-                await Threading.OnPrimaryThread(() =>
+                _syncContext.Post(_ =>
                 {
                     foreach (var item in items)
-                    {
                         Urls.Add(item);
-                    }
-                });
+                }, null);
             }
         }
 
@@ -839,15 +829,16 @@ namespace StrixMusic.Sdk.ViewModels
         }
 
         /// <inheritdoc />
-        public Task InitAsync()
+        public async Task InitAsync()
         {
             if (!IsInitialized)
-                return Task.CompletedTask;
+                return;
 
-            return Task.WhenAll(InitImageCollectionAsync(), InitArtistCollectionAsync(), InitGenreCollectionAsync());
+            await Task.WhenAll(InitImageCollectionAsync(), InitArtistCollectionAsync(), InitGenreCollectionAsync());
+            IsInitialized = true;
         }
 
         /// <inheritdoc />
-        public bool IsInitialized { get; }
+        public bool IsInitialized { get; private set; }
     }
 }

--- a/src/Sdk/StrixMusic.Sdk/ViewModels/UserViewModel.cs
+++ b/src/Sdk/StrixMusic.Sdk/ViewModels/UserViewModel.cs
@@ -14,8 +14,9 @@ namespace StrixMusic.Sdk.ViewModels
     public class UserViewModel : UserProfileViewModel, ISdkViewModel
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="UserViewModel"/> class.
+        /// A ViewModel for <see cref="IUser"/>.
         /// </summary>
+        /// <param name="root">The <see cref="MainViewModel"/> that this or the object that created this originated from.</param>
         /// <param name="user">The <see cref="IUser"/> to wrap.</param>
         public UserViewModel(MainViewModel root, IUser user)
             : base(root, user)


### PR DESCRIPTION
Closes [AB#885](https://dev.azure.com/arloappx/b1ab483e-8d7e-401e-9124-d115cf066c94/_workitems/edit/885)

When we originally implemented the ViewModels, we found that adding items to an ObservableCollection could not be done by calling `SynchronizationContext.SetSynchronizationContext()`. To fix this, we created the Threading extensions in OwlCore that allows us to invoke on the UI thread.

We discovered that this could instead by done via `SynchronizationContext.Post()`, meaning we no longer need to depend on the Threading extension in OwlCore.

This PR remove any usage of OwlCore.Threading in favor of SynchronizationContext in all ViewModels.