### PR TITLE
[fix] Fixed file metadata scanner crashing when FileProperties doesn't provide optional data

### DIFF
--- a/src/Sdk/StrixMusic.Sdk/FileMetadata/Scanners/AudioMetadataScanner.cs
+++ b/src/Sdk/StrixMusic.Sdk/FileMetadata/Scanners/AudioMetadataScanner.cs
@@ -398,10 +398,17 @@ namespace StrixMusic.Sdk.FileMetadata.Scanners
                 TrackArtistMetadata = new List<ArtistMetadata>(),
             };
 
-            relatedMetadata.TrackArtistMetadata.AddRange(details.Composers.Select(x => new ArtistMetadata { Name = x }));
-            relatedMetadata.TrackArtistMetadata.AddRange(details.Conductors.Select(x => new ArtistMetadata { Name = x }));
-            relatedMetadata.TrackArtistMetadata.AddRange(details.Producers.Select(x => new ArtistMetadata { Name = x }));
-            relatedMetadata.TrackArtistMetadata.AddRange(details.Writers.Select(x => new ArtistMetadata { Name = x }));
+            if (details.Composers is not null)
+                relatedMetadata.TrackArtistMetadata.AddRange(details.Composers.Select(x => new ArtistMetadata { Name = x }));
+
+            if (details.Conductors is not null)
+                relatedMetadata.TrackArtistMetadata.AddRange(details.Conductors.Select(x => new ArtistMetadata { Name = x }));
+
+            if (details.Producers is not null)
+                relatedMetadata.TrackArtistMetadata.AddRange(details.Producers.Select(x => new ArtistMetadata { Name = x }));
+
+            if (details.Writers is not null)
+                relatedMetadata.TrackArtistMetadata.AddRange(details.Writers.Select(x => new ArtistMetadata { Name = x }));
 
             // If no artist data, create "unknown" placeholder.
             if (relatedMetadata.AlbumArtistMetadata.Count == 0)


### PR DESCRIPTION
Fixed an issue where the metadata scanner could crash if abstract storage failed to provide optional artist data

<!--
To categorize this PR in the generated changelog, include one of the following in the PR title: 
[breaking], [fix], [improvement], [new], [refactor], [cleanup]
-->

## Overview
<!-- Replace with the issue number. This will auto-close the issue once the PR is merged. If no issue exists, open one first. -->

<!-- Add a brief overview here of the change. -->

<!-- Include screenshots or a short video demonstrating the change, if possible -->

## Checklist
<!-- Note: Changes to the Sdk MUST be accompanied by unit tests, even if there were none before. -->
This PR meets the following requirements:
- [x] Tested and contains **NO** breaking changes or known regressions.
- [x] Tested with the upstream branch merged in.
- [x] Tests have been added for bug fixes / features (or this option is not applicable)
- [x] All new code has been documented (or this option is not applicable)
- [x] Headers have been added to all new source files (or this option is not applicable)

<!-- 
Is this a breaking change?
Please describe the impact and migration path for existing applications below.
-->

## Additional info
<!--
Please add any other information that might be helpful to reviewers.
-->

Not provided
