### PR TITLE
[breaking] Fixed AudioMetadataScanner.CacheFolder to be optional, and renamed it to ImageOutputFolder

### DIFF
--- a/src/Sdk/StrixMusic.Sdk.Tests/MetadataScanner/AudioMetadataScanner.Tests.cs
+++ b/src/Sdk/StrixMusic.Sdk.Tests/MetadataScanner/AudioMetadataScanner.Tests.cs
@@ -22,7 +22,6 @@ namespace StrixMusic.Sdk.Tests.Services.MetadataScanner
         {
             var scanner = new AudioMetadataScanner(degreesOfParallelism: 2);
             scanner.ScanTypes = scanTypes;
-            scanner.CacheFolder = new SystemFolderData(Path.GetTempPath()); // TODO: https://github.com/Arlodotexe/strix-music/issues/160
 
             var filePath = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!, @"MetadataScanner\Samples", fileName);
             var file = new SystemFileData(filePath);
@@ -46,7 +45,6 @@ namespace StrixMusic.Sdk.Tests.Services.MetadataScanner
         {
             var scanner = new AudioMetadataScanner(degreesOfParallelism: 2);
             scanner.ScanTypes = scanTypes;
-            scanner.CacheFolder = new SystemFolderData(Path.GetTempPath()); // TODO: https://github.com/Arlodotexe/strix-music/issues/160
 
             var filePath = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!, @"MetadataScanner\Samples", fileName);
             var file = new SystemFileData(filePath);

--- a/src/Sdk/StrixMusic.Sdk/FileMetadata/FileMetadataManager.cs
+++ b/src/Sdk/StrixMusic.Sdk/FileMetadata/FileMetadataManager.cs
@@ -75,7 +75,7 @@ namespace StrixMusic.Sdk.FileMetadata
             IsInitialized = true;
 
             Logger.LogInformation($"Setting up repository data location to {_metadataStorage.Path}");
-            _audioMetadataScanner.CacheFolder = _metadataStorage;
+            _audioMetadataScanner.ImageOutputFolder = _metadataStorage;
 
             Albums.SetDataFolder(_metadataStorage);
             AlbumArtists.SetDataFolder(_metadataStorage);

--- a/src/Sdk/StrixMusic.Sdk/FileMetadata/Scanners/AudioMetadataScanner.ImageProcessing.cs
+++ b/src/Sdk/StrixMusic.Sdk/FileMetadata/Scanners/AudioMetadataScanner.ImageProcessing.cs
@@ -51,7 +51,7 @@ namespace StrixMusic.Sdk.FileMetadata.Scanners
 
         private async Task ProcessImagesAsync(IFileData fileData, Models.FileMetadata fileMetadata, IEnumerable<Stream> imageStreams)
         {
-            Guard.IsNotNull(CacheFolder, nameof(CacheFolder));
+            Guard.IsNotNull(ImageOutputFolder, nameof(ImageOutputFolder));
 
             if (_scanningCancellationTokenSource?.Token.IsCancellationRequested ?? false)
                 _scanningCancellationTokenSource?.Token.ThrowIfCancellationRequested();
@@ -190,12 +190,12 @@ namespace StrixMusic.Sdk.FileMetadata.Scanners
         {
             await _ongoingImageProcessingSemaphore.WaitAsync();
 
-            Guard.IsNotNull(CacheFolder, nameof(CacheFolder));
+            Guard.IsNotNull(ImageOutputFolder, nameof(ImageOutputFolder));
 
             // We store images for a file in the following structure:
             // CacheFolder/Images/{image ID}-{size}.png
             // image ID is calculated based on content. Using a shared folder means no duplicate images.
-            var fileImagesFolder = await CacheFolder.CreateFolderAsync("Images", CreationCollisionOption.OpenIfExists);
+            var fileImagesFolder = await ImageOutputFolder.CreateFolderAsync("Images", CreationCollisionOption.OpenIfExists);
 
             if (_scanningCancellationTokenSource?.Token.IsCancellationRequested ?? false)
                 _scanningCancellationTokenSource?.Token.ThrowIfCancellationRequested();

--- a/src/Sdk/StrixMusic.Sdk/FileMetadata/Scanners/AudioMetadataScanner.cs
+++ b/src/Sdk/StrixMusic.Sdk/FileMetadata/Scanners/AudioMetadataScanner.cs
@@ -39,6 +39,15 @@ namespace StrixMusic.Sdk.FileMetadata.Scanners
         /// <summary>
         /// Initializes a new instance of the <see cref="AudioMetadataScanner"/> class.
         /// </summary>
+        public AudioMetadataScanner(int degreesOfParallelism, IFolderData imageOutputFolder)
+            : this(degreesOfParallelism)
+        {
+            ImageOutputFolder = imageOutputFolder;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AudioMetadataScanner"/> class.
+        /// </summary>
         public AudioMetadataScanner(int degreesOfParallelism)
         {
             DegreesOfParallelism = degreesOfParallelism;
@@ -91,7 +100,7 @@ namespace StrixMusic.Sdk.FileMetadata.Scanners
         /// <summary>
         /// The folder to use for storing file metadata.
         /// </summary>
-        public IFolderData? CacheFolder { get; internal set; }
+        public IFolderData? ImageOutputFolder { get; internal set; }
 
         /// <inheritdoc />
         public MetadataScanTypes ScanTypes { get; set; } = MetadataScanTypes.TagLib | MetadataScanTypes.FileProperties;
@@ -451,7 +460,6 @@ namespace StrixMusic.Sdk.FileMetadata.Scanners
 
         private async Task<Models.FileMetadata?> GetId3Metadata(IFileData fileData)
         {
-            Guard.IsNotNull(CacheFolder, nameof(CacheFolder));
             Guard.IsNotNull(_scanningCancellationTokenSource, nameof(_scanningCancellationTokenSource));
 
             Logger.LogInformation($"{nameof(GetId3Metadata)} entered for {nameof(IFileData)} at {fileData.Path}");
@@ -535,7 +543,7 @@ namespace StrixMusic.Sdk.FileMetadata.Scanners
                     Guard.IsNotEqualTo(fileMetadata.AlbumArtistMetadata.Count, 0);
                     Guard.IsNotEqualTo(fileMetadata.TrackArtistMetadata.Count, 0);
 
-                    if (tag.Pictures != null)
+                    if (ImageOutputFolder is not null && tag.Pictures is not null)
                     {
                         Logger.LogInformation($"{nameof(IFileData)} at {fileData.Path}: Images found");
                         var imageStreams = tag.Pictures.Select(x => new MemoryStream(x.Data.Data));


### PR DESCRIPTION
<!--
To categorize this PR in the generated changelog, include one of the following in the PR title: 
[breaking], [fix], [improvement], [new], [refactor], [cleanup]
-->

## Overview
<!-- Replace with the issue number. This will auto-close the issue once the PR is merged. If no issue exists, open one first. -->
Closes #160

<!-- Add a brief overview here of the change. -->

<!-- Include screenshots or a short video demonstrating the change, if possible -->

## Checklist
<!-- Note: Changes to the Sdk MUST be accompanied by unit tests, even if there were none before. -->
This PR meets the following requirements:
- [x] Tested and contains **NO** breaking changes or known regressions.
- [x] Tested with the upstream branch merged in.
- [x] Tests have been added for bug fixes / features (or this option is not applicable)
- [x] All new code has been documented (or this option is not applicable)
- [x] Headers have been added to all new source files (or this option is not applicable)

<!-- 
Is this a breaking change?
Please describe the impact and migration path for existing applications below.
-->

## Additional info
<!--
Please add any other information that might be helpful to reviewers.
-->

Not provided
