### PR TITLE
[fix] Fixed MediaInfo and MediaTransport in sandbox shell.

### DIFF
--- a/src/Sdk/StrixMusic.Sdk.WinUI/Controls/NowPlaying/MediaInfo.cs
+++ b/src/Sdk/StrixMusic.Sdk.WinUI/Controls/NowPlaying/MediaInfo.cs
@@ -22,9 +22,9 @@ namespace StrixMusic.Sdk.WinUI.Controls.NowPlaying
         /// <summary>
         /// The ViewModel that holds the active device.
         /// </summary>
-        public DeviceViewModel Device
+        public DeviceViewModel? Device
         {
-            get { return (DeviceViewModel)GetValue(DeviceProperty); }
+            get { return (DeviceViewModel?)GetValue(DeviceProperty); }
             set { SetValue(DeviceProperty, value); }
         }
 

--- a/src/Sdk/StrixMusic.Sdk.WinUI/Controls/NowPlaying/MediaTransports.cs
+++ b/src/Sdk/StrixMusic.Sdk.WinUI/Controls/NowPlaying/MediaTransports.cs
@@ -15,14 +15,16 @@ namespace StrixMusic.Sdk.WinUI.Controls.NowPlaying
         public MediaTransports()
         {
             this.DefaultStyleKey = typeof(MediaTransports);
+             
+            this.DataContext = this;
         }
 
         /// <summary>
         /// The ViewModel that holds the active device.
         /// </summary>
-        public DeviceViewModel Device
+        public DeviceViewModel? Device
         {
-            get { return (DeviceViewModel)GetValue(DeviceProperty); }
+            get { return (DeviceViewModel?)GetValue(DeviceProperty); }
             set { SetValue(DeviceProperty, value); }
         }
 

--- a/src/Sdk/StrixMusic.Sdk.WinUI/Styles/Shells/NowPlayingBarStyle.xaml
+++ b/src/Sdk/StrixMusic.Sdk.WinUI/Styles/Shells/NowPlayingBarStyle.xaml
@@ -64,7 +64,7 @@
                 </Grid.ColumnDefinitions>
 
                 <!--Media info-->
-                <nowplaying:MediaInfo MaxWidth="300" Device="{Binding ActiveDevice}"/>
+                <nowplaying:MediaInfo MaxWidth="300" Device="{x:Bind ActiveDevice,Mode=OneWay}"/>
 
                 <!--Media slider control-->
                 <nowplaying:MediaSlider x:Name="slider" Grid.Column="1" VerticalAlignment="Center" Minimum="0"
@@ -79,7 +79,7 @@
                 </nowplaying:MediaSlider>
 
                 <!--Media transport controls-->
-                <nowplaying:MediaTransports Device="{Binding}" Grid.Column="2"/>
+                <nowplaying:MediaTransports Device="{x:Bind ActiveDevice,Mode=OneWay}" Grid.Column="2" />
             </Grid>
         </UserControl>
     </DataTemplate>

--- a/src/Sdk/StrixMusic.Sdk.WinUI/Styles/Shells/NowPlayingBarStyle.xaml
+++ b/src/Sdk/StrixMusic.Sdk.WinUI/Styles/Shells/NowPlayingBarStyle.xaml
@@ -64,7 +64,7 @@
                 </Grid.ColumnDefinitions>
 
                 <!--Media info-->
-                <nowplaying:MediaInfo MaxWidth="300" Device="{x:Bind ActiveDevice,Mode=OneWay}"/>
+                <nowplaying:MediaInfo MaxWidth="300" Device="{x:Bind ActiveDevice, Mode=OneWay}"/>
 
                 <!--Media slider control-->
                 <nowplaying:MediaSlider x:Name="slider" Grid.Column="1" VerticalAlignment="Center" Minimum="0"


### PR DESCRIPTION
<!--
To categorize this PR in the generated changelog, include one of the following in the PR title: 
[breaking], [fix], [improvement], [new], [refactor], [cleanup]
-->

## Overview
<!-- Replace with the issue number. This will auto-close the issue once the PR is merged. If no issue exists, open one first. -->
Closes #196 
This fixes media transport buttons such as play/pause/forward/backward and shuffle.
This fixes media info such as album image in sandbox shell.
<!-- Include screenshots or a short video demonstrating the change, if possible -->

https://user-images.githubusercontent.com/15306909/180057868-f5e860e6-1fe9-4674-b942-ae78eba3df1a.mp4



## Checklist
<!-- Note: Changes to the Sdk MUST be accompanied by unit tests, even if there were none before. -->
This PR meets the following requirements:
- [x] Tested and contains **NO** breaking changes or known regressions.
- [x] Tested with the upstream branch merged in.
- [x] Tests have been added for bug fixes / features (or this option is not applicable)
- [x] All new code has been documented (or this option is not applicable)
- [x] Headers have been added to all new source files (or this option is not applicable)

<!-- 
Is this a breaking change?
Please describe the impact and migration path for existing applications below.
-->

## Additional info
<!--
Please add any other information that might be helpful to reviewers.
-->

Not provided
