### PR TITLE
[fix] Fixed an issue where seeking on zune shell wasn't working correctly

### DIFF
--- a/src/Sdk/StrixMusic.Sdk.WinUI/Controls/NowPlaying/MediaInfo.cs
+++ b/src/Sdk/StrixMusic.Sdk.WinUI/Controls/NowPlaying/MediaInfo.cs
@@ -15,6 +15,8 @@ namespace StrixMusic.Sdk.WinUI.Controls.NowPlaying
         public MediaInfo()
         {
             this.DefaultStyleKey = typeof(MediaInfo);
+
+            this.DataContext = this;
         }
 
         /// <summary>

--- a/src/Shells/StrixMusic.Shells.ZuneDesktop/Styles/NowPlaying/DefaultZuneMediaInfoStyle.xaml
+++ b/src/Shells/StrixMusic.Shells.ZuneDesktop/Styles/NowPlaying/DefaultZuneMediaInfoStyle.xaml
@@ -24,7 +24,7 @@
         </ResourceDictionary>
     </ResourceDictionary.MergedDictionaries>
 
-    <DataTemplate x:Key="NowPlayingBarDataTemplate" x:DataType="sdkShellControls:NowPlayingBar">
+    <DataTemplate x:Key="MediaInfoDataTemplate" x:DataType="nowplaying:MediaInfo">
                     <Grid>
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="64"/>
@@ -39,19 +39,19 @@
                             <Rectangle x:Name="TrackCover" Width="64" Height="64" Fill="#E6E6E6"/>
                         </controls:DropShadowPanel>
 
-                        <strix:SafeImage x:Name="PART_TrackImage" Width="64" Height="64" Grid.RowSpan="3" VerticalAlignment="Center" ImageCollection="{Binding ActiveDevice.NowPlaying.Track}"/>
+                    <strix:SafeImage x:Name="PART_TrackImage" Width="64" Height="64" Grid.RowSpan="3" VerticalAlignment="Center" ImageCollection="{Binding Device.NowPlaying.Track}"/>
 
-                        <TextBlock Text="{Binding ActiveDevice.NowPlaying.Track.Name}" FontSize="16" FontWeight="Bold" Grid.Column="1" Margin="12,0,0,0" Foreground="{ThemeResource Foreground}" />
+                <TextBlock Text="{Binding Device.NowPlaying.Track.Name}" FontSize="16" FontWeight="Bold" Grid.Column="1" Margin="12,0,0,0" Foreground="{ThemeResource Foreground}" />
 
                         <FontIcon Glyph="&#xE006;" FontSize="16" FontWeight="Bold" Grid.Column="1" HorizontalAlignment="Right" Opacity=".5" Foreground="{ThemeResource Foreground}" />
 
                         <nowplaying:MediaSlider x:Name="PART_MediaSlider" Grid.Row="1" Grid.Column="1" Margin="12,0,0,0" Style="{StaticResource ZuneSlider}"
-                                    Value="{x:Bind ActiveDevice.Position.TotalMilliseconds,Mode=OneWay}"
-                                    Maximum="{x:Bind ActiveDevice.NowPlaying.Track.Duration.TotalMilliseconds,Mode=OneWay}"
+                                    Value="{x:Bind Device.Position.TotalMilliseconds,Mode=OneWay}"
+                                    Maximum="{x:Bind Device.NowPlaying.Track.Duration.TotalMilliseconds,Mode=OneWay}"
                                     FlowDirection="LeftToRight">
                             <interactivity:Interaction.Behaviors>
                                 <core:EventTriggerBehavior EventName="SliderManipulationCompleted">
-                        <core:InvokeCommandAction Command="{x:Bind ActiveDevice.SeekAsyncCommand}" CommandParameter="{Binding Value, ElementName=PART_MediaSlider, Converter={StaticResource DoubleToTimeSpanConverter}}" />
+                        <core:InvokeCommandAction Command="{x:Bind Device.SeekAsyncCommand}" CommandParameter="{Binding Value, ElementName=PART_MediaSlider, Converter={StaticResource DoubleToTimeSpanConverter}}" />
                                 </core:EventTriggerBehavior>
                             </interactivity:Interaction.Behaviors>
                         </nowplaying:MediaSlider>
@@ -64,7 +64,7 @@
             <Setter Property="Template">
                 <Setter.Value>
                     <ControlTemplate TargetType="nowplaying:MediaInfo">
-                        <ContentControl ContentTemplate="{StaticResource NowPlayingBarDataTemplate}" Content="{Binding Device, RelativeSource={RelativeSource Mode=TemplatedParent},Mode=OneWay}"
+                        <ContentControl ContentTemplate="{StaticResource MediaInfoDataTemplate}" 
                                     HorizontalContentAlignment="Stretch" VerticalContentAlignment="Stretch"/>
                     </ControlTemplate>
                 </Setter.Value>

--- a/src/Shells/StrixMusic.Shells.ZuneDesktop/Styles/NowPlaying/DefaultZuneMediaInfoStyle.xaml
+++ b/src/Shells/StrixMusic.Shells.ZuneDesktop/Styles/NowPlaying/DefaultZuneMediaInfoStyle.xaml
@@ -51,7 +51,7 @@
                                     FlowDirection="LeftToRight">
                             <interactivity:Interaction.Behaviors>
                                 <core:EventTriggerBehavior EventName="SliderManipulationCompleted">
-                        <core:InvokeCommandAction Command="{x:Bind Device.SeekAsyncCommand}" CommandParameter="{Binding Value, ElementName=PART_MediaSlider, Converter={StaticResource DoubleToTimeSpanConverter}}" />
+                        <core:InvokeCommandAction Command="{x:Bind Device.SeekAsyncCommand, Mode=OneWay}" CommandParameter="{Binding Value, ElementName=PART_MediaSlider, Converter={StaticResource DoubleToTimeSpanConverter}}" />
                                 </core:EventTriggerBehavior>
                             </interactivity:Interaction.Behaviors>
                         </nowplaying:MediaSlider>


### PR DESCRIPTION
<!--
To categorize this PR in the generated changelog, include one of the following in the PR title: 
[breaking], [fix], [improvement], [new], [refactor], [cleanup]
-->

## Overview
Closes #188
Fixed an issue where seeking on zune shell wasn't working correctly.
The issue was with the MediaInfo binding and incorrect DataContext being passed to MediaInfo.

<!-- Include screenshots or a short video demonstrating the change, if possible -->

https://user-images.githubusercontent.com/15306909/177621232-208f1856-9ccb-4c00-b70d-77366d0a197d.mp4



## Checklist
<!-- Note: Changes to the Sdk MUST be accompanied by unit tests, even if there were none before. -->
This PR meets the following requirements:
- [x] Tested and contains **NO** breaking changes or known regressions.
- [x] Tested with the upstream branch merged in.
- [x] Tests have been added for bug fixes / features (or this option is not applicable)
- [x] All new code has been documented (or this option is not applicable)
- [x] Headers have been added to all new source files (or this option is not applicable)

<!-- 
Is this a breaking change?
Please describe the impact and migration path for existing applications below.
-->

## Additional info
<!--
Please add any other information that might be helpful to reviewers.
-->

Not provided
