### PR TITLE
[breaking] Removed unnecessary dependencies from metadata scanner constructors

### DIFF
--- a/src/Cores/Files/StrixMusic.Cores.OneDrive/OneDriveCore.cs
+++ b/src/Cores/Files/StrixMusic.Cores.OneDrive/OneDriveCore.cs
@@ -242,9 +242,6 @@ namespace StrixMusic.Cores.OneDrive
             var driveItem = await graphClient.Drive.Items[Settings.SelectedFolderId].Request().GetAsync(cancellationToken);
             Guard.IsNotNull(driveItem, nameof(driveItem));
 
-            var folderToScan = new OneDriveFolderData(graphClient, driveItem);
-            FileMetadataManager = new FileMetadataManager(folderToScan, _metadataStorage, NotificationService);
-
             // Scanning file contents are possible but extremely slow over the network.
             // The Graph API supplies music metadata from file properties, which is much faster.
             // Use the user's preferences.
@@ -256,8 +253,10 @@ namespace StrixMusic.Cores.OneDrive
             if (Settings.ScanWithFileProperties)
                 scanTypes |= MetadataScanTypes.FileProperties;
 
+            var folderToScan = new OneDriveFolderData(graphClient, driveItem);
+            FileMetadataManager = new FileMetadataManager(folderToScan, _metadataStorage, NotificationService, degreesOfParallelism: 8);
+
             FileMetadataManager.ScanTypes = scanTypes;
-            FileMetadataManager.DegreesOfParallelism = 8;
 
             await FileMetadataManager.InitAsync(cancellationToken);
             _ = FileMetadataManager.ScanAsync(cancellationToken);

--- a/src/Sdk/StrixMusic.Sdk.Tests/Services/MetadataScanner/AudioMetadataScanner.Tests.cs
+++ b/src/Sdk/StrixMusic.Sdk.Tests/Services/MetadataScanner/AudioMetadataScanner.Tests.cs
@@ -15,25 +15,16 @@ namespace StrixMusic.Sdk.Tests.Services.MetadataScanner
     [TestClass]
     public class AudioMetadataScannerTests
     {
-        [TestInitialize]
-        public void Setup()
-        {
-        }
-
         [TestMethod]
         [DataRow(MetadataScanTypes.TagLib)]
         [Timeout(10000)]
-        public async Task MultipleArtistsFromTrackTest(MetadataScanTypes scanType)
+        public async Task MultipleArtistsFromTrackTest(MetadataScanTypes scanTypes)
         {
             var audioFilePath = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) ?? string.Empty, @"Services\MetadataScanner\Samples");
-            var cacheFolder = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) ?? string.Empty, @"Services\MetadataScanner\Cache");
 
-
-            var fm = new FileMetadataManager(new SystemFolderData(audioFilePath), new SystemFolderData(Path.GetTempPath()));
-            fm.ScanTypes = scanType;
-
-            var scanner = new AudioMetadataScanner(fm);
-            scanner.CacheFolder = new SystemFolderData(cacheFolder);
+            var scanner = new AudioMetadataScanner(degreesOfParallelism: 2);
+            scanner.ScanTypes = scanTypes;
+            scanner.CacheFolder = new SystemFolderData(Path.GetTempPath());
 
             var folder = new SystemFolderData(audioFilePath);
             var files = await folder.GetFilesAsync();
@@ -46,7 +37,6 @@ namespace StrixMusic.Sdk.Tests.Services.MetadataScanner
                 Assert.IsNotNull(item.ArtistMetadataCollection);
                 Assert.IsTrue(item.ArtistMetadataCollection.Count() > 1);
             }
-
         }
     }
 }

--- a/src/Sdk/StrixMusic.Sdk/FileMetadata/IFileMetadataManager.cs
+++ b/src/Sdk/StrixMusic.Sdk/FileMetadata/IFileMetadataManager.cs
@@ -53,7 +53,7 @@ namespace StrixMusic.Sdk.FileMetadata
         /// <summary>
         /// The number of files that are scanned concurrently.
         /// </summary>
-        int DegreesOfParallelism { get; set; }
+        int DegreesOfParallelism { get; }
 
         /// <summary>
         /// Starts scanning the given folder.

--- a/src/Sdk/StrixMusic.Sdk/FileMetadata/Scanners/PlaylistMetadataScanner.Parsers.cs
+++ b/src/Sdk/StrixMusic.Sdk/FileMetadata/Scanners/PlaylistMetadataScanner.Parsers.cs
@@ -25,11 +25,10 @@ namespace StrixMusic.Sdk.FileMetadata.Scanners
         /// <summary>
         /// Scans playlist file for metadata.
         /// </summary>
-        /// <param name="rootFolder">The most folder that we have permission to access files.</param>
         /// <param name="playlistFile">The path to the file.</param>
         /// <param name="files">The relevant files to link data to.</param>
         /// <returns>Fully scanned <see cref="PlaylistMetadata"/>.</returns>
-        public static async Task<PlaylistMetadata?> ScanPlaylistMetadata(IFolderData rootFolder, IFileData playlistFile, IEnumerable<Models.FileMetadata> files)
+        public static async Task<PlaylistMetadata?> ScanPlaylistMetadata(IFileData playlistFile, IEnumerable<Models.FileMetadata> files)
         {
             PlaylistMetadata? playlistMetadata;
             switch (playlistFile.FileExtension)


### PR DESCRIPTION


<!--
To categorize this PR in the generated changelog, include one of the following in the PR title: 
[breaking], [fix], [improvement], [new], [refactor], [cleanup]
-->

## Overview
<!-- Replace with the issue number. This will auto-close the issue once the PR is merged. If no issue exists, open one first. -->
Closes #112

<!-- Add a brief overview here of the change. -->
## Breaking changes
- The constructors for `FileMetadataManager`, `AudioMetadataScanner` and `PlaylistMetadataScanner` have been changed.
- `AudioMetadataScanner` no longer inherits the scan mode from `FileMetadataManager`. Instead, `FileMetadataManager` gets and sets the scan mode from `AudioMetadataScanner`.
- The property `IFileMetadataManager.DegreesOfParallelism` no longer has a public setter, properly reflecting that parallelism can't be changed after construction.

<!-- Include screenshots or a short video demonstrating the change, if possible -->

## Checklist
<!-- Note: Changes to the Sdk MUST be accompanied by unit tests, even if there were none before. -->
This PR meets the following requirements:
- [x] Tested and contains **NO** breaking changes or known regressions.
- [x] Tested with the upstream branch merged in.
- [x] Tests have been added for bug fixes / features (or this option is not applicable)
- [x] All new code has been documented (or this option is not applicable)
- [x] Headers have been added to all new source files (or this option is not applicable)

<!-- 
Is this a breaking change?
Please describe the impact and migration path for existing applications below.
-->


## Additional info
<!--
Please add any other information that might be helpful to reviewers.
-->

Not provided
