### PR TITLE
[fix][improvement][cleanup] ZuneAlbumCollection loose coupling for events and playback of play icon fixes.

### DIFF
--- a/src/Sdk/StrixMusic.Sdk.WinUI/Controls/Collections/AlbumCollection.cs
+++ b/src/Sdk/StrixMusic.Sdk.WinUI/Controls/Collections/AlbumCollection.cs
@@ -33,7 +33,7 @@ namespace StrixMusic.Sdk.WinUI.Controls.Collections
             // and the visual tree might be incomplete as of Loaded.
             base.OnApplyTemplate();
 
-            OnCollectionChanged(null, Collection);
+            OnCollectionChangedAsync(null, Collection);
 
             AttachHandlers();
         }
@@ -82,12 +82,12 @@ namespace StrixMusic.Sdk.WinUI.Controls.Collections
         /// Dependency property for <ses cref="IAlbumCollectionViewModel" />.
         /// </summary>
         public static readonly DependencyProperty CollectionProperty =
-            DependencyProperty.Register(nameof(Collection), typeof(IAlbumCollectionViewModel), typeof(AlbumCollection), new PropertyMetadata(null, (s, e) => s.Cast<AlbumCollection>().OnCollectionChanged((IAlbumCollectionViewModel?)e.OldValue, (IAlbumCollectionViewModel?)e.NewValue)));
+            DependencyProperty.Register(nameof(Collection), typeof(IAlbumCollectionViewModel), typeof(AlbumCollection), new PropertyMetadata(null, (s, e) => s.Cast<AlbumCollection>().OnCollectionChangedAsync((IAlbumCollectionViewModel?)e.OldValue, (IAlbumCollectionViewModel?)e.NewValue)));
 
         /// <summary>
         /// Fires when the <see cref="Collection"/> property changes.
         /// </summary>
-        protected virtual void OnCollectionChanged(IAlbumCollectionViewModel? oldValue, IAlbumCollectionViewModel? newValue)
+        protected virtual void OnCollectionChangedAsync(IAlbumCollectionViewModel? oldValue, IAlbumCollectionViewModel? newValue)
         {
             if (newValue is not null && !newValue.PopulateMoreAlbumsCommand.IsRunning && newValue.Albums.Count == 0)
                 newValue.PopulateMoreAlbumsCommand.Execute(20);

--- a/src/Shells/StrixMusic.Shells.ZuneDesktop/Controls/Views/Collection/CollectionContent.xaml.cs
+++ b/src/Shells/StrixMusic.Shells.ZuneDesktop/Controls/Views/Collection/CollectionContent.xaml.cs
@@ -3,6 +3,7 @@ using CommunityToolkit.Diagnostics;
 using StrixMusic.Sdk;
 using StrixMusic.Sdk.ViewModels;
 using StrixMusic.Sdk.WinUI.Controls.Collections.Events;
+using StrixMusic.Shells.ZuneDesktop.Controls.Views.Collection;
 using StrixMusic.Shells.ZuneDesktop.Controls.Views.Items;
 using Windows.System;
 using Windows.UI.Xaml;
@@ -107,13 +108,16 @@ namespace StrixMusic.Shells.ZuneDesktop.Controls.Views.Collections
             TrackCollection.Collection = e.SelectedItem;
         }
 
-        private void AlbumSelected(object sender, SelectionChangedEventArgs<AlbumViewModel> e)
+        private void AlbumSelected(object sender, SelectionChangedEventArgs<ZuneAlbumCollectionItem> e)
         {
             if (e.SelectedItem == null)
                 return;
 
-            e.SelectedItem.PopulateMoreTracksCommand.Execute(e.SelectedItem.TotalTrackCount);
-            TrackCollection.Collection = e.SelectedItem;
+            if (e.SelectedItem.Album == null)
+                return;
+
+            e.SelectedItem.Album.PopulateMoreTracksCommand.Execute(e.SelectedItem.Album.TotalTrackCount);
+            TrackCollection.Collection = e.SelectedItem.Album;
         }
 
         private void PlaylistSelected(object sender, SelectionChangedEventArgs<PlaylistViewModel> e)

--- a/src/Shells/StrixMusic.Shells.ZuneDesktop/Controls/Views/Collection/ZuneAlbumCollection.cs
+++ b/src/Shells/StrixMusic.Shells.ZuneDesktop/Controls/Views/Collection/ZuneAlbumCollection.cs
@@ -75,7 +75,6 @@ namespace StrixMusic.Shells.ZuneDesktop.Controls.Views.Collection
         public static readonly DependencyProperty ZuneCollectionTypeProperty =
             DependencyProperty.Register(nameof(ZuneCollectionType), typeof(CollectionContent), typeof(ZuneAlbumCollection), new PropertyMetadata(CollectionContentType.Albums, null));
 
-
         /// <summary>
         /// The backing dependency property for <see cref="Collection" />.
         /// </summary>

--- a/src/Shells/StrixMusic.Shells.ZuneDesktop/Controls/Views/Collection/ZuneAlbumCollection.cs
+++ b/src/Shells/StrixMusic.Shells.ZuneDesktop/Controls/Views/Collection/ZuneAlbumCollection.cs
@@ -28,7 +28,6 @@ namespace StrixMusic.Shells.ZuneDesktop.Controls.Views.Collection
     [INotifyPropertyChanged]
     public partial class ZuneAlbumCollection : CollectionControl<ZuneAlbumCollectionItem, ZuneAlbumItem>
     {
-        private object _lockObj = new object();
         private ResourceLoader _loacalizationService;
 
         private ObservableCollection<ZuneAlbumCollectionItem> _albumItems = new();

--- a/src/Shells/StrixMusic.Shells.ZuneDesktop/Controls/Views/Collection/ZuneAlbumCollection.cs
+++ b/src/Shells/StrixMusic.Shells.ZuneDesktop/Controls/Views/Collection/ZuneAlbumCollection.cs
@@ -267,6 +267,7 @@ namespace StrixMusic.Shells.ZuneDesktop.Controls.Views.Collection
         /// <inheritdoc/>
         protected async Task OnCollectionChangedAsync(IAlbumCollectionViewModel? oldValue, IAlbumCollectionViewModel? newValue)
         {
+            _albumItems.Clear();
             if (newValue is not null)
             {
                 if (newValue.InitAlbumCollectionAsyncCommand.IsRunning && newValue.InitAlbumCollectionAsyncCommand.ExecutionTask is not null)

--- a/src/Shells/StrixMusic.Shells.ZuneDesktop/Controls/Views/Collection/ZuneAlbumCollectionItem.cs
+++ b/src/Shells/StrixMusic.Shells.ZuneDesktop/Controls/Views/Collection/ZuneAlbumCollectionItem.cs
@@ -17,7 +17,6 @@ namespace StrixMusic.Shells.ZuneDesktop.Controls.Views.Collection
         /// </summary>
         public ZuneAlbumCollectionItem()
         {
-            PlayAlbumCollectionCommand = new RelayCommand(PlayAlbumCollection);
         }
 
         [ObservableProperty]
@@ -27,15 +26,11 @@ namespace StrixMusic.Shells.ZuneDesktop.Controls.Views.Collection
         private AlbumViewModel? _album;
 
         /// <summary>
-        /// Command to play album collection using play icon.
-        /// </summary>
-        public RelayCommand PlayAlbumCollectionCommand { get; set; }
-
-        /// <summary>
         /// Emits the <see cref="ZuneAlbumCollectionItem"/> whose collection needs to be played.
         /// </summary>
         public event EventHandler<AlbumViewModel>? AlbumPlaybackTriggered;
 
+        [RelayCommand]
         private void PlayAlbumCollection()
         {
             if (_album == null)

--- a/src/Shells/StrixMusic.Shells.ZuneDesktop/Controls/Views/Collection/ZuneAlbumCollectionItem.cs
+++ b/src/Shells/StrixMusic.Shells.ZuneDesktop/Controls/Views/Collection/ZuneAlbumCollectionItem.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using CommunityToolkit.Mvvm.ComponentModel;
+using StrixMusic.Sdk.ViewModels;
+
+namespace StrixMusic.Shells.ZuneDesktop.Controls.Views.Collection
+{
+    /// <summary>
+    /// An container for items in a <see cref="ZuneAlbumCollectionItem"/>, with added functionality and observable properties.
+    /// </summary>
+    public partial class ZuneAlbumCollectionItem : ObservableObject
+    {
+        [ObservableProperty]
+        private IAlbumCollectionViewModel? _parentCollection;
+
+        [ObservableProperty]
+        private AlbumViewModel? _album;
+
+        /// <summary>
+        /// Emits the <see cref="ZuneAlbumCollectionItem"/> whose collection needs to be played.
+        /// </summary>
+        public event EventHandler<AlbumViewModel>? AlbumPlaybackTriggered;
+    }
+}

--- a/src/Shells/StrixMusic.Shells.ZuneDesktop/Controls/Views/Collection/ZuneAlbumCollectionItem.cs
+++ b/src/Shells/StrixMusic.Shells.ZuneDesktop/Controls/Views/Collection/ZuneAlbumCollectionItem.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
 using StrixMusic.Sdk.ViewModels;
 
 namespace StrixMusic.Shells.ZuneDesktop.Controls.Views.Collection
@@ -11,6 +12,14 @@ namespace StrixMusic.Shells.ZuneDesktop.Controls.Views.Collection
     /// </summary>
     public partial class ZuneAlbumCollectionItem : ObservableObject
     {
+        /// <summary>
+        /// Creates a new instance for <see cref="ZuneAlbumCollectionItem"/>.
+        /// </summary>
+        public ZuneAlbumCollectionItem()
+        {
+            PlayAlbumCollectionCommand = new RelayCommand(PlayAlbumCollection);
+        }
+
         [ObservableProperty]
         private IAlbumCollectionViewModel? _parentCollection;
 
@@ -18,8 +27,21 @@ namespace StrixMusic.Shells.ZuneDesktop.Controls.Views.Collection
         private AlbumViewModel? _album;
 
         /// <summary>
+        /// Command to play album collection using play icon.
+        /// </summary>
+        public RelayCommand PlayAlbumCollectionCommand { get; set; }
+
+        /// <summary>
         /// Emits the <see cref="ZuneAlbumCollectionItem"/> whose collection needs to be played.
         /// </summary>
         public event EventHandler<AlbumViewModel>? AlbumPlaybackTriggered;
+
+        private void PlayAlbumCollection()
+        {
+            if (_album == null)
+                return;
+
+            AlbumPlaybackTriggered?.Invoke(this, _album);
+        }
     }
 }

--- a/src/Shells/StrixMusic.Shells.ZuneDesktop/Controls/Views/Items/ZuneAlbumItem.cs
+++ b/src/Shells/StrixMusic.Shells.ZuneDesktop/Controls/Views/Items/ZuneAlbumItem.cs
@@ -127,7 +127,6 @@ namespace StrixMusic.Shells.ZuneDesktop.Controls.Views.Items
         {
             Guard.IsNotNull(PART_PlayIcon, nameof(PART_PlayIcon));
             PART_PlayIcon.Tapped -= PART_PlayIcon_Tapped;
-            PART_PlayIcon.Tapped -= PART_PlayIcon_Tapped;
         }
 
         private void PART_PlayIcon_Tapped(object sender, Windows.UI.Xaml.Input.TappedRoutedEventArgs e)

--- a/src/Shells/StrixMusic.Shells.ZuneDesktop/Styles/Collections/AlbumCollectionStyle.xaml
+++ b/src/Shells/StrixMusic.Shells.ZuneDesktop/Styles/Collections/AlbumCollectionStyle.xaml
@@ -47,7 +47,7 @@
                                 <ProgressBar IsIndeterminate="True" Visibility="{Binding Collection.PopulateMoreAlbumsCommand.IsRunning, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"/>
                             </StackPanel>
 
-                            <GridView x:Name="PART_Selector" ItemsSource="{Binding Collection.Albums, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
+                            <GridView x:Name="PART_Selector" ItemsSource="{Binding AlbumItems, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
                                         ItemContainerStyle="{StaticResource ZuneDesktopAlbumGridViewItemStyle}" Grid.Row="1"
                                         Padding="10,6" HorizontalAlignment="Stretch" SelectionMode="Extended" IsItemClickEnabled="True">
                                 <GridView.GroupStyle>
@@ -62,10 +62,10 @@
 
                                 <GridView.ItemTemplate>
                                     <DataTemplate x:Key="ZuneDesktopAlbumCollectionItemStyle" x:DataType="collections:ZuneAlbumCollectionItem">
-                                        <zuneItems:ZuneAlbumItem Album="{Binding}" Opacity="1">
+                                        <zuneItems:ZuneAlbumItem Album="{x:Bind Album}" Opacity="1">
                                             <interactivity:Interaction.Behaviors>
                                                 <core:EventTriggerBehavior EventName="DoubleTapped">
-                                                    <core:InvokeCommandAction Command="{Binding ElementName=ContextHolder, Path=Content.PlayAlbumAsyncCommand, Mode=OneWay}" CommandParameter="{Binding}" />
+                                                    <core:InvokeCommandAction Command="{Binding ElementName=ContextHolder, Path=Content.PlayAlbumAsyncCommand, Mode=OneWay}" CommandParameter="{Binding }" />
                                                 </core:EventTriggerBehavior>
                                             </interactivity:Interaction.Behaviors>
                                         </zuneItems:ZuneAlbumItem>

--- a/src/Shells/StrixMusic.Shells.ZuneDesktop/Styles/Collections/AlbumCollectionStyle.xaml
+++ b/src/Shells/StrixMusic.Shells.ZuneDesktop/Styles/Collections/AlbumCollectionStyle.xaml
@@ -34,8 +34,6 @@
 
                             <!--  SemanticZoom grouped source  -->
 
-                            <ContentControl x:Name="ContextHolder" Content="{Binding Collection, RelativeSource={RelativeSource TemplatedParent}}" Visibility="Collapsed"/>
-
                             <StackPanel Margin="24,0,0,0" Spacing="5" Orientation="Horizontal">
                                 <TextBlock Text="{Binding Collection.TotalAlbumItemsCount, RelativeSource={RelativeSource TemplatedParent},Converter={StaticResource CountToAlbumsConverter}, Mode=OneWay}"
                                             FontSize="12" FontWeight="Bold" Margin="4,0,0,0" a:TextHelpers.CharacterCasing="Upper"/>
@@ -65,10 +63,10 @@
                                         <zuneItems:ZuneAlbumItem Album="{x:Bind Album}" Opacity="1">
                                             <interactivity:Interaction.Behaviors>
                                                 <core:EventTriggerBehavior EventName="DoubleTapped">
-                                                    <core:InvokeCommandAction Command="{Binding ElementName=ContextHolder, Path=Content.PlayAlbumAsyncCommand, Mode=OneWay}" CommandParameter="{Binding Album}" />
+                                                    <core:InvokeCommandAction Command="{Binding ParentCollection.PlayAlbumAsyncCommand, Mode=OneWay}" CommandParameter="{Binding Album}" />
                                                 </core:EventTriggerBehavior>
                                                 <core:EventTriggerBehavior EventName="AlbumPlaybackTriggered">
-                                                    <core:InvokeCommandAction Command="{Binding ElementName=ContextHolder, Path=Content.PlayAlbumAsyncCommand, Mode=OneWay}" CommandParameter="{Binding Album}" />
+                                                    <core:InvokeCommandAction Command="{Binding ParentCollection.PlayAlbumAsyncCommand, Mode=OneWay}" CommandParameter="{Binding Album}" />
                                                 </core:EventTriggerBehavior>
                                             </interactivity:Interaction.Behaviors>
                                         </zuneItems:ZuneAlbumItem>

--- a/src/Shells/StrixMusic.Shells.ZuneDesktop/Styles/Collections/AlbumCollectionStyle.xaml
+++ b/src/Shells/StrixMusic.Shells.ZuneDesktop/Styles/Collections/AlbumCollectionStyle.xaml
@@ -61,7 +61,7 @@
                                 </GridView.GroupStyle>
 
                                 <GridView.ItemTemplate>
-                                    <DataTemplate x:Key="ZuneDesktopAlbumCollectionItemStyle" x:DataType="viewModels:AlbumViewModel">
+                                    <DataTemplate x:Key="ZuneDesktopAlbumCollectionItemStyle" x:DataType="collections:ZuneAlbumCollectionItem">
                                         <zuneItems:ZuneAlbumItem Album="{Binding}" Opacity="1">
                                             <interactivity:Interaction.Behaviors>
                                                 <core:EventTriggerBehavior EventName="DoubleTapped">

--- a/src/Shells/StrixMusic.Shells.ZuneDesktop/Styles/Collections/AlbumCollectionStyle.xaml
+++ b/src/Shells/StrixMusic.Shells.ZuneDesktop/Styles/Collections/AlbumCollectionStyle.xaml
@@ -65,7 +65,7 @@
                                         <zuneItems:ZuneAlbumItem Album="{x:Bind Album}" Opacity="1">
                                             <interactivity:Interaction.Behaviors>
                                                 <core:EventTriggerBehavior EventName="DoubleTapped">
-                                                    <core:InvokeCommandAction Command="{Binding ElementName=ContextHolder, Path=Content.PlayAlbumAsyncCommand, Mode=OneWay}" CommandParameter="{Binding }" />
+                                                    <core:InvokeCommandAction Command="{Binding ElementName=ContextHolder, Path=Content.PlayAlbumAsyncCommand, Mode=OneWay}" CommandParameter="{Binding Album}" />
                                                 </core:EventTriggerBehavior>
                                             </interactivity:Interaction.Behaviors>
                                         </zuneItems:ZuneAlbumItem>

--- a/src/Shells/StrixMusic.Shells.ZuneDesktop/Styles/Collections/AlbumCollectionStyle.xaml
+++ b/src/Shells/StrixMusic.Shells.ZuneDesktop/Styles/Collections/AlbumCollectionStyle.xaml
@@ -67,6 +67,9 @@
                                                 <core:EventTriggerBehavior EventName="DoubleTapped">
                                                     <core:InvokeCommandAction Command="{Binding ElementName=ContextHolder, Path=Content.PlayAlbumAsyncCommand, Mode=OneWay}" CommandParameter="{Binding Album}" />
                                                 </core:EventTriggerBehavior>
+                                                <core:EventTriggerBehavior EventName="AlbumPlaybackTriggered">
+                                                    <core:InvokeCommandAction Command="{Binding ElementName=ContextHolder, Path=Content.PlayAlbumAsyncCommand, Mode=OneWay}" CommandParameter="{Binding Album}" />
+                                                </core:EventTriggerBehavior>
                                             </interactivity:Interaction.Behaviors>
                                         </zuneItems:ZuneAlbumItem>
                                     </DataTemplate>

--- a/src/Shells/StrixMusic.Shells.ZuneDesktop/Styles/Items/AlbumItemStyle.xaml
+++ b/src/Shells/StrixMusic.Shells.ZuneDesktop/Styles/Items/AlbumItemStyle.xaml
@@ -109,7 +109,7 @@
                                                                       HorizontalContentAlignment="Stretch" VerticalContentAlignment="Stretch">
                                         <Grid Background="#F4F4F4">
                                             <Grid>
-                                                <strix:SafeImage ImageCollection="{Binding }" />
+                                                <strix:SafeImage ImageCollection="{Binding Album, RelativeSource={RelativeSource Mode=TemplatedParent}}" />
                                                 <Rectangle x:Name="ImageHover" Opacity="0">
                                                     <Rectangle.Fill>
                                                         <ImageBrush ImageSource="ms-appx:///Assets/Shells/Zune.Desktop.4.8/Hover.png"/>
@@ -161,7 +161,7 @@
                             <StackPanel x:Name="PART_LabelPnl" Grid.Row="1" Width="86">
                                 <interactivity:Interaction.Behaviors>
                                     <core:EventTriggerBehavior EventName="Loaded">
-                                        <core:InvokeCommandAction Command="{Binding PopulateMoreArtistsCommand}" CommandParameter="{StaticResource LoadMoreArtistsCount}"/>
+                                        <core:InvokeCommandAction Command="{Binding Album.PopulateMoreArtistsCommand}" CommandParameter="{StaticResource LoadMoreArtistsCount}"/>
                                     </core:EventTriggerBehavior>
                                 </interactivity:Interaction.Behaviors>
 

--- a/src/Shells/StrixMusic.Shells.ZuneDesktop/Styles/Items/AlbumItemStyle.xaml
+++ b/src/Shells/StrixMusic.Shells.ZuneDesktop/Styles/Items/AlbumItemStyle.xaml
@@ -109,7 +109,7 @@
                                                                       HorizontalContentAlignment="Stretch" VerticalContentAlignment="Stretch">
                                         <Grid Background="#F4F4F4">
                                             <Grid>
-                                                <strix:SafeImage ImageCollection="{Binding Album, RelativeSource={RelativeSource Mode=TemplatedParent}}" />
+                                                <strix:SafeImage ImageCollection="{Binding Album}" />
                                                 <Rectangle x:Name="ImageHover" Opacity="0">
                                                     <Rectangle.Fill>
                                                         <ImageBrush ImageSource="ms-appx:///Assets/Shells/Zune.Desktop.4.8/Hover.png"/>
@@ -170,8 +170,8 @@
                                     </core:EventTriggerBehavior>
                                 </interactivity:Interaction.Behaviors>
 
-                                <TextBlock x:Name="AlbumName" Text="{Binding Album.Name, RelativeSource={RelativeSource Mode=TemplatedParent}}" FontSize="11" TextTrimming="Clip" Foreground="#242628" />
-                                <TextBlock x:Name="ArtistName" Text="{Binding Album.Artists[0].Name, RelativeSource={RelativeSource Mode=TemplatedParent}}" FontSize="11" Foreground="#919497" Margin="0,-2,0,0"/>
+                                <TextBlock x:Name="AlbumName" Text="{Binding Album.Name}" FontSize="11" TextTrimming="Clip" Foreground="#242628" />
+                                <TextBlock x:Name="ArtistName" Text="{Binding Album.Artists[0].Name}" FontSize="11" Foreground="#919497" Margin="0,-2,0,0"/>
                             </StackPanel>
                         </Grid>
                     </ControlTemplate>

--- a/src/Shells/StrixMusic.Shells.ZuneDesktop/Styles/Items/AlbumItemStyle.xaml
+++ b/src/Shells/StrixMusic.Shells.ZuneDesktop/Styles/Items/AlbumItemStyle.xaml
@@ -118,6 +118,11 @@
 
                                                 <Button x:Name="PART_PlayIcon"
                                                         HorizontalAlignment="Center"   VerticalAlignment="Bottom" Background="Transparent" Opacity="0">
+                                                    <interactivity:Interaction.Behaviors>
+                                                        <core:EventTriggerBehavior EventName="Tapped">
+                                                            <core:InvokeCommandAction Command="{Binding PlayAlbumCollectionCommand}" />
+                                                        </core:EventTriggerBehavior>
+                                                    </interactivity:Interaction.Behaviors>
                                                     <Button.Resources>
                                                         <ResourceDictionary>
                                                             <ResourceDictionary.ThemeDictionaries>


### PR DESCRIPTION
## Overview
<!-- Replace with the issue number. This will auto-close the issue once the PR is merged. If no issue exists, open one first. -->
Closes #124 

<!-- Add a brief overview here of the change. -->

1. Refactored ZuneAlbumCollection in such that it uses a wrapper ViewModel to interact with the AlbumItems.
2. The wrapper ViewModel sits in-line with the trickle-down MVVM pattern and fixes lots of playback issues of play icon.
3. Used source generators for observable properties and the commands.
4. Fixed sorting issues caused by the refactor.

<!-- Include screenshots or a short video demonstrating the change, if possible -->

https://user-images.githubusercontent.com/15306909/175814389-3649349f-ebb1-4438-b783-d68da4968dca.mp4


## Checklist
This PR meets the following requirements:
- [x] Tested and contains **NO** breaking changes or known regressions.
- [x] Tested with the upstream branch merged in.
- [x] Tests have been added for bug fixes / features (or this option is not applicable)
- [x] All new code has been documented (or this option is not applicable)
- [x] Headers have been added to all new source files (or this option is not applicable)


## Additional info
Not provided
