### PR TITLE
[fix] Fixed InvalidCastException when loading Zune shell with debugger attached

### DIFF
--- a/src/Shells/StrixMusic.Shells.ZuneDesktop/Styles/NowPlaying/DefaultZuneMediaInfoStyle.xaml
+++ b/src/Shells/StrixMusic.Shells.ZuneDesktop/Styles/NowPlaying/DefaultZuneMediaInfoStyle.xaml
@@ -8,6 +8,7 @@
     xmlns:sdk="using:StrixMusic.Sdk"
     xmlns:strix="using:StrixMusic.Sdk.WinUI.Controls"
     xmlns:viewModels="using:StrixMusic.Sdk.ViewModels"
+    xmlns:sdkShellControls="using:StrixMusic.Sdk.WinUI.Controls.Shells"
     xmlns:vm="using:StrixMusic.Sdk.ViewModels"
     xmlns:convertnumtime="using:OwlCore.WinUI.Converters.Time.Numerical"
     xmlns:interactivity="using:Microsoft.Xaml.Interactivity"
@@ -23,7 +24,7 @@
         </ResourceDictionary>
     </ResourceDictionary.MergedDictionaries>
 
-    <DataTemplate x:Key="NowPlayingBarDataTemplate" x:DataType="vm:DeviceViewModel">
+    <DataTemplate x:Key="NowPlayingBarDataTemplate" x:DataType="sdkShellControls:NowPlayingBar">
                     <Grid>
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="64"/>
@@ -38,19 +39,19 @@
                             <Rectangle x:Name="TrackCover" Width="64" Height="64" Fill="#E6E6E6"/>
                         </controls:DropShadowPanel>
 
-                        <strix:SafeImage x:Name="PART_TrackImage" Width="64" Height="64" Grid.RowSpan="3" VerticalAlignment="Center" ImageCollection="{Binding NowPlaying.Track}"/>
+                        <strix:SafeImage x:Name="PART_TrackImage" Width="64" Height="64" Grid.RowSpan="3" VerticalAlignment="Center" ImageCollection="{Binding ActiveDevice.NowPlaying.Track}"/>
 
-                         <TextBlock Text="{Binding NowPlaying.Track.Name}" FontSize="16" FontWeight="Bold" Grid.Column="1" Margin="12,0,0,0" Foreground="{ThemeResource Foreground}" />
+                        <TextBlock Text="{Binding ActiveDevice.NowPlaying.Track.Name}" FontSize="16" FontWeight="Bold" Grid.Column="1" Margin="12,0,0,0" Foreground="{ThemeResource Foreground}" />
 
                         <FontIcon Glyph="&#xE006;" FontSize="16" FontWeight="Bold" Grid.Column="1" HorizontalAlignment="Right" Opacity=".5" Foreground="{ThemeResource Foreground}" />
 
                         <nowplaying:MediaSlider x:Name="PART_MediaSlider" Grid.Row="1" Grid.Column="1" Margin="12,0,0,0" Style="{StaticResource ZuneSlider}"
-                                    Value="{x:Bind Position.TotalMilliseconds,Mode=OneWay}"
-                                    Maximum="{x:Bind NowPlaying.Track.Duration.TotalMilliseconds,Mode=OneWay}"
+                                    Value="{x:Bind ActiveDevice.Position.TotalMilliseconds,Mode=OneWay}"
+                                    Maximum="{x:Bind ActiveDevice.NowPlaying.Track.Duration.TotalMilliseconds,Mode=OneWay}"
                                     FlowDirection="LeftToRight">
                             <interactivity:Interaction.Behaviors>
                                 <core:EventTriggerBehavior EventName="SliderManipulationCompleted">
-                        <core:InvokeCommandAction Command="{x:Bind SeekAsyncCommand}" CommandParameter="{Binding Value, ElementName=PART_MediaSlider, Converter={StaticResource DoubleToTimeSpanConverter}}" />
+                        <core:InvokeCommandAction Command="{x:Bind ActiveDevice.SeekAsyncCommand}" CommandParameter="{Binding Value, ElementName=PART_MediaSlider, Converter={StaticResource DoubleToTimeSpanConverter}}" />
                                 </core:EventTriggerBehavior>
                             </interactivity:Interaction.Behaviors>
                         </nowplaying:MediaSlider>


### PR DESCRIPTION
<!--
To categorize this PR in the generated changelog, include one of the following in the PR title: 
[breaking], [fix], [improvement], [new], [refactor], [cleanup]
-->

## Overview
<!-- Replace with the issue number. This will auto-close the issue once the PR is merged. If no issue exists, open one first. -->
Closes #104

This fixes an issue where a DataTemplate in DefaultDefaultMediaInfoStyle.xaml isn't able to typecast the NowPlayingBar to the DeviceViewModel.
<!-- Add a brief overview here of the change. -->

<!-- Include screenshots or a short video demonstrating the change, if possible -->

## Checklist
<!-- Note: Changes to the Sdk MUST be accompanied by unit tests, even if there were none before. -->
This PR meets the following requirements:
- [x] Tested and contains **NO** breaking changes or known regressions.
- [x] Tested with the upstream branch merged in.
- [x] Tests have been added for bug fixes / features (or this option is not applicable)
- [x] All new code has been documented (or this option is not applicable)
- [x] Headers have been added to all new source files (or this option is not applicable)

<!-- 
Is this a breaking change?
Please describe the impact and migration path for existing applications below.
-->
## Additional info
<!--
Please add any other information that might be helpful to reviewers.
-->

Not provided
