### PR TITLE
[breaking] Switched to IAsyncEnumerable, renamed to PlaylistMetadataScanner.ScanPlaylistsAsync  

### DIFF
--- a/src/Sdk/StrixMusic.Sdk/FileMetadata/FileMetadataManager.cs
+++ b/src/Sdk/StrixMusic.Sdk/FileMetadata/FileMetadataManager.cs
@@ -345,7 +345,7 @@ namespace StrixMusic.Sdk.FileMetadata
 
             Logger.LogInformation($"Starting metadata scan of playlist files");
             ScanState = new FileScanState(FileScanStage.Playlists, ScanState.FilesProcessed, ScanState.FilesFound);
-            await _playlistMetadataScanner.ScanPlaylists(_knownFiles, fileMetadata, currentToken).ToListAsync(cancellationToken: currentToken);
+            await _playlistMetadataScanner.ScanPlaylistsAsync(_knownFiles, fileMetadata, currentToken).ToListAsync(cancellationToken: currentToken);
 
             currentToken.ThrowIfCancellationRequested();
 

--- a/src/Sdk/StrixMusic.Sdk/FileMetadata/FileMetadataManager.cs
+++ b/src/Sdk/StrixMusic.Sdk/FileMetadata/FileMetadataManager.cs
@@ -345,7 +345,7 @@ namespace StrixMusic.Sdk.FileMetadata
 
             Logger.LogInformation($"Starting metadata scan of playlist files");
             ScanState = new FileScanState(FileScanStage.Playlists, ScanState.FilesProcessed, ScanState.FilesFound);
-            await _playlistMetadataScanner.ScanPlaylists(_knownFiles, fileMetadata, currentToken);
+            await _playlistMetadataScanner.ScanPlaylists(_knownFiles, fileMetadata, currentToken).ToListAsync(cancellationToken: currentToken);
 
             currentToken.ThrowIfCancellationRequested();
 

--- a/src/Sdk/StrixMusic.Sdk/FileMetadata/Scanners/PlaylistMetadataScanner.cs
+++ b/src/Sdk/StrixMusic.Sdk/FileMetadata/Scanners/PlaylistMetadataScanner.cs
@@ -86,7 +86,7 @@ namespace StrixMusic.Sdk.FileMetadata.Scanners
         /// <param name="fileMetadata">The file metadata to use when linking playlist data.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> that cancels the ongoing task.</param>
         /// <returns>An <see cref="IEnumerable{PlaylistMetadata}"/> with playlist data linked to the given <paramref name="fileMetadata"/>.</returns>
-        public async IAsyncEnumerable<PlaylistMetadata> ScanPlaylists(IEnumerable<IFileData> files, IEnumerable<Models.FileMetadata> fileMetadata, [EnumeratorCancellation] CancellationToken cancellationToken)
+        public async IAsyncEnumerable<PlaylistMetadata> ScanPlaylistsAsync(IEnumerable<IFileData> files, IEnumerable<Models.FileMetadata> fileMetadata, [EnumeratorCancellation] CancellationToken cancellationToken)
         {
             _filesProcessed = 0;
 


### PR DESCRIPTION
<!--
To categorize this PR in the generated changelog, include one of the following in the PR title: 
[breaking], [fix], [improvement], [new], [refactor], [cleanup]
-->

## Overview
<!-- Replace with the issue number. This will auto-close the issue once the PR is merged. If no issue exists, open one first. -->
Closes #156

<!-- Add a brief overview here of the change. -->

<!-- Include screenshots or a short video demonstrating the change, if possible -->

## Checklist
<!-- Note: Changes to the Sdk MUST be accompanied by unit tests, even if there were none before. -->
This PR meets the following requirements:
- [x] Tested and contains **NO** breaking changes or known regressions.
- [x] Tested with the upstream branch merged in.
- [x] Tests have been added for bug fixes / features (or this option is not applicable)
- [x] All new code has been documented (or this option is not applicable)
- [x] Headers have been added to all new source files (or this option is not applicable)

<!-- 
Is this a breaking change?
Please describe the impact and migration path for existing applications below.
-->

## Additional info
<!--
Please add any other information that might be helpful to reviewers.
-->

Not provided
