### PR TITLE
[fix] AudioMetadataScanner now ignores files that throw UnauthorizedAccessException when scanning id3 data

### DIFF
--- a/src/Sdk/StrixMusic.Sdk/FileMetadata/Scanners/AudioMetadataScanner.cs
+++ b/src/Sdk/StrixMusic.Sdk/FileMetadata/Scanners/AudioMetadataScanner.cs
@@ -523,6 +523,11 @@ namespace StrixMusic.Sdk.FileMetadata.Scanners
                 Logger.LogError($"{nameof(ArgumentException)} for {nameof(IFileData)} at {fileData.Path}", ex);
                 return null;
             }
+            catch (UnauthorizedAccessException ex)
+            {
+                Logger.LogError($"{nameof(UnauthorizedAccessException)} for {nameof(IFileData)} at {fileData.Path}", ex);
+                return null;
+            }
         }
 
         private async Task<Models.FileMetadata?> ProcessFile(IFileData file)


### PR DESCRIPTION
<!--
To categorize this PR in the generated changelog, include one of the following in the PR title: 
[breaking], [fix], [improvement], [new], [refactor], [cleanup]
-->

## Overview
<!-- Replace with the issue number. This will auto-close the issue once the PR is merged. If no issue exists, open one first. -->
Progress towards #145 

<!-- Add a brief overview here of the change. -->
AudioMetadataScanner now ignores files that throw `UnauthorizedAccessException` when scanning id3 data

<!-- Include screenshots or a short video demonstrating the change, if possible -->

## Checklist
<!-- Note: Changes to the Sdk MUST be accompanied by unit tests, even if there were none before. -->
This PR meets the following requirements:
- [x] Tested and contains **NO** breaking changes or known regressions.
- [x] Tested with the upstream branch merged in.
- [x] Tests have been added for bug fixes / features (or this option is not applicable)
- [x] All new code has been documented (or this option is not applicable)
- [x] Headers have been added to all new source files (or this option is not applicable)

<!-- 
Is this a breaking change?
Please describe the impact and migration path for existing applications below.
-->

## Additional info
<!--
Please add any other information that might be helpful to reviewers.
-->

Not provided
