### PR TITLE
[fix] Fixed crash when playing a track in Zune Desktop shell

### DIFF
--- a/src/Shells/StrixMusic.Shells.ZuneDesktop/Styles/Collections/TrackCollectionStyle.xaml
+++ b/src/Shells/StrixMusic.Shells.ZuneDesktop/Styles/Collections/TrackCollectionStyle.xaml
@@ -108,7 +108,7 @@
 
                                                 <interactivity:Interaction.Behaviors>
                                                     <core:EventTriggerBehavior EventName="DoubleTapped">
-                                                        <core:InvokeCommandAction Command="{x:Bind ParentCollection.PlayTrackAsyncCommand, Mode=OneWay}" CommandParameter="{x:Bind}" />
+                                                        <core:InvokeCommandAction Command="{x:Bind ParentCollection.PlayTrackAsyncCommand, Mode=OneWay}" CommandParameter="{x:Bind Track}" />
                                                     </core:EventTriggerBehavior>
                                                 </interactivity:Interaction.Behaviors>
 


### PR DESCRIPTION
<!--
To categorize this PR in the generated changelog, include one of the following in the PR title: 
[breaking], [fix], [improvement], [new], [refactor], [cleanup]
-->
Fixed a regression from #165 when playing a track in Zune Desktop

## Overview
<!-- Replace with the issue number. This will auto-close the issue once the PR is merged. If no issue exists, open one first. -->


<!-- Add a brief overview here of the change. -->

<!-- Include screenshots or a short video demonstrating the change, if possible -->

## Checklist
<!-- Note: Changes to the Sdk MUST be accompanied by unit tests, even if there were none before. -->
This PR meets the following requirements:
- [x] Tested and contains **NO** breaking changes or known regressions.
- [x] Tested with the upstream branch merged in.
- [x] Tests have been added for bug fixes / features (or this option is not applicable)
- [x] All new code has been documented (or this option is not applicable)
- [x] Headers have been added to all new source files (or this option is not applicable)

<!-- 
Is this a breaking change?
Please describe the impact and migration path for existing applications below.
-->

## Additional info
<!--
Please add any other information that might be helpful to reviewers.
-->

Not provided
