### PR TITLE
[fix] Fixed crash caused by cores not always using current SDK version

### DIFF
--- a/src/Cores/Files/StrixMusic.Cores.LocalFiles/LocalFilesCore.cs
+++ b/src/Cores/Files/StrixMusic.Cores.LocalFiles/LocalFilesCore.cs
@@ -94,7 +94,7 @@ namespace StrixMusic.Cores.LocalFiles
         public static CoreMetadata Metadata { get; } = new CoreMetadata(id: nameof(LocalFilesCore),
                                                                         displayName: "Local Files",
                                                                         logoUri: new Uri("ms-appx:///Assets/Cores/LocalFiles/Logo.svg"),
-                                                                        sdkVer: Version.Parse("0.0.0.0"));
+                                                                        sdkVer: typeof(ICore).Assembly.GetName().Version);
 
         /// <summary>
         /// The settings for this core instance.

--- a/src/Cores/Files/StrixMusic.Cores.OneDrive/OneDriveCore.cs
+++ b/src/Cores/Files/StrixMusic.Cores.OneDrive/OneDriveCore.cs
@@ -81,7 +81,7 @@ namespace StrixMusic.Cores.OneDrive
         public static CoreMetadata Metadata { get; } = new CoreMetadata(id: nameof(OneDriveCore),
                                                                         displayName: "OneDrive",
                                                                         logoUri: new Uri("ms-appx:///Assets/Cores/OneDrive/Logo.svg"),
-                                                                        sdkVer: Version.Parse("0.0.0.0"));
+                                                                        sdkVer: typeof(ICore).Assembly.GetName().Version);
         /// <inheritdoc/>
         public override string InstanceDescriptor { get; set; } = string.Empty;
 

--- a/src/Cores/Remote/StrixMusic.Cores.OwlCoreRpc.Tests/Mock/MockCore.cs
+++ b/src/Cores/Remote/StrixMusic.Cores.OwlCoreRpc.Tests/Mock/MockCore.cs
@@ -57,7 +57,10 @@ namespace StrixMusic.Cores.OwlCoreRpc.Tests.Mock
 
         public event EventHandler<string>? InstanceDescriptorChanged;
 
-        public CoreMetadata Registration { get; } = new CoreMetadata(nameof(MockCore), "Mock core", new Uri("https://strixmusic.com/"), Version.Parse("0.0.0.0"));
+        public CoreMetadata Registration { get; } = new CoreMetadata(id: nameof(MockCore),
+                                                                     displayName: "Mock core",
+                                                                     logoUri: new Uri("https://strixmusic.com/"),
+                                                                     sdkVer: typeof(ICore).Assembly.GetName().Version!);
 
         public string InstanceId { get; set; }
 

--- a/src/Cores/Remote/StrixMusic.Cores.OwlCoreRpc.Tests/Mock/MockCore.cs
+++ b/src/Cores/Remote/StrixMusic.Cores.OwlCoreRpc.Tests/Mock/MockCore.cs
@@ -60,7 +60,7 @@ namespace StrixMusic.Cores.OwlCoreRpc.Tests.Mock
         public CoreMetadata Registration { get; } = new CoreMetadata(id: nameof(MockCore),
                                                                      displayName: "Mock core",
                                                                      logoUri: new Uri("https://strixmusic.com/"),
-                                                                     sdkVer: typeof(ICore).Assembly.GetName().Version!);
+                                                                     sdkVer: typeof(ICore).Assembly.GetName().Version  ?? throw new ArgumentNullException());
 
         public string InstanceId { get; set; }
 

--- a/src/Cores/Remote/StrixMusic.Cores.OwlCoreRpc.Tests/Mock/MockCore.cs
+++ b/src/Cores/Remote/StrixMusic.Cores.OwlCoreRpc.Tests/Mock/MockCore.cs
@@ -60,7 +60,7 @@ namespace StrixMusic.Cores.OwlCoreRpc.Tests.Mock
         public CoreMetadata Registration { get; } = new CoreMetadata(id: nameof(MockCore),
                                                                      displayName: "Mock core",
                                                                      logoUri: new Uri("https://strixmusic.com/"),
-                                                                     sdkVer: typeof(ICore).Assembly.GetName().Version  ?? throw new ArgumentNullException());
+                                                                     sdkVer: typeof(ICore).Assembly.GetName().Version ?? throw new ArgumentNullException());
 
         public string InstanceId { get; set; }
 

--- a/src/Sdk/StrixMusic.Sdk.Tests/Mock/Core/MockCore.cs
+++ b/src/Sdk/StrixMusic.Sdk.Tests/Mock/Core/MockCore.cs
@@ -60,7 +60,7 @@ namespace StrixMusic.Sdk.Tests.Mock.Core
         public CoreMetadata Registration { get; } = new CoreMetadata(id: nameof(MockCore),
                                                                      displayName: "Mock core",
                                                                      logoUri: new Uri("https://strixmusic.com/"),
-                                                                     sdkVer: typeof(ICore).Assembly.GetName().Version!);
+                                                                     sdkVer: typeof(ICore).Assembly.GetName().Version ?? throw new ArgumentNullException());
 
         public string InstanceId { get; set; }
 

--- a/src/Sdk/StrixMusic.Sdk.Tests/Mock/Core/MockCore.cs
+++ b/src/Sdk/StrixMusic.Sdk.Tests/Mock/Core/MockCore.cs
@@ -57,7 +57,10 @@ namespace StrixMusic.Sdk.Tests.Mock.Core
 
         public event EventHandler<string>? InstanceDescriptorChanged;
 
-        public CoreMetadata Registration { get; } = new CoreMetadata(nameof(MockCore), "Mock core", new Uri("https://strixmusic.com/"), Version.Parse("0.0.0.0"));
+        public CoreMetadata Registration { get; } = new CoreMetadata(id: nameof(MockCore),
+                                                                     displayName: "Mock core",
+                                                                     logoUri: new Uri("https://strixmusic.com/"),
+                                                                     sdkVer: typeof(ICore).Assembly.GetName().Version!);
 
         public string InstanceId { get; set; }
 


### PR DESCRIPTION
<!--
To categorize this PR in the generated changelog, include one of the following in the PR title: 
[breaking], [fix], [improvement], [new], [refactor], [cleanup]
-->

## Overview
<!-- Replace with the issue number. This will auto-close the issue once the PR is merged. If no issue exists, open one first. -->
Closes #140

<!-- Add a brief overview here of the change. -->
This PR fixes a regression in cores' use of `CoreMetadata.SdkVer`. Previously, they were hard-coded to `0.0.0.0`, which would cause an `IncompatibleSdkVersionException` to be thrown by the app, halting library initialization.

<!-- Include screenshots or a short video demonstrating the change, if possible -->

## Checklist
<!-- Note: Changes to the Sdk MUST be accompanied by unit tests, even if there were none before. -->
This PR meets the following requirements:
- [x] Tested and contains **NO** breaking changes or known regressions.
- [x] Tested with the upstream branch merged in.
- [ ] Tests have been added for bug fixes / features (or this option is not applicable)
- [x] All new code has been documented (or this option is not applicable)
- [x] Headers have been added to all new source files (or this option is not applicable)

<!-- 
Is this a breaking change?
Please describe the impact and migration path for existing applications below.
-->

## Additional info
<!--
Please add any other information that might be helpful to reviewers.
-->

Not provided
