### PR TITLE
[fix] Fixed Zune Desktop shell crashing when debugger isn't attached

### DIFF
--- a/src/Shells/StrixMusic.Shells.ZuneDesktop/Styles/Collections/TrackTableStyle.xaml
+++ b/src/Shells/StrixMusic.Shells.ZuneDesktop/Styles/Collections/TrackTableStyle.xaml
@@ -2,7 +2,7 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:tkcontrols="using:Microsoft.Toolkit.Uwp.UI.Controls"
-    xmlns:collections="using:StrixMusic.Sdk.WinUI.Controls.Collections"
+    xmlns:collections="using:StrixMusic.Shells.ZuneDesktop.Controls.Views.Collection"
     xmlns:items="using:StrixMusic.Sdk.WinUI.Controls.Items"
     xmlns:viewModels="using:StrixMusic.Sdk.ViewModels"
     xmlns:convert="using:StrixMusic.Shells.ZuneDesktop.Converters.TrackTable"
@@ -114,11 +114,11 @@
         </Grid>
     </DataTemplate>
 
-    <Style x:Key="ZuneDesktopTrackTableControlStyle" TargetType="collections:TrackCollection">
+    <Style x:Key="ZuneDesktopTrackTableControlStyle" TargetType="collections:ZuneTrackCollection">
         <Style.Setters>
             <Setter Property="Template">
                 <Setter.Value>
-                    <ControlTemplate TargetType="collections:TrackCollection">
+                    <ControlTemplate TargetType="collections:ZuneTrackCollection">
                         <ContentControl ContentTemplate="{StaticResource ZuneDesktopTrackTableTemplate}"
                                         HorizontalContentAlignment="Stretch" VerticalContentAlignment="Stretch" />
                     </ControlTemplate>


### PR DESCRIPTION
<!--
To categorize this PR in the generated changelog, include one of the following in the PR title: 
[breaking], [fix], [improvement], [new], [refactor], [cleanup]
-->

## Overview
<!-- Replace with the issue number. This will auto-close the issue once the PR is merged. If no issue exists, open one first. -->
Closes N/A (No issue was filed for this)

There was a crash on zune shell where it was consistently crashing without the debugger attached.


https://user-images.githubusercontent.com/15306909/184946863-7ffb6a9e-e358-4ebd-aeaf-5a5569cee060.mp4

## Checklist
<!-- Note: Changes to the Sdk MUST be accompanied by unit tests, even if there were none before. -->
This PR meets the following requirements:
- [x] Tested and contains **NO** breaking changes or known regressions.
- [x] Tested with the upstream branch merged in.
- [x] Tests have been added for bug fixes / features (or this option is not applicable)
- [x] All new code has been documented (or this option is not applicable)
- [x] Headers have been added to all new source files (or this option is not applicable)

<!-- 
Is this a breaking change?
Please describe the impact and migration path for existing applications below.
-->

## Additional info


Not provided
