### PR TITLE
[fix] PopulateMore*Async ViewModel methods no longer return prematurely

### DIFF
--- a/src/Cores/Files/StrixMusic.Cores.Files/StrixMusic.Cores.Files.csproj
+++ b/src/Cores/Files/StrixMusic.Cores.Files/StrixMusic.Cores.Files.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="MessagePack" Version="2.3.85" />
-    <PackageReference Include="OwlCore" Version="0.0.70" />
+    <PackageReference Include="OwlCore" Version="0.0.71" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Cores/Files/StrixMusic.Cores.LocalFiles/StrixMusic.Cores.LocalFiles.csproj
+++ b/src/Cores/Files/StrixMusic.Cores.LocalFiles/StrixMusic.Cores.LocalFiles.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OwlCore" Version="0.0.70" />
+    <PackageReference Include="OwlCore" Version="0.0.71" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Cores/Files/StrixMusic.Cores.OneDrive/StrixMusic.Cores.OneDrive.csproj
+++ b/src/Cores/Files/StrixMusic.Cores.OneDrive/StrixMusic.Cores.OneDrive.csproj
@@ -18,7 +18,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Graph" Version="4.14.0" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.40.0" />
-    <PackageReference Include="OwlCore" Version="0.0.70" />
+    <PackageReference Include="OwlCore" Version="0.0.71" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Cores/Remote/StrixMusic.Cores.OwlCoreRpc.Tests/StrixMusic.Cores.OwlCoreRpc.Tests.csproj
+++ b/src/Cores/Remote/StrixMusic.Cores.OwlCoreRpc.Tests/StrixMusic.Cores.OwlCoreRpc.Tests.csproj
@@ -13,7 +13,7 @@
 		<PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
 		<PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
 		<PackageReference Include="coverlet.collector" Version="3.1.0" />
-		<PackageReference Include="OwlCore" Version="0.0.70" />
+		<PackageReference Include="OwlCore" Version="0.0.71" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Cores/Remote/StrixMusic.Cores.OwlCoreRpc/StrixMusic.Cores.OwlCoreRpc.csproj
+++ b/src/Cores/Remote/StrixMusic.Cores.OwlCoreRpc/StrixMusic.Cores.OwlCoreRpc.csproj
@@ -20,7 +20,7 @@
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="OwlCore" Version="0.0.70" />
+		<PackageReference Include="OwlCore" Version="0.0.71" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Libs/OwlCore.WinUI/OwlCore.WinUI.csproj
+++ b/src/Libs/OwlCore.WinUI/OwlCore.WinUI.csproj
@@ -21,7 +21,7 @@
   <ItemGroup>
     <PackageReference Include="ClusterNet" Version="0.0.3-alpha" />
     <PackageReference Include="Microsoft.Toolkit.Uwp.UI.Controls" Version="7.1.2" />
-    <PackageReference Include="OwlCore" Version="0.0.70" />
+    <PackageReference Include="OwlCore" Version="0.0.71" />
     <PackageReference Include="SixLabors.ImageSharp" Version="1.0.4" />
     <PackageReference Include="Uno.UI" Version="4.0.13" />
   </ItemGroup>

--- a/src/Platforms/StrixMusic.Droid/StrixMusic.Droid.csproj
+++ b/src/Platforms/StrixMusic.Droid/StrixMusic.Droid.csproj
@@ -101,7 +101,7 @@
       <Version>1.7.4</Version>
     </PackageReference>
     <PackageReference Include="OwlCore">
-      <Version>0.0.70</Version>
+      <Version>0.0.71</Version>
     </PackageReference>
     <PackageReference Include="StyleCop.Analyzers">
       <Version>1.1.118</Version>

--- a/src/Platforms/StrixMusic.UWP/StrixMusic.UWP.csproj
+++ b/src/Platforms/StrixMusic.UWP/StrixMusic.UWP.csproj
@@ -55,7 +55,7 @@
       <Version>1.7.4</Version>
     </PackageReference>
     <PackageReference Include="OwlCore">
-      <Version>0.0.70</Version>
+      <Version>0.0.71</Version>
     </PackageReference>
     <PackageReference Include="StyleCop.Analyzers">
       <Version>1.1.118</Version>

--- a/src/Platforms/StrixMusic.Wasm/StrixMusic.Wasm.csproj
+++ b/src/Platforms/StrixMusic.Wasm/StrixMusic.Wasm.csproj
@@ -53,7 +53,7 @@
 		<PackageReference Include="CommunityToolkit.Diagnostics" Version="8.0.0-preview4" />
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.0.0-preview4" />
 		<PackageReference Include="Microsoft.Windows.Compatibility" Version="6.0.0" />
-		<PackageReference Include="OwlCore" Version="0.0.70" />
+		<PackageReference Include="OwlCore" Version="0.0.71" />
 		<PackageReference Include="Uno.Extensions.Logging.WebAssembly.Console" Version="1.1.0" />
 		<PackageReference Include="Uno.Microsoft.Xaml.Behaviors.Interactivity" Version="2.3.0" />
 		<PackageReference Include="Uno.Microsoft.Xaml.Behaviors.Uwp.Managed" Version="2.3.0" />

--- a/src/Sdk/StrixMusic.Sdk.Tests/StrixMusic.Sdk.Tests.csproj
+++ b/src/Sdk/StrixMusic.Sdk.Tests/StrixMusic.Sdk.Tests.csproj
@@ -22,7 +22,7 @@
 		<PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
 		<PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
 		<PackageReference Include="coverlet.collector" Version="3.1.0" />
-		<PackageReference Include="OwlCore" Version="0.0.70" />
+		<PackageReference Include="OwlCore" Version="0.0.71" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Sdk/StrixMusic.Sdk.Tests/ViewModels/AlbumCollectionViewModelTests.cs
+++ b/src/Sdk/StrixMusic.Sdk.Tests/ViewModels/AlbumCollectionViewModelTests.cs
@@ -1,0 +1,75 @@
+﻿using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using StrixMusic.Sdk.ViewModels;
+
+namespace StrixMusic.Sdk.Tests.ViewModels
+{
+    [TestClass]
+    public class AlbumCollectionViewModelTests
+    {
+        [DataRow(1), DataRow(5), DataRow(100)]
+        [TestMethod, Timeout(5000)]
+        public async Task PopulateMoreImagesAsync_PopulatesBeforeTaskCompletes(int itemCount)
+        {
+            SynchronizationContext.SetSynchronizationContext(new());
+
+            var data = new Mock.AppModels.MockAlbumCollection();
+
+            foreach (var i in Enumerable.Range(0, itemCount))
+                await data.AddImageAsync(new Mock.AppModels.MockImage(), i);
+
+            var vm = new AlbumCollectionViewModel(data);
+
+            Assert.IsFalse(vm.IsInitialized);
+            Assert.AreEqual(0, vm.Images.Count);
+
+            await vm.PopulateMoreImagesAsync(itemCount);
+
+            Assert.AreEqual(itemCount, vm.Images.Count);
+        }
+
+        [DataRow(1), DataRow(5), DataRow(100)]
+        [TestMethod, Timeout(5000)]
+        public async Task PopulateMoreUrlsAsync_PopulatesBeforeTaskCompletes(int itemCount)
+        {
+            SynchronizationContext.SetSynchronizationContext(new());
+
+            var data = new Mock.AppModels.MockAlbumCollection();
+
+            foreach (var i in Enumerable.Range(0, itemCount))
+                await data.AddUrlAsync(new Mock.AppModels.MockUrl(), i);
+
+            var vm = new AlbumCollectionViewModel(data);
+
+            Assert.IsFalse(vm.IsInitialized);
+            Assert.AreEqual(0, vm.Urls.Count);
+
+            await vm.PopulateMoreUrlsAsync(itemCount);
+
+            Assert.AreEqual(itemCount, vm.Urls.Count);
+        }
+
+        [DataRow(1), DataRow(5), DataRow(100)]
+        [TestMethod, Timeout(5000)]
+        public async Task PopulateMoreAlbumsAsync_PopulatesBeforeTaskCompletes(int itemCount)
+        {
+            SynchronizationContext.SetSynchronizationContext(new());
+
+            var data = new Mock.AppModels.MockAlbumCollection();
+
+            foreach (var i in Enumerable.Range(0, itemCount))
+                await data.AddAlbumItemAsync(new Mock.AppModels.MockAlbum(), i);
+
+            var vm = new AlbumCollectionViewModel(data);
+
+            Assert.IsFalse(vm.IsInitialized);
+            Assert.AreEqual(0, vm.Albums.Count);
+
+            await vm.PopulateMoreAlbumsAsync(itemCount);
+
+            Assert.AreEqual(itemCount, vm.Albums.Count);
+        }
+    }
+}

--- a/src/Sdk/StrixMusic.Sdk.Tests/ViewModels/AlbumViewModelTests.cs
+++ b/src/Sdk/StrixMusic.Sdk.Tests/ViewModels/AlbumViewModelTests.cs
@@ -1,0 +1,96 @@
+﻿using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using StrixMusic.Sdk.ViewModels;
+
+namespace StrixMusic.Sdk.Tests.ViewModels
+{
+    [TestClass]
+    public class AlbumViewModelTests
+    {
+        [DataRow(1), DataRow(5), DataRow(100)]
+        [TestMethod, Timeout(5000)]
+        public async Task PopulateMoreImagesAsync_PopulatesBeforeTaskCompletes(int itemCount)
+        {
+            SynchronizationContext.SetSynchronizationContext(new());
+
+            var data = new Mock.AppModels.MockAlbum();
+
+            foreach (var i in Enumerable.Range(0, itemCount))
+                await data.AddImageAsync(new Mock.AppModels.MockImage(), i);
+
+            var vm = new AlbumViewModel(data);
+
+            Assert.IsFalse(vm.IsInitialized);
+            Assert.AreEqual(0, vm.Images.Count);
+
+            await vm.PopulateMoreImagesAsync(itemCount);
+
+            Assert.AreEqual(itemCount, vm.Images.Count);
+        }
+
+        [DataRow(1), DataRow(5), DataRow(100)]
+        [TestMethod, Timeout(5000)]
+        public async Task PopulateMoreUrlsAsync_PopulatesBeforeTaskCompletes(int itemCount)
+        {
+            SynchronizationContext.SetSynchronizationContext(new());
+
+            var data = new Mock.AppModels.MockAlbum();
+
+            foreach (var i in Enumerable.Range(0, itemCount))
+                await data.AddUrlAsync(new Mock.AppModels.MockUrl(), i);
+
+            var vm = new AlbumViewModel(data);
+
+            Assert.IsFalse(vm.IsInitialized);
+            Assert.AreEqual(0, vm.Urls.Count);
+
+            await vm.PopulateMoreUrlsAsync(itemCount);
+
+            Assert.AreEqual(itemCount, vm.Urls.Count);
+        }
+
+        [DataRow(1), DataRow(5), DataRow(100)]
+        [TestMethod, Timeout(5000)]
+        public async Task PopulateMoreArtistsAsync_PopulatesBeforeTaskCompletes(int itemCount)
+        {
+            SynchronizationContext.SetSynchronizationContext(new());
+
+            var data = new Mock.AppModels.MockAlbum();
+
+            foreach (var i in Enumerable.Range(0, itemCount))
+                await data.AddArtistItemAsync(new Mock.AppModels.MockArtist(), i);
+
+            var vm = new AlbumViewModel(data);
+
+            Assert.IsFalse(vm.IsInitialized);
+            Assert.AreEqual(0, vm.Artists.Count);
+
+            await vm.PopulateMoreArtistsAsync(itemCount);
+
+            Assert.AreEqual(itemCount, vm.Artists.Count);
+        }
+
+        [DataRow(1), DataRow(5), DataRow(100)]
+        [TestMethod, Timeout(5000)]
+        public async Task PopulateMoreTracksAsync_PopulatesBeforeTaskCompletes(int itemCount)
+        {
+            SynchronizationContext.SetSynchronizationContext(new());
+
+            var data = new Mock.AppModels.MockAlbum();
+
+            foreach (var i in Enumerable.Range(0, itemCount))
+                await data.AddTrackAsync(new Mock.AppModels.MockTrack(), i);
+
+            var vm = new AlbumViewModel(data);
+
+            Assert.IsFalse(vm.IsInitialized);
+            Assert.AreEqual(0, vm.Tracks.Count);
+
+            await vm.PopulateMoreTracksAsync(itemCount);
+
+            Assert.AreEqual(itemCount, vm.Tracks.Count);
+        }
+    }
+}

--- a/src/Sdk/StrixMusic.Sdk.Tests/ViewModels/ArtistCollectionViewModelTests.cs
+++ b/src/Sdk/StrixMusic.Sdk.Tests/ViewModels/ArtistCollectionViewModelTests.cs
@@ -1,0 +1,75 @@
+﻿using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using StrixMusic.Sdk.ViewModels;
+
+namespace StrixMusic.Sdk.Tests.ViewModels
+{
+    [TestClass]
+    public class ArtistCollectionViewModelTests
+    {
+        [DataRow(1), DataRow(5), DataRow(100)]
+        [TestMethod, Timeout(5000)]
+        public async Task PopulateMoreImagesAsync_PopulatesBeforeTaskCompletes(int itemCount)
+        {
+            SynchronizationContext.SetSynchronizationContext(new());
+
+            var data = new Mock.AppModels.MockArtistCollection();
+
+            foreach (var i in Enumerable.Range(0, itemCount))
+                await data.AddImageAsync(new Mock.AppModels.MockImage(), i);
+
+            var vm = new ArtistCollectionViewModel(data);
+
+            Assert.IsFalse(vm.IsInitialized);
+            Assert.AreEqual(0, vm.Images.Count);
+
+            await vm.PopulateMoreImagesAsync(itemCount);
+
+            Assert.AreEqual(itemCount, vm.Images.Count);
+        }
+
+        [DataRow(1), DataRow(5), DataRow(100)]
+        [TestMethod, Timeout(5000)]
+        public async Task PopulateMoreUrlsAsync_PopulatesBeforeTaskCompletes(int itemCount)
+        {
+            SynchronizationContext.SetSynchronizationContext(new());
+
+            var data = new Mock.AppModels.MockArtistCollection();
+
+            foreach (var i in Enumerable.Range(0, itemCount))
+                await data.AddUrlAsync(new Mock.AppModels.MockUrl(), i);
+
+            var vm = new ArtistCollectionViewModel(data);
+
+            Assert.IsFalse(vm.IsInitialized);
+            Assert.AreEqual(0, vm.Urls.Count);
+
+            await vm.PopulateMoreUrlsAsync(itemCount);
+
+            Assert.AreEqual(itemCount, vm.Urls.Count);
+        }
+
+        [DataRow(1), DataRow(5), DataRow(100)]
+        [TestMethod, Timeout(5000)]
+        public async Task PopulateMoreArtistsAsync_PopulatesBeforeTaskCompletes(int itemCount)
+        {
+            SynchronizationContext.SetSynchronizationContext(new());
+
+            var data = new Mock.AppModels.MockArtistCollection();
+
+            foreach (var i in Enumerable.Range(0, itemCount))
+                await data.AddArtistItemAsync(new Mock.AppModels.MockArtist(), i);
+
+            var vm = new ArtistCollectionViewModel(data);
+
+            Assert.IsFalse(vm.IsInitialized);
+            Assert.AreEqual(0, vm.Artists.Count);
+
+            await vm.PopulateMoreArtistsAsync(itemCount);
+
+            Assert.AreEqual(itemCount, vm.Artists.Count);
+        }
+    }
+}

--- a/src/Sdk/StrixMusic.Sdk.Tests/ViewModels/ArtistViewModelTests.cs
+++ b/src/Sdk/StrixMusic.Sdk.Tests/ViewModels/ArtistViewModelTests.cs
@@ -1,0 +1,96 @@
+﻿using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using StrixMusic.Sdk.ViewModels;
+
+namespace StrixMusic.Sdk.Tests.ViewModels
+{
+    [TestClass]
+    public class ArtistViewModelTests
+    {
+        [DataRow(1), DataRow(5), DataRow(100)]
+        [TestMethod, Timeout(5000)]
+        public async Task PopulateMoreImagesAsync_PopulatesBeforeTaskCompletes(int itemCount)
+        {
+            SynchronizationContext.SetSynchronizationContext(new());
+
+            var data = new Mock.AppModels.MockArtist();
+
+            foreach (var i in Enumerable.Range(0, itemCount))
+                await data.AddImageAsync(new Mock.AppModels.MockImage(), i);
+
+            var vm = new ArtistViewModel(data);
+
+            Assert.IsFalse(vm.IsInitialized);
+            Assert.AreEqual(0, vm.Images.Count);
+
+            await vm.PopulateMoreImagesAsync(itemCount);
+
+            Assert.AreEqual(itemCount, vm.Images.Count);
+        }
+
+        [DataRow(1), DataRow(5), DataRow(100)]
+        [TestMethod, Timeout(5000)]
+        public async Task PopulateMoreUrlsAsync_PopulatesBeforeTaskCompletes(int itemCount)
+        {
+            SynchronizationContext.SetSynchronizationContext(new());
+
+            var data = new Mock.AppModels.MockArtist();
+
+            foreach (var i in Enumerable.Range(0, itemCount))
+                await data.AddUrlAsync(new Mock.AppModels.MockUrl(), i);
+
+            var vm = new ArtistViewModel(data);
+
+            Assert.IsFalse(vm.IsInitialized);
+            Assert.AreEqual(0, vm.Urls.Count);
+
+            await vm.PopulateMoreUrlsAsync(itemCount);
+
+            Assert.AreEqual(itemCount, vm.Urls.Count);
+        }
+
+        [DataRow(1), DataRow(5), DataRow(100)]
+        [TestMethod, Timeout(5000)]
+        public async Task PopulateMoreAlbumsAsync_PopulatesBeforeTaskCompletes(int itemCount)
+        {
+            SynchronizationContext.SetSynchronizationContext(new());
+
+            var data = new Mock.AppModels.MockArtist();
+
+            foreach (var i in Enumerable.Range(0, itemCount))
+                await data.AddAlbumItemAsync(new Mock.AppModels.MockAlbum(), i);
+
+            var vm = new ArtistViewModel(data);
+
+            Assert.IsFalse(vm.IsInitialized);
+            Assert.AreEqual(0, vm.Albums.Count);
+
+            await vm.PopulateMoreAlbumsAsync(itemCount);
+
+            Assert.AreEqual(itemCount, vm.Albums.Count);
+        }
+
+        [DataRow(1), DataRow(5), DataRow(100)]
+        [TestMethod, Timeout(5000)]
+        public async Task PopulateMoreTracksAsync_PopulatesBeforeTaskCompletes(int itemCount)
+        {
+            SynchronizationContext.SetSynchronizationContext(new());
+
+            var data = new Mock.AppModels.MockArtist();
+
+            foreach (var i in Enumerable.Range(0, itemCount))
+                await data.AddTrackAsync(new Mock.AppModels.MockTrack(), i);
+
+            var vm = new ArtistViewModel(data);
+
+            Assert.IsFalse(vm.IsInitialized);
+            Assert.AreEqual(0, vm.Tracks.Count);
+
+            await vm.PopulateMoreTracksAsync(itemCount);
+
+            Assert.AreEqual(itemCount, vm.Tracks.Count);
+        }
+    }
+}

--- a/src/Sdk/StrixMusic.Sdk.Tests/ViewModels/PlayableCollectionGroupViewModelTests.cs
+++ b/src/Sdk/StrixMusic.Sdk.Tests/ViewModels/PlayableCollectionGroupViewModelTests.cs
@@ -1,0 +1,138 @@
+﻿using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using StrixMusic.Sdk.ViewModels;
+
+namespace StrixMusic.Sdk.Tests.ViewModels
+{
+    [TestClass]
+    public class PlayableCollectionGroupViewModelTests
+    {
+        [DataRow(1), DataRow(5), DataRow(100)]
+        [TestMethod, Timeout(5000)]
+        public async Task PopulateMoreImagesAsync_PopulatesBeforeTaskCompletes(int itemCount)
+        {
+            SynchronizationContext.SetSynchronizationContext(new());
+
+            var data = new Mock.AppModels.MockPlayableCollectionGroup();
+
+            foreach (var i in Enumerable.Range(0, itemCount))
+                await data.AddImageAsync(new Mock.AppModels.MockImage(), i);
+
+            var vm = new PlayableCollectionGroupViewModel(data);
+
+            Assert.IsFalse(vm.IsInitialized);
+            Assert.AreEqual(0, vm.Images.Count);
+
+            await vm.PopulateMoreImagesAsync(itemCount);
+
+            Assert.AreEqual(itemCount, vm.Images.Count);
+        }
+
+        [DataRow(1), DataRow(5), DataRow(100)]
+        [TestMethod, Timeout(5000)]
+        public async Task PopulateMoreUrlsAsync_PopulatesBeforeTaskCompletes(int itemCount)
+        {
+            SynchronizationContext.SetSynchronizationContext(new());
+
+            var data = new Mock.AppModels.MockPlayableCollectionGroup();
+
+            foreach (var i in Enumerable.Range(0, itemCount))
+                await data.AddUrlAsync(new Mock.AppModels.MockUrl(), i);
+
+            var vm = new PlayableCollectionGroupViewModel(data);
+
+            Assert.IsFalse(vm.IsInitialized);
+            Assert.AreEqual(0, vm.Urls.Count);
+
+            await vm.PopulateMoreUrlsAsync(itemCount);
+
+            Assert.AreEqual(itemCount, vm.Urls.Count);
+        }
+
+        [DataRow(1), DataRow(5), DataRow(100)]
+        [TestMethod, Timeout(5000)]
+        public async Task PopulateMoreAlbumsAsync_PopulatesBeforeTaskCompletes(int itemCount)
+        {
+            SynchronizationContext.SetSynchronizationContext(new());
+
+            var data = new Mock.AppModels.MockPlayableCollectionGroup();
+
+            foreach (var i in Enumerable.Range(0, itemCount))
+                await data.AddAlbumItemAsync(new Mock.AppModels.MockAlbum(), i);
+
+            var vm = new PlayableCollectionGroupViewModel(data);
+
+            Assert.IsFalse(vm.IsInitialized);
+            Assert.AreEqual(0, vm.Albums.Count);
+
+            await vm.PopulateMoreAlbumsAsync(itemCount);
+
+            Assert.AreEqual(itemCount, vm.Albums.Count);
+        }
+
+        [DataRow(1), DataRow(5), DataRow(100)]
+        [TestMethod, Timeout(5000)]
+        public async Task PopulateMoreArtistsAsync_PopulatesBeforeTaskCompletes(int itemCount)
+        {
+            SynchronizationContext.SetSynchronizationContext(new());
+
+            var data = new Mock.AppModels.MockPlayableCollectionGroup();
+
+            foreach (var i in Enumerable.Range(0, itemCount))
+                await data.AddArtistItemAsync(new Mock.AppModels.MockArtist(), i);
+
+            var vm = new PlayableCollectionGroupViewModel(data);
+
+            Assert.IsFalse(vm.IsInitialized);
+            Assert.AreEqual(0, vm.Artists.Count);
+
+            await vm.PopulateMoreArtistsAsync(itemCount);
+
+            Assert.AreEqual(itemCount, vm.Artists.Count);
+        }
+
+        [DataRow(1), DataRow(5), DataRow(100)]
+        [TestMethod, Timeout(5000)]
+        public async Task PopulateMorePlaylistsAsync_PopulatesBeforeTaskCompletes(int itemCount)
+        {
+            SynchronizationContext.SetSynchronizationContext(new());
+
+            var data = new Mock.AppModels.MockPlayableCollectionGroup();
+
+            foreach (var i in Enumerable.Range(0, itemCount))
+                await data.AddPlaylistItemAsync(new Mock.AppModels.MockPlaylist(), i);
+
+            var vm = new PlayableCollectionGroupViewModel(data);
+
+            Assert.IsFalse(vm.IsInitialized);
+            Assert.AreEqual(0, vm.Playlists.Count);
+
+            await vm.PopulateMorePlaylistsAsync(itemCount);
+
+            Assert.AreEqual(itemCount, vm.Playlists.Count);
+        }
+
+        [DataRow(1), DataRow(5), DataRow(100)]
+        [TestMethod, Timeout(5000)]
+        public async Task PopulateMoreTracksAsync_PopulatesBeforeTaskCompletes(int itemCount)
+        {
+            SynchronizationContext.SetSynchronizationContext(new());
+
+            var data = new Mock.AppModels.MockPlayableCollectionGroup();
+
+            foreach (var i in Enumerable.Range(0, itemCount))
+                await data.AddTrackAsync(new Mock.AppModels.MockTrack(), i);
+
+            var vm = new PlayableCollectionGroupViewModel(data);
+
+            Assert.IsFalse(vm.IsInitialized);
+            Assert.AreEqual(0, vm.Tracks.Count);
+
+            await vm.PopulateMoreTracksAsync(itemCount);
+
+            Assert.AreEqual(itemCount, vm.Tracks.Count);
+        }
+    }
+}

--- a/src/Sdk/StrixMusic.Sdk.Tests/ViewModels/PlaylistCollectionViewModelTests.cs
+++ b/src/Sdk/StrixMusic.Sdk.Tests/ViewModels/PlaylistCollectionViewModelTests.cs
@@ -1,0 +1,75 @@
+﻿using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using StrixMusic.Sdk.ViewModels;
+
+namespace StrixMusic.Sdk.Tests.ViewModels
+{
+    [TestClass]
+    public class PlaylistCollectionViewModelTests
+    {
+        [DataRow(1), DataRow(5), DataRow(100)]
+        [TestMethod, Timeout(5000)]
+        public async Task PopulateMoreImagesAsync_PopulatesBeforeTaskCompletes(int itemCount)
+        {
+            SynchronizationContext.SetSynchronizationContext(new());
+
+            var data = new Mock.AppModels.MockPlaylistCollection();
+
+            foreach (var i in Enumerable.Range(0, itemCount))
+                await data.AddImageAsync(new Mock.AppModels.MockImage(), i);
+
+            var vm = new PlaylistCollectionViewModel(data);
+
+            Assert.IsFalse(vm.IsInitialized);
+            Assert.AreEqual(0, vm.Images.Count);
+
+            await vm.PopulateMoreImagesAsync(itemCount);
+
+            Assert.AreEqual(itemCount, vm.Images.Count);
+        }
+
+        [DataRow(1), DataRow(5), DataRow(100)]
+        [TestMethod, Timeout(5000)]
+        public async Task PopulateMoreUrlsAsync_PopulatesBeforeTaskCompletes(int itemCount)
+        {
+            SynchronizationContext.SetSynchronizationContext(new());
+
+            var data = new Mock.AppModels.MockPlaylistCollection();
+
+            foreach (var i in Enumerable.Range(0, itemCount))
+                await data.AddUrlAsync(new Mock.AppModels.MockUrl(), i);
+
+            var vm = new PlaylistCollectionViewModel(data);
+
+            Assert.IsFalse(vm.IsInitialized);
+            Assert.AreEqual(0, vm.Urls.Count);
+
+            await vm.PopulateMoreUrlsAsync(itemCount);
+
+            Assert.AreEqual(itemCount, vm.Urls.Count);
+        }
+
+        [DataRow(1), DataRow(5), DataRow(100)]
+        [TestMethod, Timeout(5000)]
+        public async Task PopulateMorePlaylistsAsync_PopulatesBeforeTaskCompletes(int itemCount)
+        {
+            SynchronizationContext.SetSynchronizationContext(new());
+
+            var data = new Mock.AppModels.MockPlaylistCollection();
+
+            foreach (var i in Enumerable.Range(0, itemCount))
+                await data.AddPlaylistItemAsync(new Mock.AppModels.MockPlaylist(), i);
+
+            var vm = new PlaylistCollectionViewModel(data);
+
+            Assert.IsFalse(vm.IsInitialized);
+            Assert.AreEqual(0, vm.Playlists.Count);
+
+            await vm.PopulateMorePlaylistsAsync(itemCount);
+
+            Assert.AreEqual(itemCount, vm.Playlists.Count);
+        }
+    }
+}

--- a/src/Sdk/StrixMusic.Sdk.Tests/ViewModels/PlaylistViewModelTests.cs
+++ b/src/Sdk/StrixMusic.Sdk.Tests/ViewModels/PlaylistViewModelTests.cs
@@ -1,0 +1,75 @@
+﻿using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using StrixMusic.Sdk.ViewModels;
+
+namespace StrixMusic.Sdk.Tests.ViewModels
+{
+    [TestClass]
+    public class PlaylistViewModelTests
+    {
+        [DataRow(1), DataRow(5), DataRow(100)]
+        [TestMethod, Timeout(5000)]
+        public async Task PopulateMoreImagesAsync_PopulatesBeforeTaskCompletes(int itemCount)
+        {
+            SynchronizationContext.SetSynchronizationContext(new());
+
+            var data = new Mock.AppModels.MockPlaylist();
+
+            foreach (var i in Enumerable.Range(0, itemCount))
+                await data.AddImageAsync(new Mock.AppModels.MockImage(), i);
+
+            var vm = new PlaylistViewModel(data);
+
+            Assert.IsFalse(vm.IsInitialized);
+            Assert.AreEqual(0, vm.Images.Count);
+
+            await vm.PopulateMoreImagesAsync(itemCount);
+
+            Assert.AreEqual(itemCount, vm.Images.Count);
+        }
+
+        [DataRow(1), DataRow(5), DataRow(100)]
+        [TestMethod, Timeout(5000)]
+        public async Task PopulateMoreUrlsAsync_PopulatesBeforeTaskCompletes(int itemCount)
+        {
+            SynchronizationContext.SetSynchronizationContext(new());
+
+            var data = new Mock.AppModels.MockPlaylist();
+
+            foreach (var i in Enumerable.Range(0, itemCount))
+                await data.AddUrlAsync(new Mock.AppModels.MockUrl(), i);
+
+            var vm = new PlaylistViewModel(data);
+
+            Assert.IsFalse(vm.IsInitialized);
+            Assert.AreEqual(0, vm.Urls.Count);
+
+            await vm.PopulateMoreUrlsAsync(itemCount);
+
+            Assert.AreEqual(itemCount, vm.Urls.Count);
+        }
+
+        [DataRow(1), DataRow(5), DataRow(100)]
+        [TestMethod, Timeout(5000)]
+        public async Task PopulateMoreTracksAsync_PopulatesBeforeTaskCompletes(int itemCount)
+        {
+            SynchronizationContext.SetSynchronizationContext(new());
+
+            var data = new Mock.AppModels.MockPlaylist();
+
+            foreach (var i in Enumerable.Range(0, itemCount))
+                await data.AddTrackAsync(new Mock.AppModels.MockTrack(), i);
+
+            var vm = new PlaylistViewModel(data);
+
+            Assert.IsFalse(vm.IsInitialized);
+            Assert.AreEqual(0, vm.Tracks.Count);
+
+            await vm.PopulateMoreTracksAsync(itemCount);
+
+            Assert.AreEqual(itemCount, vm.Tracks.Count);
+        }
+    }
+}

--- a/src/Sdk/StrixMusic.Sdk.Tests/ViewModels/TrackCollectionViewModelTests.cs
+++ b/src/Sdk/StrixMusic.Sdk.Tests/ViewModels/TrackCollectionViewModelTests.cs
@@ -1,0 +1,75 @@
+﻿using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using StrixMusic.Sdk.ViewModels;
+
+namespace StrixMusic.Sdk.Tests.ViewModels
+{
+    [TestClass]
+    public class TrackCollectionViewModelTests
+    {
+        [DataRow(1), DataRow(5), DataRow(100)]
+        [TestMethod, Timeout(5000)]
+        public async Task PopulateMoreImagesAsync_PopulatesBeforeTaskCompletes(int itemCount)
+        {
+            SynchronizationContext.SetSynchronizationContext(new());
+
+            var data = new Mock.AppModels.MockTrackCollection();
+
+            foreach (var i in Enumerable.Range(0, itemCount))
+                await data.AddImageAsync(new Mock.AppModels.MockImage(), i);
+
+            var vm = new TrackCollectionViewModel(data);
+
+            Assert.IsFalse(vm.IsInitialized);
+            Assert.AreEqual(0, vm.Images.Count);
+
+            await vm.PopulateMoreImagesAsync(itemCount);
+
+            Assert.AreEqual(itemCount, vm.Images.Count);
+        }
+
+        [DataRow(1), DataRow(5), DataRow(100)]
+        [TestMethod, Timeout(5000)]
+        public async Task PopulateMoreUrlsAsync_PopulatesBeforeTaskCompletes(int itemCount)
+        {
+            SynchronizationContext.SetSynchronizationContext(new());
+
+            var data = new Mock.AppModels.MockTrackCollection();
+
+            foreach (var i in Enumerable.Range(0, itemCount))
+                await data.AddUrlAsync(new Mock.AppModels.MockUrl(), i);
+
+            var vm = new TrackCollectionViewModel(data);
+
+            Assert.IsFalse(vm.IsInitialized);
+            Assert.AreEqual(0, vm.Urls.Count);
+
+            await vm.PopulateMoreUrlsAsync(itemCount);
+
+            Assert.AreEqual(itemCount, vm.Urls.Count);
+        }
+
+        [DataRow(1), DataRow(5), DataRow(100)]
+        [TestMethod, Timeout(5000)]
+        public async Task PopulateMoreTracksAsync_PopulatesBeforeTaskCompletes(int itemCount)
+        {
+            SynchronizationContext.SetSynchronizationContext(new());
+
+            var data = new Mock.AppModels.MockTrackCollection();
+
+            foreach (var i in Enumerable.Range(0, itemCount))
+                await data.AddTrackAsync(new Mock.AppModels.MockTrack(), i);
+
+            var vm = new TrackCollectionViewModel(data);
+
+            Assert.IsFalse(vm.IsInitialized);
+            Assert.AreEqual(0, vm.Tracks.Count);
+
+            await vm.PopulateMoreTracksAsync(itemCount);
+
+            Assert.AreEqual(itemCount, vm.Tracks.Count);
+        }
+    }
+}

--- a/src/Sdk/StrixMusic.Sdk.Tests/ViewModels/TrackViewModelTests.cs
+++ b/src/Sdk/StrixMusic.Sdk.Tests/ViewModels/TrackViewModelTests.cs
@@ -1,0 +1,75 @@
+﻿using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using StrixMusic.Sdk.ViewModels;
+
+namespace StrixMusic.Sdk.Tests.ViewModels
+{
+    [TestClass]
+    public class TrackViewModelTests
+    {
+        [DataRow(1), DataRow(5), DataRow(100)]
+        [TestMethod, Timeout(5000)]
+        public async Task PopulateMoreImagesAsync_PopulatesBeforeTaskCompletes(int itemCount)
+        {
+            SynchronizationContext.SetSynchronizationContext(new());
+
+            var data = new Mock.AppModels.MockTrack();
+
+            foreach (var i in Enumerable.Range(0, itemCount))
+                await data.AddImageAsync(new Mock.AppModels.MockImage(), i);
+
+            var vm = new TrackViewModel(data);
+
+            Assert.IsFalse(vm.IsInitialized);
+            Assert.AreEqual(0, vm.Artists.Count);
+
+            await vm.PopulateMoreImagesAsync(itemCount);
+
+            Assert.AreEqual(itemCount, vm.Images.Count);
+        }
+
+        [DataRow(1), DataRow(5), DataRow(100)]
+        [TestMethod, Timeout(5000)]
+        public async Task PopulateMoreUrlsAsync_PopulatesBeforeTaskCompletes(int itemCount)
+        {
+            SynchronizationContext.SetSynchronizationContext(new());
+
+            var data = new Mock.AppModels.MockTrack();
+
+            foreach (var i in Enumerable.Range(0, itemCount))
+                await data.AddUrlAsync(new Mock.AppModels.MockUrl(), i);
+
+            var vm = new TrackViewModel(data);
+
+            Assert.IsFalse(vm.IsInitialized);
+            Assert.AreEqual(0, vm.Artists.Count);
+
+            await vm.PopulateMoreUrlsAsync(itemCount);
+
+            Assert.AreEqual(itemCount, vm.Urls.Count);
+        }
+
+        [DataRow(1), DataRow(5), DataRow(100)]
+        [TestMethod, Timeout(5000)]
+        public async Task PopulateMoreArtistsAsync_PopulatesBeforeTaskCompletes(int itemCount)
+        {
+            SynchronizationContext.SetSynchronizationContext(new());
+
+            var data = new Mock.AppModels.MockTrack();
+
+            foreach (var i in Enumerable.Range(0, itemCount))
+                await data.AddArtistItemAsync(new Mock.AppModels.MockArtist(), i);
+
+            var vm = new TrackViewModel(data);
+
+            Assert.IsFalse(vm.IsInitialized);
+            Assert.AreEqual(0, vm.Artists.Count);
+
+            await vm.PopulateMoreArtistsAsync(itemCount);
+
+            Assert.AreEqual(itemCount, vm.Artists.Count);
+        }
+    }
+}

--- a/src/Sdk/StrixMusic.Sdk.WinUI/StrixMusic.Sdk.WinUI.csproj
+++ b/src/Sdk/StrixMusic.Sdk.WinUI/StrixMusic.Sdk.WinUI.csproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="Nito.AsyncEx" Version="5.1.2" />
-    <PackageReference Include="OwlCore" Version="0.0.70" />
+    <PackageReference Include="OwlCore" Version="0.0.71" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Sdk/StrixMusic.Sdk/StrixMusic.Sdk.csproj
+++ b/src/Sdk/StrixMusic.Sdk/StrixMusic.Sdk.csproj
@@ -46,7 +46,7 @@
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
 		<PackageReference Include="Microsoft.Identity.Client" Version="4.40.0" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-		<PackageReference Include="OwlCore" Version="0.0.70" />
+		<PackageReference Include="OwlCore" Version="0.0.71" />
 		<PackageReference Include="SixLabors.ImageSharp" Version="1.0.4" />
 		<PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
 			<PrivateAssets>all</PrivateAssets>

--- a/src/Sdk/StrixMusic.Sdk/ViewModels/AlbumCollectionViewModel.cs
+++ b/src/Sdk/StrixMusic.Sdk/ViewModels/AlbumCollectionViewModel.cs
@@ -321,7 +321,7 @@ namespace StrixMusic.Sdk.ViewModels
             {
                 using var releaseReg = cancellationToken.Register(() => _populateAlbumsMutex.Release());
 
-                _syncContext.Post(async _ =>
+                await _syncContext.PostAsync(async () =>
                 {
                     await foreach (var item in _collection.GetAlbumItemsAsync(limit, Albums.Count, cancellationToken))
                     {
@@ -339,7 +339,7 @@ namespace StrixMusic.Sdk.ViewModels
                                 break;
                         }
                     }
-                }, null);
+                });
             }
         }
 
@@ -350,11 +350,11 @@ namespace StrixMusic.Sdk.ViewModels
             {
                 using var releaseReg = cancellationToken.Register(() => _populateImagesMutex.Release());
 
-                _syncContext.Post(async _ =>
+                await _syncContext.PostAsync(async () =>
                 {
                     await foreach (var item in _collection.GetImagesAsync(limit, Images.Count, cancellationToken))
                         Images.Add(item);
-                }, null);
+                });
             }
         }
 
@@ -365,11 +365,11 @@ namespace StrixMusic.Sdk.ViewModels
             {
                 using var releaseReg = cancellationToken.Register(() => _populateUrlsMutex.Release());
 
-                _syncContext.Post(async _ =>
+                await _syncContext.PostAsync(async () =>
                 {
                     await foreach (var item in _collection.GetUrlsAsync(limit, Urls.Count, cancellationToken))
                         Urls.Add(item);
-                }, null);
+                });
             }
         }
 

--- a/src/Sdk/StrixMusic.Sdk/ViewModels/AlbumViewModel.cs
+++ b/src/Sdk/StrixMusic.Sdk/ViewModels/AlbumViewModel.cs
@@ -686,7 +686,7 @@ namespace StrixMusic.Sdk.ViewModels
             {
                 using var releaseReg = cancellationToken.Register(() => _populateTracksMutex.Release());
 
-                _syncContext.Post(async _ =>
+                await _syncContext.PostAsync(async () =>
                 {
                     await foreach (var item in _album.GetTracksAsync(limit, Tracks.Count, cancellationToken))
                     {
@@ -694,7 +694,7 @@ namespace StrixMusic.Sdk.ViewModels
                         Tracks.Add(tvm);
                         UnsortedTracks.Add(tvm);
                     }
-                }, null);
+                });
             }
         }
 
@@ -717,7 +717,7 @@ namespace StrixMusic.Sdk.ViewModels
             {
                 using var releaseReg = cancellationToken.Register(() => _populateArtistsMutex.Release());
 
-                _syncContext.Post(async _ =>
+                await _syncContext.PostAsync(async () =>
                 {
                     await foreach (var item in _album.GetArtistItemsAsync(limit, Artists.Count, cancellationToken))
                     {
@@ -735,7 +735,7 @@ namespace StrixMusic.Sdk.ViewModels
                                 break;
                         }
                     }
-                }, null);
+                });
             }
         }
 
@@ -746,11 +746,11 @@ namespace StrixMusic.Sdk.ViewModels
             {
                 using var releaseReg = cancellationToken.Register(() => _populateImagesMutex.Release());
 
-                _syncContext.Post(async _ =>
+                await _syncContext.PostAsync(async () =>
                 {
                     await foreach (var item in _album.GetImagesAsync(limit, Images.Count, cancellationToken))
                         Images.Add(item);
-                }, null);
+                });
             }
         }
 
@@ -761,11 +761,11 @@ namespace StrixMusic.Sdk.ViewModels
             {
                 using var releaseReg = cancellationToken.Register(() => _populateUrlsMutex.Release());
 
-                _syncContext.Post(async _ =>
+                await _syncContext.PostAsync(async () =>
                 {
                     await foreach (var item in _album.GetUrlsAsync(limit, Urls.Count, cancellationToken))
                         Urls.Add(item);
-                }, null);
+                });
             }
         }
 
@@ -776,11 +776,11 @@ namespace StrixMusic.Sdk.ViewModels
             {
                 using var releaseReg = cancellationToken.Register(() => _populateGenresMutex.Release());
 
-                _syncContext.Post(async _ =>
+                await _syncContext.PostAsync(async () =>
                 {
                     await foreach (var item in _album.GetGenresAsync(limit, Genres.Count, cancellationToken))
                         Genres.Add(item);
-                }, null);
+                });
             }
         }
 

--- a/src/Sdk/StrixMusic.Sdk/ViewModels/ArtistCollectionViewModel.cs
+++ b/src/Sdk/StrixMusic.Sdk/ViewModels/ArtistCollectionViewModel.cs
@@ -496,7 +496,7 @@ namespace StrixMusic.Sdk.ViewModels
             {
                 using var releaseReg = cancellationToken.Register(() => _populateArtistsMutex.Release());
 
-                _syncContext.Post(async _ =>
+                await _syncContext.PostAsync(async () =>
                 {
                     await foreach (var item in _collection.GetArtistItemsAsync(limit, Artists.Count, cancellationToken))
                     {
@@ -514,7 +514,7 @@ namespace StrixMusic.Sdk.ViewModels
                                 break;
                         }
                     }
-                }, null);
+                });
             }
         }
 
@@ -525,11 +525,11 @@ namespace StrixMusic.Sdk.ViewModels
             {
                 using var releaseReg = cancellationToken.Register(() => _populateImagesMutex.Release());
                 
-                _syncContext.Post(async _ =>
+                await _syncContext.PostAsync(async () =>
                 {
                     await foreach (var item in _collection.GetImagesAsync(limit, Images.Count, cancellationToken))
                         Images.Add(item);
-                }, null);
+                });
             }
         }
 
@@ -540,11 +540,11 @@ namespace StrixMusic.Sdk.ViewModels
             {
                 using var releaseReg = cancellationToken.Register(() => _populateUrlsMutex.Release());
                 
-                _syncContext.Post(async _ =>
+                await _syncContext.PostAsync(async () =>
                 {
                     await foreach (var item in _collection.GetUrlsAsync(limit, Urls.Count, cancellationToken))
                         Urls.Add(item);
-                }, null);
+                });
             }
         }
 

--- a/src/Sdk/StrixMusic.Sdk/ViewModels/ArtistViewModel.cs
+++ b/src/Sdk/StrixMusic.Sdk/ViewModels/ArtistViewModel.cs
@@ -654,7 +654,7 @@ namespace StrixMusic.Sdk.ViewModels
             {
                 using var releaseReg = cancellationToken.Register(() => _populateAlbumsMutex.Release());
 
-                _syncContext.Post(async _ =>
+                await _syncContext.PostAsync(async () =>
                 {
                     await foreach (var item in _artist.GetAlbumItemsAsync(limit, Albums.Count, cancellationToken))
                     {
@@ -672,7 +672,7 @@ namespace StrixMusic.Sdk.ViewModels
                                 break;
                         }
                     }
-                }, null);
+                });
             }
         }
 
@@ -683,7 +683,7 @@ namespace StrixMusic.Sdk.ViewModels
             {
                 using var releaseReg = cancellationToken.Register(() => _populateTracksMutex.Release());
 
-                _syncContext.Post(async _ =>
+                await _syncContext.PostAsync(async () =>
                 {
                     await foreach (var item in GetTracksAsync(limit, Tracks.Count, cancellationToken))
                     {
@@ -691,7 +691,7 @@ namespace StrixMusic.Sdk.ViewModels
                         Tracks.Add(tvm);
                         UnsortedTracks.Add(tvm);
                     }
-                }, null);
+                });
             }
         }
 
@@ -702,11 +702,11 @@ namespace StrixMusic.Sdk.ViewModels
             {
                 using var releaseReg = cancellationToken.Register(() => _populateImagesMutex.Release());
 
-                _syncContext.Post(async _ =>
+                await _syncContext.PostAsync(async () =>
                 {
                     await foreach (var item in _artist.GetImagesAsync(limit, Images.Count, cancellationToken))
                         Images.Add(item);
-                }, null);
+                });
             }
         }
 
@@ -717,11 +717,11 @@ namespace StrixMusic.Sdk.ViewModels
             {
                 using var releaseReg = cancellationToken.Register(() => _populateGenresMutex.Release());
 
-                _syncContext.Post(async _ =>
+                await _syncContext.PostAsync(async () =>
                 {
                     await foreach (var item in _artist.GetGenresAsync(limit, Genres.Count, cancellationToken))
                         Genres.Add(item);
-                }, null);
+                });
             }
         }
 
@@ -732,13 +732,13 @@ namespace StrixMusic.Sdk.ViewModels
             {
                 using var releaseReg = cancellationToken.Register(() => _populateUrlsMutex.Release());
 
-                _syncContext.Post(async _ =>
+                await _syncContext.PostAsync(async () =>
                 {
                     await foreach (var item in _artist.GetUrlsAsync(limit, Urls.Count, cancellationToken))
                     {
                         Urls.Add(item);
                     }
-                }, null);
+                });
             }
         }
 

--- a/src/Sdk/StrixMusic.Sdk/ViewModels/PlayableCollectionGroupViewModel.cs
+++ b/src/Sdk/StrixMusic.Sdk/ViewModels/PlayableCollectionGroupViewModel.cs
@@ -882,7 +882,7 @@ namespace StrixMusic.Sdk.ViewModels
             {
                 using var releaseReg = cancellationToken.Register(() => _populatePlaylistsMutex.Release());
 
-                _syncContext.Post(async _ =>
+                await _syncContext.PostAsync(async () =>
                 {
                     await foreach (var item in _collectionGroup.GetPlaylistItemsAsync(limit, Playlists.Count, cancellationToken))
                     {
@@ -900,7 +900,7 @@ namespace StrixMusic.Sdk.ViewModels
                                 break;
                         }
                     }
-                }, null);
+                });
             }
         }
 
@@ -911,7 +911,7 @@ namespace StrixMusic.Sdk.ViewModels
             {
                 using var releaseReg = cancellationToken.Register(() => _populateTracksMutex.Release());
 
-                _syncContext.Post(async _ =>
+                await _syncContext.PostAsync(async () =>
                 {
                     await foreach (var item in _collectionGroup.GetTracksAsync(limit, Tracks.Count, cancellationToken))
                     {
@@ -919,7 +919,7 @@ namespace StrixMusic.Sdk.ViewModels
                         Tracks.Add(tvm);
                         UnsortedTracks.Add(tvm);
                     }
-                }, null);
+                });
             }
         }
 
@@ -930,7 +930,7 @@ namespace StrixMusic.Sdk.ViewModels
             {
                 using var releaseReg = cancellationToken.Register(() => _populateAlbumsMutex.Release());
 
-                _syncContext.Post(async _ =>
+                await _syncContext.PostAsync(async () =>
                 {
                     await foreach (var item in _collectionGroup.GetAlbumItemsAsync(limit, Albums.Count, cancellationToken))
                     {
@@ -948,7 +948,7 @@ namespace StrixMusic.Sdk.ViewModels
                                 break;
                         }
                     }
-                }, null);
+                });
             }
         }
 
@@ -959,7 +959,7 @@ namespace StrixMusic.Sdk.ViewModels
             {
                 using var releaseReg = cancellationToken.Register(() => _populateArtistsMutex.Release());
 
-                _syncContext.Post(async _ =>
+                await _syncContext.PostAsync(async () =>
                 {
                     await foreach (var item in _collectionGroup.GetArtistItemsAsync(limit, Artists.Count, cancellationToken))
                     {
@@ -977,7 +977,7 @@ namespace StrixMusic.Sdk.ViewModels
                                 break;
                         }
                     }
-                }, null);
+                });
             }
         }
 
@@ -988,13 +988,13 @@ namespace StrixMusic.Sdk.ViewModels
             {
                 using var releaseReg = cancellationToken.Register(() => _populateChildrenMutex.Release());
 
-                _syncContext.Post(async _ =>
+                await _syncContext.PostAsync(async () =>
                 {
                     await foreach (var item in _collectionGroup.GetChildrenAsync(limit, Albums.Count, cancellationToken))
                     {
                         Children.Add(new PlayableCollectionGroupViewModel(item));
                     }
-                }, null);
+                });
             }
         }
 
@@ -1005,13 +1005,13 @@ namespace StrixMusic.Sdk.ViewModels
             {
                 using var releaseReg = cancellationToken.Register(() => _populateImagesMutex.Release());
 
-                _syncContext.Post(async _ =>
+                await _syncContext.PostAsync(async () =>
                 {
                     await foreach (var item in _collectionGroup.GetImagesAsync(limit, Images.Count, cancellationToken))
                     {
                         Images.Add(item);
                     }
-                }, null);
+                });
             }
         }
 
@@ -1022,13 +1022,13 @@ namespace StrixMusic.Sdk.ViewModels
             {
                 using var releaseReg = cancellationToken.Register(() => _populateUrlsMutex.Release());
 
-                _syncContext.Post(async _ =>
+                await _syncContext.PostAsync(async () =>
                 {
                     await foreach (var item in _collectionGroup.GetUrlsAsync(limit, Urls.Count, cancellationToken))
                     {
                         Urls.Add(item);
                     }
-                }, null);
+                });
             }
         }
 

--- a/src/Sdk/StrixMusic.Sdk/ViewModels/PlaylistCollectionViewModel.cs
+++ b/src/Sdk/StrixMusic.Sdk/ViewModels/PlaylistCollectionViewModel.cs
@@ -465,7 +465,7 @@ namespace StrixMusic.Sdk.ViewModels
             {
                 using var releaseReg = cancellationToken.Register(() => _populatePlaylistsMutex.Release());
                 
-                _syncContext.Post(async _ =>
+                await _syncContext.PostAsync(async () =>
                 {
                     await foreach (var item in _collection.GetPlaylistItemsAsync(limit, Playlists.Count, cancellationToken))
                     {
@@ -483,7 +483,7 @@ namespace StrixMusic.Sdk.ViewModels
                                 break;
                         }
                     }
-                }, null);
+                });
             }
         }
 
@@ -494,11 +494,11 @@ namespace StrixMusic.Sdk.ViewModels
             {
                 using var releaseReg = cancellationToken.Register(() => _populateImagesMutex.Release());
 
-                _syncContext.Post(async _ =>
+                await _syncContext.PostAsync(async () =>
                 {
                     await foreach (var item in  _collection.GetImagesAsync(limit, Images.Count, cancellationToken))
                         Images.Add(item);
-                }, null);
+                });
             }
         }
 
@@ -509,11 +509,11 @@ namespace StrixMusic.Sdk.ViewModels
             {
                 using var releaseReg = cancellationToken.Register(() => _populateUrlsMutex.Release());
 
-                _syncContext.Post(async _ =>
+                await _syncContext.PostAsync(async () =>
                 {
                     await foreach (var item in _collection.GetUrlsAsync(limit, Urls.Count, cancellationToken))
                         Urls.Add(item);
-                }, null);
+                });
             }
         }
 

--- a/src/Sdk/StrixMusic.Sdk/ViewModels/PlaylistViewModel.cs
+++ b/src/Sdk/StrixMusic.Sdk/ViewModels/PlaylistViewModel.cs
@@ -502,7 +502,7 @@ namespace StrixMusic.Sdk.ViewModels
             {
                 using var releaseReg = cancellationToken.Register(() => _populateTracksMutex.Release());
 
-                _syncContext.Post(async _ =>
+                await _syncContext.PostAsync(async () =>
                 {
                     await foreach (var item in _playlist.GetTracksAsync(limit, Tracks.Count, cancellationToken))
                     {
@@ -510,7 +510,7 @@ namespace StrixMusic.Sdk.ViewModels
                         Tracks.Add(tvm);
                         UnsortedTracks.Add(tvm);
                     }
-                }, null);
+                });
             }
         }
 
@@ -521,11 +521,11 @@ namespace StrixMusic.Sdk.ViewModels
             {
                 using var releaseReg = cancellationToken.Register(() => _populateImagesMutex.Release());
 
-                _syncContext.Post(async _ =>
+                await _syncContext.PostAsync(async () =>
                 {
                     await foreach (var item in _playlist.GetImagesAsync(limit, Images.Count, cancellationToken))
                         Images.Add(item);
-                }, null);
+                });
             }
         }
 
@@ -536,11 +536,11 @@ namespace StrixMusic.Sdk.ViewModels
             {
                 using var releaseReg = cancellationToken.Register(() => _populateUrlsMutex.Release());
 
-                _syncContext.Post(async _ =>
+                await _syncContext.PostAsync(async () =>
                 {
                     await foreach (var item in _playlist.GetUrlsAsync(limit, Urls.Count, cancellationToken))
                         Urls.Add(item);
-                }, null);
+                });
             }
         }
 

--- a/src/Sdk/StrixMusic.Sdk/ViewModels/TrackCollectionViewModel.cs
+++ b/src/Sdk/StrixMusic.Sdk/ViewModels/TrackCollectionViewModel.cs
@@ -483,7 +483,7 @@ namespace StrixMusic.Sdk.ViewModels
             {
                 using var releaseReg = cancellationToken.Register(() => _populateTracksMutex.Release());
 
-                _syncContext.Post(async _ =>
+                await _syncContext.PostAsync(async () =>
                 {
                     await foreach (var item in _collection.GetTracksAsync(limit, Tracks.Count, cancellationToken))
                     {
@@ -491,7 +491,7 @@ namespace StrixMusic.Sdk.ViewModels
                         Tracks.Add(tvm);
                         UnsortedTracks.Add(tvm);
                     }
-                }, null);
+                });
             }
         }
 
@@ -502,11 +502,11 @@ namespace StrixMusic.Sdk.ViewModels
             {
                 using var releaseReg = cancellationToken.Register(() => _populateImagesMutex.Release());
 
-                _syncContext.Post(async _ =>
+                await _syncContext.PostAsync(async () =>
                 {
                     await foreach (var item in _collection.GetImagesAsync(limit, Images.Count, cancellationToken))
                         Images.Add(item);
-                }, null);
+                });
             }
         }
 
@@ -517,11 +517,11 @@ namespace StrixMusic.Sdk.ViewModels
             {
                 using var releaseReg = cancellationToken.Register(() => _populateUrlsMutex.Release());
 
-                _syncContext.Post(async _ =>
+                await _syncContext.PostAsync(async () =>
                 {
                     await foreach (var item in _collection.GetUrlsAsync(limit, Urls.Count, cancellationToken))
                         Urls.Add(item);
-                }, null);
+                });
             }
         }
 

--- a/src/Sdk/StrixMusic.Sdk/ViewModels/TrackViewModel.cs
+++ b/src/Sdk/StrixMusic.Sdk/ViewModels/TrackViewModel.cs
@@ -670,7 +670,7 @@ namespace StrixMusic.Sdk.ViewModels
             {
                 using var releaseReg = cancellationToken.Register(() => _populateArtistsMutex.Release());
 
-                _syncContext.Post(async _ =>
+                await _syncContext.PostAsync(async () =>
                 {
                     await foreach (var item in GetArtistItemsAsync(limit, Artists.Count, cancellationToken))
                     {
@@ -688,7 +688,7 @@ namespace StrixMusic.Sdk.ViewModels
                                 break;
                         }
                     }
-                }, null);
+                });
             }
         }
 
@@ -699,11 +699,11 @@ namespace StrixMusic.Sdk.ViewModels
             {
                 using var releaseReg = cancellationToken.Register(() => _populateImagesMutex.Release());
 
-                _syncContext.Post(async _ =>
+                await _syncContext.PostAsync(async () =>
                 {
                     await foreach (var item in GetImagesAsync(limit, Images.Count, cancellationToken))
                         Images.Add(item);
-                }, null);
+                });
             }
         }
 
@@ -714,11 +714,11 @@ namespace StrixMusic.Sdk.ViewModels
             {
                 using var releaseReg = cancellationToken.Register(() => _populateGenresMutex.Release());
 
-                _syncContext.Post(async _ =>
+                await _syncContext.PostAsync(async () =>
                 {
                     await foreach (var item in GetGenresAsync(limit, Genres.Count, cancellationToken))
                         Genres.Add(item);
-                }, null);
+                });
             }
         }
 
@@ -729,11 +729,11 @@ namespace StrixMusic.Sdk.ViewModels
             {
                 using var releaseReg = cancellationToken.Register(() => _populateUrlsMutex.Release());
 
-                _syncContext.Post(async _ =>
+                await _syncContext.PostAsync(async () =>
                 {
                     await foreach (var item in GetUrlsAsync(limit, Urls.Count, cancellationToken))
                         Urls.Add(item);
-                }, null);
+                });
             }
         }
 

--- a/src/Sdk/StrixMusic.Sdk/ViewModels/UserProfileViewModel.cs
+++ b/src/Sdk/StrixMusic.Sdk/ViewModels/UserProfileViewModel.cs
@@ -234,21 +234,21 @@ namespace StrixMusic.Sdk.ViewModels
         /// <inheritdoc />
         public async Task PopulateMoreImagesAsync(int limit, CancellationToken cancellationToken = default)
         {
-            _syncContext.Post(async _ =>
+            await _syncContext.PostAsync(async () =>
             {
                 await foreach (var item in GetImagesAsync(limit, Images.Count, cancellationToken))
                     Images.Add(item);
-            }, null);
+            });
         }
 
         /// <inheritdoc />
         public async Task PopulateMoreUrlsAsync(int limit, CancellationToken cancellationToken = default)
         {
-            _syncContext.Post(async _ =>
+            await _syncContext.PostAsync(async () =>
             {
                 await foreach (var item in GetUrlsAsync(limit, Urls.Count, cancellationToken))
                     Urls.Add(item);
-            }, null);
+            });
         }
 
         /// <inheritdoc />

--- a/src/Shells/StrixMusic.Shells.Groove/StrixMusic.Shells.Groove.csproj
+++ b/src/Shells/StrixMusic.Shells.Groove/StrixMusic.Shells.Groove.csproj
@@ -15,7 +15,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="ClusterNet" Version="0.0.3-alpha" />
-		<PackageReference Include="OwlCore" Version="0.0.70" />
+		<PackageReference Include="OwlCore" Version="0.0.71" />
 		<PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Shells/StrixMusic.Shells.ZuneDesktop/StrixMusic.Shells.ZuneDesktop.csproj
+++ b/src/Shells/StrixMusic.Shells.ZuneDesktop/StrixMusic.Shells.ZuneDesktop.csproj
@@ -23,7 +23,7 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
-		<PackageReference Include="OwlCore" Version="0.0.70" />
+		<PackageReference Include="OwlCore" Version="0.0.71" />
 		<PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
<!--
To categorize this PR in the generated changelog, include one of the following in the PR title: 
[breaking], [fix], [improvement], [new], [refactor], [cleanup]
-->

## Overview
<!-- Replace with the issue number. This will auto-close the issue once the PR is merged. If no issue exists, open one first. -->
Closes #172 

<!-- Add a brief overview here of the change. -->

<!-- Include screenshots or a short video demonstrating the change, if possible -->

## Checklist
<!-- Note: Changes to the Sdk MUST be accompanied by unit tests, even if there were none before. -->
This PR meets the following requirements:
- [x] Tested and contains **NO** breaking changes or known regressions.
- [x] Tested with the upstream branch merged in.
- [x] Tests have been added for bug fixes / features (or this option is not applicable)
- [x] All new code has been documented (or this option is not applicable)
- [x] Headers have been added to all new source files (or this option is not applicable)

<!-- 
Is this a breaking change?
Please describe the impact and migration path for existing applications below.
-->

## Additional info
<!--
Please add any other information that might be helpful to reviewers.
-->

Not provided
