### PR TITLE
[breaking] Removed CoreMetadata, refactored into ICore

### DIFF
--- a/src/Cores/Files/StrixMusic.Cores.Files/FilesCore.cs
+++ b/src/Cores/Files/StrixMusic.Cores.Files/FilesCore.cs
@@ -32,8 +32,14 @@ namespace StrixMusic.Cores.Files
             Library = new FilesCoreLibrary(this);
         }
 
-        /// <inheritdoc/>
-        public abstract CoreMetadata Registration { get; }
+        /// <inheritdoc />
+        public abstract string Id { get; }
+
+        /// <inheritdoc />
+        public abstract string DisplayName { get; }
+
+        /// <inheritdoc />
+        public abstract ICoreImage? Logo { get; }
 
         /// <inheritdoc/>
         public string InstanceId { get; }
@@ -49,7 +55,7 @@ namespace StrixMusic.Cores.Files
 
         /// <inheritdoc />
         public ICore SourceCore => this;
-        
+
         /// <summary>
         /// Manages scanning and caching of all music metadata from files in a folder.
         /// </summary>
@@ -101,9 +107,15 @@ namespace StrixMusic.Cores.Files
         /// <inheritdoc />
         public abstract event EventHandler<string>? InstanceDescriptorChanged;
 
+        /// <inheritdoc />
+        public event EventHandler<ICoreImage?>? LogoChanged;
+
+        /// <inheritdoc />
+        public event EventHandler<string>? DisplayNameChanged;
+
         /// <inheritdoc/>
         public abstract Task InitAsync(CancellationToken cancellationToken = default);
-        
+
         /// <inheritdoc/>
         public bool IsInitialized { get; protected set; }
 
@@ -119,7 +131,7 @@ namespace StrixMusic.Cores.Files
         public async Task<ICoreModel?> GetContextByIdAsync(string id, CancellationToken cancellationToken = default)
         {
             Guard.IsNotNull(FileMetadataManager, nameof(FileMetadataManager));
-            
+
             var artist = await FileMetadataManager.AlbumArtists.GetByIdAsync(id);
             if (artist != null)
                 return InstanceCache.Artists.GetOrCreate(id, SourceCore, artist);

--- a/src/Cores/Files/StrixMusic.Cores.LocalFiles/LocalFilesCore.cs
+++ b/src/Cores/Files/StrixMusic.Cores.LocalFiles/LocalFilesCore.cs
@@ -51,6 +51,7 @@ namespace StrixMusic.Cores.LocalFiles
         public LocalFilesCore(string instanceId, LocalFilesCoreSettings settings, IFileSystemService fileSystem, INotificationService notificationService, Progress<FileScanState>? fileScanProgress)
             : base(instanceId, fileScanProgress)
         {
+            Logo = new LogoImage(this);
             FileSystem = fileSystem;
             NotificationService = notificationService;
             Settings = settings;
@@ -75,21 +76,19 @@ namespace StrixMusic.Cores.LocalFiles
         }
 
         /// <inheritdoc/>
-        public override CoreMetadata Registration { get; } = Metadata;
+        public override string Id => nameof(LocalFilesCore);
+
+        /// <inheritdoc/>
+        public override string DisplayName => "Local Files";
+
+        /// <inheritdoc/>
+        public override ICoreImage? Logo { get; }
 
         /// <inheritdoc />
         public override AbstractUICollection AbstractConfigPanel => _configPanel;
 
         /// <inheritdoc />
         public override MediaPlayerType PlaybackType { get; } = MediaPlayerType.Standard;
-
-        /// <summary>
-        /// The metadata that identifies this core before instantiation.
-        /// </summary>
-        public static CoreMetadata Metadata { get; } = new CoreMetadata(Id: nameof(LocalFilesCore),
-                                                                        DisplayName: "Local Files",
-                                                                        LogoUri: new Uri("ms-appx:///Assets/Cores/LocalFiles/Logo.svg"),
-                                                                        SdkVer: typeof(ICore).Assembly.GetName().Version);
 
         /// <summary>
         /// The settings for this core instance.

--- a/src/Cores/Files/StrixMusic.Cores.LocalFiles/Logo.svg
+++ b/src/Cores/Files/StrixMusic.Cores.LocalFiles/Logo.svg
@@ -1,0 +1,15 @@
+<svg width="auto" height="auto" viewBox="0 0 65 85" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M43.8518 1H3.03226C1.90984 1 1 1.90984 1 3.03226V82.2903C1 83.4128 1.90984 84.3226 3.03226 84.3226H61.9678C63.0902 84.3226 64 83.4128 64 82.2903V21.1482C64 20.6093 63.7859 20.0924 63.4048 19.7112L45.2888 1.59525C44.9077 1.2141 44.3908 1 43.8518 1Z" fill="url(#paint0_linear)" stroke="#CCCCCC" stroke-width="0.555484" stroke-miterlimit="10"/>
+<path d="M43.6774 1V19.2903C43.6774 20.4127 44.5873 21.3226 45.7097 21.3226H64" fill="url(#paint1_linear)"/>
+<path d="M43.6774 1V19.2903C43.6774 20.4127 44.5873 21.3226 45.7097 21.3226H64" stroke="#CCCCCC" stroke-width="0.555484" stroke-miterlimit="10"/>
+<defs>
+<linearGradient id="paint0_linear" x1="64" y1="1" x2="-16.1688" y2="61.6155" gradientUnits="userSpaceOnUse">
+<stop stop-color="#9E18B4"/>
+<stop offset="1" stop-color="#B24FE3"/>
+</linearGradient>
+<linearGradient id="paint1_linear" x1="64" y1="1" x2="43.6774" y2="21.3226" gradientUnits="userSpaceOnUse">
+<stop stop-color="#9E18B4"/>
+<stop offset="1" stop-color="#B24FE3"/>
+</linearGradient>
+</defs>
+</svg>

--- a/src/Cores/Files/StrixMusic.Cores.LocalFiles/LogoImage.cs
+++ b/src/Cores/Files/StrixMusic.Cores.LocalFiles/LogoImage.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.IO;
+using System.Reflection;
+using System.Threading.Tasks;
+using StrixMusic.Sdk.CoreModels;
+
+namespace StrixMusic.Cores.LocalFiles
+{
+    public sealed class LogoImage : ICoreImage
+    {
+        public LogoImage(ICore sourceCore)
+        {
+            SourceCore = sourceCore;
+        }
+
+        public string? MimeType => "image/svg";
+
+        public double? Height => 85;
+
+        public double? Width => 65;
+
+        public ICore SourceCore { get; }
+
+        public ValueTask DisposeAsync() => throw new NotImplementedException();
+
+        public Task<Stream> OpenStreamAsync()
+        {
+            var assembly = Assembly.GetExecutingAssembly();
+
+            return Task.FromResult(assembly.GetManifestResourceStream("StrixMusic.Cores.LocalFiles.Logo.svg"));
+        }
+    }
+}

--- a/src/Cores/Files/StrixMusic.Cores.LocalFiles/StrixMusic.Cores.LocalFiles.csproj
+++ b/src/Cores/Files/StrixMusic.Cores.LocalFiles/StrixMusic.Cores.LocalFiles.csproj
@@ -9,6 +9,11 @@
   <ItemGroup>
     <None Remove="LICENSE" />
     <None Remove="LICENSE.LESSER" />
+    <None Remove="Logo.svg" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="Logo.svg" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Cores/Files/StrixMusic.Cores.OneDrive/Logo.svg
+++ b/src/Cores/Files/StrixMusic.Cores.OneDrive/Logo.svg
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 23.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" [
+	<!ENTITY ns_extend "http://ns.adobe.com/Extensibility/1.0/">
+	<!ENTITY ns_ai "http://ns.adobe.com/AdobeIllustrator/10.0/">
+	<!ENTITY ns_graphs "http://ns.adobe.com/Graphs/1.0/">
+	<!ENTITY ns_vars "http://ns.adobe.com/Variables/1.0/">
+	<!ENTITY ns_imrep "http://ns.adobe.com/ImageReplacement/1.0/">
+	<!ENTITY ns_sfw "http://ns.adobe.com/SaveForWeb/1.0/">
+	<!ENTITY ns_custom "http://ns.adobe.com/GenericCustomNamespace/1.0/">
+	<!ENTITY ns_adobe_xpath "http://ns.adobe.com/XPath/1.0/">
+]>
+<svg version="1.1" id="Livello_1" xmlns:x="&ns_extend;" xmlns:i="&ns_ai;" xmlns:graph="&ns_graphs;"
+	 xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 1030.04 659.922"
+	 enable-background="new 0 0 1030.04 659.922" xml:space="preserve">
+<metadata>
+	<sfw  xmlns="&ns_sfw;">
+		<slices></slices>
+		<sliceSourceBounds  bottomLeftOrigin="true" height="659.922" width="1030.04" x="-490" y="-344.922"></sliceSourceBounds>
+	</sfw>
+</metadata>
+<g id="STYLE_COLOR_1_">
+	<path fill="#0364B8" d="M622.292,445.338l212.613-203.327C790.741,69.804,615.338-33.996,443.13,10.168
+		C365.58,30.056,298.224,78.13,254.209,145.005C257.5,144.922,622.292,445.338,622.292,445.338z"/>
+	<path fill="#0078D4" d="M392.776,183.283l-0.01,0.035c-40.626-25.162-87.479-38.462-135.267-38.397
+		c-1.104,0-2.189,0.07-3.291,0.083C112.064,146.765-1.74,263.423,0.02,405.567c0.638,51.562,16.749,101.743,46.244,144.04
+		l318.528-39.894l244.209-196.915L392.776,183.283z"/>
+	<path fill="#1490DF" d="M834.905,242.012c-4.674-0.312-9.371-0.528-14.123-0.528c-28.523-0.028-56.749,5.798-82.93,17.117
+		l-0.006-0.022l-128.844,54.22l142.041,175.456l253.934,61.728c54.799-101.732,16.752-228.625-84.98-283.424
+		c-26.287-14.16-55.301-22.529-85.091-24.546V242.012z"/>
+	<path fill="#28A8EA" d="M46.264,549.607C94.359,618.756,173.27,659.966,257.5,659.922h563.281
+		c76.946,0.022,147.691-42.202,184.195-109.937L609.001,312.798L46.264,549.607z"/>
+</g>
+</svg>

--- a/src/Cores/Files/StrixMusic.Cores.OneDrive/LogoImage.cs
+++ b/src/Cores/Files/StrixMusic.Cores.OneDrive/LogoImage.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.IO;
+using System.Reflection;
+using System.Threading.Tasks;
+using StrixMusic.Sdk.CoreModels;
+
+namespace StrixMusic.Cores.OneDrive
+{
+    public sealed class LogoImage : ICoreImage
+    {
+        public LogoImage(ICore sourceCore)
+        {
+            SourceCore = sourceCore;
+        }
+
+        public string? MimeType => "image/svg";
+
+        public double? Height => 659.922;
+
+        public double? Width => 1030.04;
+
+        public ICore SourceCore { get; }
+
+        public ValueTask DisposeAsync() => throw new NotImplementedException();
+
+        public Task<Stream> OpenStreamAsync()
+        {
+            var assembly = Assembly.GetExecutingAssembly();
+
+            return Task.FromResult(assembly.GetManifestResourceStream("StrixMusic.Cores.OneDrive.Logo.svg"));
+        }
+    }
+}

--- a/src/Cores/Files/StrixMusic.Cores.OneDrive/OneDriveCore.cs
+++ b/src/Cores/Files/StrixMusic.Cores.OneDrive/OneDriveCore.cs
@@ -56,6 +56,7 @@ namespace StrixMusic.Cores.OneDrive
         public OneDriveCore(string instanceId, OneDriveCoreSettings settings, IFolderData metadataStorage, INotificationService notificationService, Progress<FileScanState>? fileScanProgress = null)
             : base(instanceId, fileScanProgress)
         {
+            Logo = new LogoImage(this);
             NotificationService = notificationService;
             _metadataStorage = metadataStorage;
             Settings = settings;
@@ -65,16 +66,6 @@ namespace StrixMusic.Cores.OneDrive
             _completeGenericSetupButton.Clicked += CompleteGenericSetupButton_Clicked;
         }
 
-        /// <inheritdoc/>
-        public override CoreMetadata Registration { get; } = Metadata;
-
-        /// <summary>
-        /// The metadata that identifies this core before instantiation.
-        /// </summary>
-        public static CoreMetadata Metadata { get; } = new CoreMetadata(Id: nameof(OneDriveCore),
-                                                                        DisplayName: "OneDrive",
-                                                                        LogoUri: new Uri("ms-appx:///Assets/Cores/OneDrive/Logo.svg"),
-                                                                        SdkVer: typeof(ICore).Assembly.GetName().Version);
         /// <inheritdoc/>
         public override string InstanceDescriptor { get; set; } = string.Empty;
 
@@ -100,6 +91,15 @@ namespace StrixMusic.Cores.OneDrive
         /// A service that can notify the user with interactive UI or messages.
         /// </summary>
         public INotificationService NotificationService { get; }
+
+        /// <inheritdoc/>
+        public override string Id => nameof(OneDriveCore);
+
+        /// <inheritdoc/>
+        public override string DisplayName => "OneDrive";
+
+        /// <inheritdoc/>
+        public override ICoreImage? Logo { get; }
 
         /// <summary>
         /// Raised when the user requests to visit an external web page for OneDrive login.
@@ -260,7 +260,7 @@ namespace StrixMusic.Cores.OneDrive
 
             if (ScannerWaitBehavior == ScannerWaitBehavior.WaitIfNoData)
             {
-                var itemCounts = await Task.WhenAll(FileMetadataManager.Tracks.GetItemCount(), FileMetadataManager.Albums.GetItemCount(), FileMetadataManager.AlbumArtists.GetItemCount(),FileMetadataManager.TrackArtists.GetItemCount(), FileMetadataManager.Playlists.GetItemCount());
+                var itemCounts = await Task.WhenAll(FileMetadataManager.Tracks.GetItemCount(), FileMetadataManager.Albums.GetItemCount(), FileMetadataManager.AlbumArtists.GetItemCount(), FileMetadataManager.TrackArtists.GetItemCount(), FileMetadataManager.Playlists.GetItemCount());
 
                 if (itemCounts.Sum() == 0)
                     await scannerTask;

--- a/src/Cores/Files/StrixMusic.Cores.OneDrive/StrixMusic.Cores.OneDrive.csproj
+++ b/src/Cores/Files/StrixMusic.Cores.OneDrive/StrixMusic.Cores.OneDrive.csproj
@@ -9,6 +9,11 @@
   <ItemGroup>
     <None Remove="LICENSE" />
     <None Remove="LICENSE.LESSER" />
+    <None Remove="Logo.svg" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="Logo.svg" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Sdk/StrixMusic.Sdk.Tests/Mock/Core/MockCore.cs
+++ b/src/Sdk/StrixMusic.Sdk.Tests/Mock/Core/MockCore.cs
@@ -56,11 +56,8 @@ namespace StrixMusic.Sdk.Tests.Mock.Core
         public event EventHandler? AbstractConfigPanelChanged;
 
         public event EventHandler<string>? InstanceDescriptorChanged;
-
-        public CoreMetadata Registration { get; } = new CoreMetadata(Id: nameof(MockCore),
-                                                                     DisplayName: "Mock core",
-                                                                     LogoUri: new Uri("https://strixmusic.com/"),
-                                                                     SdkVer: typeof(ICore).Assembly.GetName().Version ?? throw new ArgumentNullException());
+        public event EventHandler<ICoreImage?>? LogoChanged;
+        public event EventHandler<string>? DisplayNameChanged;
 
         public string InstanceId { get; set; }
 
@@ -105,6 +102,12 @@ namespace StrixMusic.Sdk.Tests.Mock.Core
         }
 
         public ICore SourceCore { get; set; }
+
+        public string Id => throw new NotImplementedException();
+
+        public string DisplayName => throw new NotImplementedException();
+
+        public ICoreImage? Logo => throw new NotImplementedException();
 
         public Task<ICoreModel?> GetContextByIdAsync(string id, CancellationToken cancellationToken = default)
         {

--- a/src/Sdk/StrixMusic.Sdk/AdapterModels/MergedCore.cs
+++ b/src/Sdk/StrixMusic.Sdk/AdapterModels/MergedCore.cs
@@ -39,9 +39,6 @@ namespace StrixMusic.Sdk.AdapterModels
             _sources = cores.ToList();
             Guard.HasSizeGreaterThan(_sources, 0, nameof(_sources));
 
-            foreach (var core in _sources)
-                CheckSdkVersion(core.Registration);
-
             MergeConfig = config;
 
             _library = new MergedLibrary(_sources.Select(x => x.Library), config);
@@ -193,8 +190,6 @@ namespace StrixMusic.Sdk.AdapterModels
             if (_sources.Contains(itemToMerge))
                 ThrowHelper.ThrowArgumentException(nameof(itemToMerge), "Cannot add the same source twice.");
 
-            CheckSdkVersion(itemToMerge.Registration);
-
             _devices.AddRange(itemToMerge.Devices.Select(x => new DeviceAdapter(x)));
             _library.AddSource(itemToMerge.Library);
 
@@ -307,13 +302,6 @@ namespace StrixMusic.Sdk.AdapterModels
             }
 
             IsInitialized = false;
-        }
-
-        private void CheckSdkVersion(CoreMetadata coreMetadata)
-        {
-            var currentSdkVersion = typeof(ICore).Assembly.GetName().Version;
-            if (coreMetadata.SdkVer != currentSdkVersion)
-                throw new IncompatibleSdkVersionException(coreMetadata.SdkVer, coreMetadata.DisplayName);
         }
     }
 }

--- a/src/Sdk/StrixMusic.Sdk/CoreModels/ICore.cs
+++ b/src/Sdk/StrixMusic.Sdk/CoreModels/ICore.cs
@@ -27,19 +27,29 @@ namespace StrixMusic.Sdk.CoreModels
     public interface ICore : IAsyncInit, ICoreModel, IAsyncDisposable
     {
         /// <summary>
-        /// The registered metadata for this core. Contains information to identify the core before creating an instance.
+        /// A unique identifier for this core, identical across all instances.
         /// </summary>
-        public CoreMetadata Registration { get; }
+        public string Id { get; }
 
         /// <summary>
-        /// Identifies this instance of the core. This is given to each core via the constructor.
+        /// Uniquely identifies this instance.
         /// </summary>
         public string InstanceId { get; }
 
         /// <summary>
-        /// A string of text to display to the user to help identify which core instance this is, such as a username or the path to a file location. Longer strings will be truncated as needed.
+        /// A supplementary description that helps identify which core instance this is, such as a username or the path to a file location.
         /// </summary>
         public string InstanceDescriptor { get; }
+
+        /// <summary>
+        /// The user-friendly name of the core.
+        /// </summary>
+        public string DisplayName { get; }
+
+        /// <summary>
+        /// A logo for this core, if any.
+        /// </summary>
+        public ICoreImage? Logo { get; }
 
         /// <summary>
         /// Abstract UI elements that will be presented to the user for Settings, About, Legal notices, Donation links, etc.
@@ -116,6 +126,11 @@ namespace StrixMusic.Sdk.CoreModels
         public Task<IMediaSourceConfig?> GetMediaSourceAsync(ICoreTrack track, CancellationToken cancellationToken = default);
 
         /// <summary>
+        /// Raised when the <see cref="Logo"/> is changed.
+        /// </summary>
+        public event EventHandler<ICoreImage?>? LogoChanged;
+
+        /// <summary>
         /// Raised when the <see cref="AppModels.CoreState"/> has changed.
         /// </summary>
         public event EventHandler<CoreState>? CoreStateChanged;
@@ -129,6 +144,11 @@ namespace StrixMusic.Sdk.CoreModels
         /// Raised when <see cref="AbstractUIElement"/> is changed.
         /// </summary>
         public event EventHandler? AbstractConfigPanelChanged;
+
+        /// <summary>
+        /// Raised when <see cref="DisplayName"/> is changed.
+        /// </summary>
+        public event EventHandler<string>? DisplayNameChanged;
 
         /// <summary>
         /// Raised when <see cref="InstanceDescriptor"/> is changed.

--- a/src/Shared/AppLoadingView.xaml
+++ b/src/Shared/AppLoadingView.xaml
@@ -54,11 +54,7 @@
                 <GridView.ItemTemplate>
                     <DataTemplate x:DataType="viewModels:CoreViewModel">
                         <StackPanel Spacing="8" Width="75">
-                            <Image Height="50" Width="50" HorizontalAlignment="Center">
-                                <Image.Source>
-                                    <SvgImageSource UriSource="{x:Bind LogoUri, Mode=OneWay}"/>
-                                </Image.Source>
-                            </Image>
+                            <controls:CoreImage Image="{x:Bind Logo, Mode=OneWay}" Height="50" Width="50" HorizontalAlignment="Center" />
 
                             <TextBlock Text="{x:Bind CoreState, Mode=OneWay}" HorizontalAlignment="Center" Foreground="White" />
                         </StackPanel>

--- a/src/Shared/AppLoadingView.xaml.cs
+++ b/src/Shared/AppLoadingView.xaml.cs
@@ -156,7 +156,7 @@ namespace StrixMusic.Shared
             {
                 if (cores.FirstOrDefault(x => x.InstanceId == entry.Key) is not ICore core)
                 {
-                    Logger.LogInformation($"Creating core with instanceId {entry.Key}, display name {entry.Value.DisplayName}, id {entry.Value.Id}");
+                    Logger.LogInformation($"Creating core with instanceId {entry.Key} id {entry.Value.Id}");
                     core = await CoreRegistry.CreateCoreAsync(entry.Value.Id, entry.Key);
                     cores.Add(core);
                 }
@@ -371,7 +371,7 @@ namespace StrixMusic.Shared
         {
             CoreRegistry.CoreRegistered += OnCoreRegistered;
 
-            CoreRegistry.Register(LocalFilesCore.Metadata, async instanceId =>
+            CoreRegistry.Register(new CoreMetadata(nameof(LocalFilesCore), "Local Files") { Logo = new Cores.LocalFiles.LogoImage(null!) }, async instanceId =>
             {
                 var coreFolder = await ApplicationData.Current.LocalFolder.CreateFolderAsync("Cores", Windows.Storage.CreationCollisionOption.OpenIfExists);
                 var coreInstanceFolder = await coreFolder.CreateFolderAsync(instanceId, Windows.Storage.CreationCollisionOption.OpenIfExists);
@@ -382,7 +382,7 @@ namespace StrixMusic.Shared
                 };
             });
 
-            CoreRegistry.Register(OneDriveCore.Metadata, async instanceId =>
+            CoreRegistry.Register(new CoreMetadata(nameof(OneDriveCore), "OneDrive") { Logo = new Cores.OneDrive.LogoImage(null!) }, async instanceId =>
             {
                 var coreFolder = await ApplicationData.Current.LocalFolder.CreateFolderAsync("Cores", Windows.Storage.CreationCollisionOption.OpenIfExists);
                 var coreInstanceFolder = await coreFolder.CreateFolderAsync(instanceId, Windows.Storage.CreationCollisionOption.OpenIfExists);
@@ -431,7 +431,7 @@ namespace StrixMusic.Shared
                 ThrowHelper.ThrowInvalidOperationException($"{nameof(CoreRegistry.MetadataRegistry)} contains no elements after registry initialization. App cannot function without at least 1 core.");
 
             CoreRegistry.CoreRegistered -= OnCoreRegistered;
-            void OnCoreRegistered(object? sender, CoreMetadata metadata) => Logger.LogInformation($"Core registered. Id {metadata.Id}, Display name {metadata.DisplayName}");
+            void OnCoreRegistered(object? sender, CoreMetadata metadata) => Logger.LogInformation($"Core registered. Id {metadata.Id}");
         }
 
         private void FilesCoreProgressChanged(string instanceId, FileScanState state)

--- a/src/Shared/Controls/CoreImage.xaml
+++ b/src/Shared/Controls/CoreImage.xaml
@@ -1,0 +1,13 @@
+﻿<UserControl
+    x:Class="StrixMusic.Controls.CoreImage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:StrixMusic.Controls"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    d:DesignHeight="300"
+    d:DesignWidth="400">
+
+    <Image Source="{x:Bind Source, Mode=OneWay}" />
+</UserControl>

--- a/src/Shared/Controls/CoreImage.xaml.cs
+++ b/src/Shared/Controls/CoreImage.xaml.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.IO;
+using System.Threading.Tasks;
+using StrixMusic.Sdk.CoreModels;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Media.Imaging;
+
+namespace StrixMusic.Controls
+{
+    /// <summary>
+    /// Displays the provided instance of <see cref="ICoreImage"/>.
+    /// </summary>
+    public sealed partial class CoreImage : UserControl
+    {
+        /// <summary>
+        /// Creates a new instance of <see cref="CoreImage"/>.
+        /// </summary>
+        public CoreImage()
+        {
+            this.InitializeComponent();
+        }
+
+        /// <summary>
+        /// The image source.
+        /// </summary>
+        public ImageSource? Source => (ImageSource)GetValue(SourceProperty);
+
+        /// <summary>
+        /// The backing dependency property for <see cref="Source"/>.
+        /// </summary>
+        public static readonly DependencyProperty SourceProperty =
+            DependencyProperty.Register(nameof(Source), typeof(ImageSource), typeof(CoreImage), new PropertyMetadata(null));
+
+        /// <summary>
+        /// The image to display.
+        /// </summary>
+        public ICoreImage? Image
+        {
+            get => (ICoreImage)GetValue(ImageProperty);
+            set => SetValue(ImageProperty, value);
+        }
+
+        /// <summary>
+        /// The backing dependency property for <see cref="Image"/>.
+        /// </summary>
+        public static readonly DependencyProperty ImageProperty =
+            DependencyProperty.Register(nameof(Image), typeof(ICoreImage), typeof(CoreImage), new PropertyMetadata(null, (d, e) => _ = ((CoreImage)d).OnImageChanged(e.OldValue as ICoreImage, e.NewValue as ICoreImage)));
+
+        private async Task OnImageChanged(ICoreImage? oldValue, ICoreImage? newValue)
+        {
+            if (newValue is null)
+                return;
+
+            using var stream = await newValue.OpenStreamAsync();
+
+            if (newValue.MimeType?.Contains("svg") ?? false)
+            {
+                var imageSource = new SvgImageSource();
+
+                if (newValue.Height is not null)
+                    imageSource.RasterizePixelHeight = (double)newValue.Height;
+
+                if (newValue.Width is not null)
+                    imageSource.RasterizePixelWidth = (double)newValue.Width;
+                
+                await imageSource.SetSourceAsync(stream.AsRandomAccessStream());
+
+                SetValue(SourceProperty, imageSource);
+            }
+            else
+            {
+                var imageSource = new BitmapImage();
+                await imageSource.SetSourceAsync(stream.AsRandomAccessStream());
+
+                SetValue(SourceProperty, imageSource);
+            }
+        }
+    }
+}

--- a/src/Shared/Services/CoreMetadata.cs
+++ b/src/Shared/Services/CoreMetadata.cs
@@ -11,8 +11,12 @@ namespace StrixMusic.Sdk.CoreModels
     /// Contains metadata for a registered core. Used to identify a core before instantiation.
     /// </summary>
     /// <param name="Id">A unique identifier for this core, across all instances.</param>
-    /// <param name="DisplayName">The user-friendly name of the core.</param>
-    /// <param name="LogoUri">A relative path pointing to a SVG file containing the logo for this core.</param>
-    /// <param name="SdkVer">The version of the Strix Music SDK that this core was built against.</param>
-    public record CoreMetadata(string Id, string DisplayName, Uri LogoUri, Version SdkVer);
+    public record CoreMetadata(string Id, string DisplayName)
+    {
+        /// <summary>
+        /// The logo for this core, if known.
+        /// </summary>
+        [JsonIgnore]
+        public ICoreImage? Logo { get; set; }
+    }
 }

--- a/src/Shared/StrixMusic.Shared.projitems
+++ b/src/Shared/StrixMusic.Shared.projitems
@@ -22,6 +22,9 @@
       <DependentUpon>AppFrame.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Controls\AdvancedAppSettingsPanel.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Controls\CoreImage.xaml.cs">
+      <DependentUpon>CoreImage.xaml</DependentUpon>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Controls\LoggingSettingsPanel.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Controls\RecoverySettingsPanel.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Controls\StrixIcon.xaml.cs">
@@ -48,6 +51,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Services\CoreManagement\ICoreManagementService.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Services\AppSettingsSerializer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Services\AppSettingsSerializerContext.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Services\CoreMetadata.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Services\FileSystemService.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Services\AppSettings.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Services\SystemMediaTransportControlsHandler.cs" />
@@ -72,6 +76,10 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="$(MSBuildThisFileDirectory)AppLoadingView.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Controls\CoreImage.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/src/Shared/Styles/CoreItemStyle.xaml
+++ b/src/Shared/Styles/CoreItemStyle.xaml
@@ -5,6 +5,7 @@
     xmlns:viewModels1="using:StrixMusic.Shared.ViewModels"
     xmlns:interactivity="using:Microsoft.Xaml.Interactivity"
     xmlns:core="using:Microsoft.Xaml.Interactions.Core"
+    xmlns:controls="using:StrixMusic.Controls"
     x:Class="StrixMusic.Shared.Styles.CoreItemStyle">
 
     <ResourceDictionary.ThemeDictionaries>
@@ -47,12 +48,8 @@
                             <core:InvokeCommandAction Command="{x:Bind CreateCoreInstanceCommand}" />
                         </core:EventTriggerBehavior>
                     </interactivity:Interaction.Behaviors>
-                    
-                    <Image Height="50" Width="50" Margin="0,0,0,40">
-                        <Image.Source>
-                            <SvgImageSource UriSource="{x:Bind Metadata.LogoUri}" />
-                        </Image.Source>
-                    </Image>
+
+                    <controls:CoreImage Image="{x:Bind Metadata.Logo, Mode=OneWay}" Height="50" Width="50" Margin="0,0,0,40"/>
 
                     <TextBlock Text="{x:Bind Metadata.DisplayName}" FontSize="18" FontWeight="SemiBold" HorizontalAlignment="Center" VerticalAlignment="Bottom" 
                                Margin="0,0,0,40" />
@@ -70,11 +67,7 @@
 
             <Border BorderBrush="{ThemeResource CoreItemBorderBrush}" BorderThickness="2,2,2,1" CornerRadius="3,3,0,0">
                 <Grid>
-                    <Image Height="50" Width="50" Margin="0,0,0,40">
-                        <Image.Source>
-                            <SvgImageSource UriSource="{x:Bind Core.LogoUri, Mode=OneWay}" />
-                        </Image.Source>
-                    </Image>
+                    <controls:CoreImage Image="{x:Bind Core.Logo, Mode=OneWay}" Height="50" Width="50" Margin="0,0,0,40" />
 
                     <StackPanel VerticalAlignment="Bottom" Margin="10,13" Spacing="2">
                         <TextBlock Text="{x:Bind Core.DisplayName}" FontSize="18" FontWeight="SemiBold" HorizontalAlignment="Center" />


### PR DESCRIPTION
<!--
To categorize this PR in the generated changelog, include one of the following in the PR title: 
[breaking], [fix], [improvement], [new], [refactor], [cleanup]
-->

## Overview
<!-- Replace with the issue number. This will auto-close the issue once the PR is merged. If no issue exists, open one first. -->
Closes #221 

<!-- Add a brief overview here of the change. -->
This PR 
- Adds a nullable `Logo` property of type `ICoreImage` to `ICore`, replacing the `LogoUri` that was on registration.
- Moved Id and DisplayName onto `ICore`.
- Removed the `SdkVer` property. We have no solid plans for this property, so we're removing it. It may be added back in the future.
- Fully removed `StrixMusic.Sdk.CoreModels.CoreMetadata` from the SDK. A copy has been moved to App-level code to maintain functionality while preparing for further refactors.
<!-- Include screenshots or a short video demonstrating the change, if possible -->

## Checklist
<!-- Note: Changes to the Sdk MUST be accompanied by unit tests, even if there were none before. -->
This PR meets the following requirements:
- [x] Tested and contains **NO** breaking changes or known regressions.
- [x] Tested with the upstream branch merged in.
- [x] Tests have been added for bug fixes / features (or this option is not applicable)
- [x] All new code has been documented (or this option is not applicable)
- [x] Headers have been added to all new source files (or this option is not applicable)

<!-- 
Is this a breaking change?
Please describe the impact and migration path for existing applications below.
-->

## Additional info
<!--
Please add any other information that might be helpful to reviewers.
-->

Not provided
