### PR TITLE
[fix] Skip empty or whitespace lines in M3U playlists

### DIFF
--- a/src/Sdk/StrixMusic.Sdk/FileMetadata/Scanners/PlaylistMetadataScanner.Parsers.cs
+++ b/src/Sdk/StrixMusic.Sdk/FileMetadata/Scanners/PlaylistMetadataScanner.Parsers.cs
@@ -150,6 +150,10 @@ namespace StrixMusic.Sdk.FileMetadata.Scanners
             {
                 var line = await content.ReadLineAsync();
 
+                // Ignore empty lines
+                if (string.IsNullOrWhiteSpace(line))
+                    continue;
+
                 // Handle M3U directives
                 if (line[0] == '#')
                 {


### PR DESCRIPTION
<!--
To categorize this PR in the generated changelog, include one of the following in the PR title: 
[breaking], [fix], [improvement], [new], [refactor], [cleanup]
-->

## Overview
<!-- Replace with the issue number. This will auto-close the issue once the PR is merged. If no issue exists, open one first. -->
Closes #137

<!-- Add a brief overview here of the change. -->
This PR adds and extra control flow in the M3U parser that ignores empty lines (which previously would have caused parsing to fail entirely, see linked issue). Note that it checks for null or whitespace, rather than simply checking line length. This is because empty lines will skip the `line[0] == '#'` branch and attempt to create a `Uri`, which will always fail if the line is empty. Since we have to check for line length anyway, we might as well skip all whitespace lines.

<!-- Include screenshots or a short video demonstrating the change, if possible -->

## Checklist
<!-- Note: Changes to the Sdk MUST be accompanied by unit tests, even if there were none before. -->
This PR meets the following requirements:
- [x] Tested and contains **NO** breaking changes or known regressions.
- [x] Tested with the upstream branch merged in.
- [ ] Tests have been added for bug fixes / features (or this option is not applicable)
- [x] All new code has been documented (or this option is not applicable)
- [x] Headers have been added to all new source files (or this option is not applicable)

<!-- 
Is this a breaking change?
Please describe the impact and migration path for existing applications below.
-->

## Additional info
<!--
Please add any other information that might be helpful to reviewers.
-->

Not provided
