### PR TITLE
[improvement] Added ScannerWaitBehavior to all file-based cores

### DIFF
--- a/src/Cores/Files/StrixMusic.Cores.Files/FilesCore.cs
+++ b/src/Cores/Files/StrixMusic.Cores.Files/FilesCore.cs
@@ -54,6 +54,11 @@ namespace StrixMusic.Cores.Files
         /// </summary>
         public IFileMetadataManager? FileMetadataManager { get; set; }
 
+        /// <summary>
+        /// The wait behavior of the metadata scanner when InitAsync is called in a file-based <see cref="ICore"/>.
+        /// </summary>
+        public ScannerWaitBehavior ScannerWaitBehavior { get; set; }
+
         /// <inheritdoc/>
         public virtual CoreState CoreState { get; protected set; }
 

--- a/src/Cores/Files/StrixMusic.Cores.Files/ScannerWaitBehavior.cs
+++ b/src/Cores/Files/StrixMusic.Cores.Files/ScannerWaitBehavior.cs
@@ -1,0 +1,26 @@
+﻿using OwlCore.Provisos;
+using StrixMusic.Sdk.CoreModels;
+
+namespace StrixMusic.Cores.Files
+{
+    /// <summary>
+    /// The wait behavior of the metadata scanner when <see cref="IAsyncInit.InitAsync"/> is called on a file-based <see cref="ICore"/>.
+    /// </summary>
+    public enum ScannerWaitBehavior
+    {
+        /// <summary>
+        /// <see cref="IAsyncInit.InitAsync"> will only wait for the scanner to complete if it there's no cached scan data.
+        /// </summary>
+        WaitIfNoData,
+
+        /// <summary>
+        /// <see cref="IAsyncInit.InitAsync"> will always wait for the scanner to complete.
+        /// </summary>
+        AlwaysWait,
+
+        /// <summary>
+        /// <see cref="IAsyncInit.InitAsync"> will never wait for the scanner to complete.
+        /// </summary>
+        NeverWait,
+    }
+}

--- a/src/Cores/Files/StrixMusic.Cores.OneDrive/OneDriveCore.cs
+++ b/src/Cores/Files/StrixMusic.Cores.OneDrive/OneDriveCore.cs
@@ -260,7 +260,20 @@ namespace StrixMusic.Cores.OneDrive
             FileMetadataManager.DegreesOfParallelism = 8;
 
             await FileMetadataManager.InitAsync(cancellationToken);
-            _ = FileMetadataManager.ScanAsync(cancellationToken);
+
+            var scannerTask = FileMetadataManager.ScanAsync(cancellationToken);
+
+            if (ScannerWaitBehavior == ScannerWaitBehavior.AlwaysWait)
+                await scannerTask;
+
+            if (ScannerWaitBehavior == ScannerWaitBehavior.WaitIfNoData)
+            {
+                var itemCounts = await Task.WhenAll(FileMetadataManager.Tracks.GetItemCount(), FileMetadataManager.Albums.GetItemCount(), FileMetadataManager.Artists.GetItemCount(), FileMetadataManager.Playlists.GetItemCount());
+
+                if (itemCounts.Sum() == 0)
+                    await scannerTask;
+            }
+
             ChangeCoreState(CoreState.Loaded);
 
             Logger.LogInformation("Post config task: setting up generic config UI.");

--- a/src/Shared/AppLoadingView.xaml.cs
+++ b/src/Shared/AppLoadingView.xaml.cs
@@ -334,7 +334,10 @@ namespace StrixMusic.Shared
                 var coreFolder = await ApplicationData.Current.LocalFolder.CreateFolderAsync("Cores", Windows.Storage.CreationCollisionOption.OpenIfExists);
                 var coreInstanceFolder = await coreFolder.CreateFolderAsync(instanceId, Windows.Storage.CreationCollisionOption.OpenIfExists);
 
-                return new LocalFilesCore(instanceId, new FileSystemService(coreInstanceFolder), new FolderData(coreInstanceFolder), notificationService);
+                return new LocalFilesCore(instanceId, new FileSystemService(coreInstanceFolder), new FolderData(coreInstanceFolder), notificationService)
+                {
+                    ScannerWaitBehavior = StrixMusic.Cores.Files.ScannerWaitBehavior.NeverWait,
+                };
             });
 
             CoreRegistry.Register(OneDriveCore.Metadata, async instanceId =>
@@ -368,6 +371,7 @@ namespace StrixMusic.Shared
                 {
                     LoginMethod = loginMethod,
                     HttpMessageHandler = messageHandler,
+                    ScannerWaitBehavior = StrixMusic.Cores.Files.ScannerWaitBehavior.NeverWait,
                 };
 
                 // TODO: Detach event when unregistered


### PR DESCRIPTION
<!--
To categorize this PR in the generated changelog, include one of the following in the PR title: 
[breaking], [fix], [improvement], [new], [refactor], [cleanup]
-->

## Overview
<!-- Replace with the issue number. This will auto-close the issue once the PR is merged. If no issue exists, open one first. -->
Closes #151 

<!-- Add a brief overview here of the change. -->
Added ScannerWaitBehavior to all file-based cores that use `StrixMusic.Cores.Files` base classes.
<!-- Include screenshots or a short video demonstrating the change, if possible -->

## Checklist
<!-- Note: Changes to the Sdk MUST be accompanied by unit tests, even if there were none before. -->
This PR meets the following requirements:
- [x] Tested and contains **NO** breaking changes or known regressions.
- [x] Tested with the upstream branch merged in.
- [x] Tests have been added for bug fixes / features (or this option is not applicable)
- [x] All new code has been documented (or this option is not applicable)
- [x] Headers have been added to all new source files (or this option is not applicable)

<!-- 
Is this a breaking change?
Please describe the impact and migration path for existing applications below.
-->

## Additional info
<!--
Please add any other information that might be helpful to reviewers.
-->

Not provided
