### PR TITLE
[breaking] Removed IAsyncDisposable from all SDK models except ICore and IStrixDataRoot

### DIFF
--- a/src/Cores/Files/StrixMusic.Cores.Files/FilesCore.cs
+++ b/src/Cores/Files/StrixMusic.Cores.Files/FilesCore.cs
@@ -122,8 +122,9 @@ namespace StrixMusic.Cores.Files
         /// <inheritdoc/>
         public virtual ValueTask DisposeAsync()
         {
-            // Dispose any resources not known to the SDK.
-            // Do not dispose Library, Devices, etc. manually. The SDK will dispose these for you.
+            if (FileMetadataManager is not null)
+                return FileMetadataManager.DisposeAsync();
+
             return default;
         }
 

--- a/src/Cores/Files/StrixMusic.Cores.Files/Models/FilesCoreAlbum.cs
+++ b/src/Cores/Files/StrixMusic.Cores.Files/Models/FilesCoreAlbum.cs
@@ -595,12 +595,5 @@ namespace StrixMusic.Cores.Files.Models
 
             await Task.CompletedTask;
         }
-
-        /// <inheritdoc />
-        public ValueTask DisposeAsync()
-        {
-            DetachEvents();
-            return default;
-        }
     }
 }

--- a/src/Cores/Files/StrixMusic.Cores.Files/Models/FilesCoreArtist.cs
+++ b/src/Cores/Files/StrixMusic.Cores.Files/Models/FilesCoreArtist.cs
@@ -562,12 +562,5 @@ namespace StrixMusic.Cores.Files.Models
 
             await Task.CompletedTask;
         }
-
-        /// <inheritdoc />
-        public ValueTask DisposeAsync()
-        {
-            DetachEvents();
-            return default;
-        }
     }
 }

--- a/src/Cores/Files/StrixMusic.Cores.Files/Models/FilesCoreGenre.cs
+++ b/src/Cores/Files/StrixMusic.Cores.Files/Models/FilesCoreGenre.cs
@@ -22,11 +22,5 @@ namespace StrixMusic.Cores.Files.Models
 
         /// <inheritdoc/>
         public ICore SourceCore { get; }
-
-        /// <inheritdoc/>
-        public ValueTask DisposeAsync()
-        {
-            return default;
-        }
     }
 }

--- a/src/Cores/Files/StrixMusic.Cores.Files/Models/FilesCoreImage.cs
+++ b/src/Cores/Files/StrixMusic.Cores.Files/Models/FilesCoreImage.cs
@@ -51,8 +51,5 @@ namespace StrixMusic.Cores.Files.Models
 
         /// <inheritdoc />
         public double? Width { get; }
-
-        /// <inheritdoc />
-        public ValueTask DisposeAsync() => default;
     }
 }

--- a/src/Cores/Files/StrixMusic.Cores.Files/Models/FilesCoreLibrary.cs
+++ b/src/Cores/Files/StrixMusic.Cores.Files/Models/FilesCoreLibrary.cs
@@ -376,26 +376,5 @@ namespace StrixMusic.Cores.Files.Models
         {
             return AsyncEnumerable.Empty<ICoreUrl>();
         }
-
-        /// <inheritdoc/>
-        public override async ValueTask DisposeAsync()
-        {
-            if (!IsInitialized)
-                return;
-
-            using (await OwlCore.Flow.EasySemaphore(_initSemaphore))
-            {
-                if (!IsInitialized)
-                    return;
-
-                if (_fileMetadataManager is not null)
-                    DetachEvents(_fileMetadataManager);
-
-                DetachEvents();
-                await base.DisposeAsync();
-
-                IsInitialized = false;
-            }
-        }
     }
 }

--- a/src/Cores/Files/StrixMusic.Cores.Files/Models/FilesCorePlayableCollectionGroupBase.cs
+++ b/src/Cores/Files/StrixMusic.Cores.Files/Models/FilesCorePlayableCollectionGroupBase.cs
@@ -557,11 +557,5 @@ namespace StrixMusic.Cores.Files.Models
         {
             throw new NotSupportedException();
         }
-
-        /// <inheritdoc />
-        public virtual ValueTask DisposeAsync()
-        {
-            return default;
-        }
     }
 }

--- a/src/Cores/Files/StrixMusic.Cores.Files/Models/FilesCorePlaylist.cs
+++ b/src/Cores/Files/StrixMusic.Cores.Files/Models/FilesCorePlaylist.cs
@@ -319,12 +319,5 @@ namespace StrixMusic.Cores.Files.Models
                     TracksCountChanged?.Invoke(this, metadata.TrackIds?.Count ?? 0);
             }
         }
-
-        /// <inheritdoc />
-        public ValueTask DisposeAsync()
-        {
-            DetachEvents();
-            return default;
-        }
     }
 }

--- a/src/Cores/Files/StrixMusic.Cores.Files/Models/FilesCoreTrack.cs
+++ b/src/Cores/Files/StrixMusic.Cores.Files/Models/FilesCoreTrack.cs
@@ -546,12 +546,5 @@ namespace StrixMusic.Cores.Files.Models
         {
             return AsyncEnumerable.Empty<ICoreUrl>();
         }
-
-        /// <inheritdoc />
-        public ValueTask DisposeAsync()
-        {
-            DetachEvents();
-            return default;
-        }
     }
 }

--- a/src/Cores/Files/StrixMusic.Cores.LocalFiles/LocalFilesCore.cs
+++ b/src/Cores/Files/StrixMusic.Cores.LocalFiles/LocalFilesCore.cs
@@ -118,15 +118,10 @@ namespace StrixMusic.Cores.LocalFiles
         /// <inheritdoc/>
         public override ValueTask DisposeAsync()
         {
-            // Dispose any resources not known to the SDK.
-            // Do not dispose Library, Devices, etc. manually. The SDK will dispose these for you.
-            FileMetadataManager?.DisposeAsync();
-
             _configPanel.ConfigDoneButton.Clicked -= ConfigDoneButtonOnClicked;
 
             DetachEvents();
-
-            return default;
+            return base.DisposeAsync();
         }
 
         /// <inheritdoc />

--- a/src/Cores/Files/StrixMusic.Cores.LocalFiles/LogoImage.cs
+++ b/src/Cores/Files/StrixMusic.Cores.LocalFiles/LogoImage.cs
@@ -21,8 +21,6 @@ namespace StrixMusic.Cores.LocalFiles
 
         public ICore SourceCore { get; }
 
-        public ValueTask DisposeAsync() => throw new NotImplementedException();
-
         public Task<Stream> OpenStreamAsync()
         {
             var assembly = Assembly.GetExecutingAssembly();

--- a/src/Cores/Files/StrixMusic.Cores.OneDrive/LogoImage.cs
+++ b/src/Cores/Files/StrixMusic.Cores.OneDrive/LogoImage.cs
@@ -21,8 +21,6 @@ namespace StrixMusic.Cores.OneDrive
 
         public ICore SourceCore { get; }
 
-        public ValueTask DisposeAsync() => throw new NotImplementedException();
-
         public Task<Stream> OpenStreamAsync()
         {
             var assembly = Assembly.GetExecutingAssembly();

--- a/src/Sdk/StrixMusic.Sdk.Tests/AssemblyInfo.cs
+++ b/src/Sdk/StrixMusic.Sdk.Tests/AssemblyInfo.cs
@@ -1,3 +1,3 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-[assembly: Parallelize(Scope = ExecutionScope.MethodLevel, Workers = 1)]
+[assembly: Parallelize(Scope = ExecutionScope.MethodLevel, Workers = 8)]

--- a/src/Sdk/StrixMusic.Sdk.Tests/AssemblyInfo.cs
+++ b/src/Sdk/StrixMusic.Sdk.Tests/AssemblyInfo.cs
@@ -1,3 +1,3 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-[assembly: Parallelize(Scope = ExecutionScope.MethodLevel, Workers = 8)]
+[assembly: Parallelize(Scope = ExecutionScope.MethodLevel, Workers = 1)]

--- a/src/Sdk/StrixMusic.Sdk.Tests/Mock/AppModels/MockGenre.cs
+++ b/src/Sdk/StrixMusic.Sdk.Tests/Mock/AppModels/MockGenre.cs
@@ -8,8 +8,6 @@ namespace StrixMusic.Sdk.Tests.Mock.AppModels;
 
 public class MockGenre : IGenre
 {
-    public ValueTask DisposeAsync() => default;
-
     public string Name { get; } = Guid.NewGuid().ToString();
 
     public bool Equals(ICoreGenre? other) => false;

--- a/src/Sdk/StrixMusic.Sdk.Tests/Mock/AppModels/MockImage.cs
+++ b/src/Sdk/StrixMusic.Sdk.Tests/Mock/AppModels/MockImage.cs
@@ -9,8 +9,6 @@ namespace StrixMusic.Sdk.Tests.Mock.AppModels;
 
 public class MockImage : IImage
 {
-    public ValueTask DisposeAsync()  => default;
-
     public Task<Stream> OpenStreamAsync() => Task.FromResult<Stream>(new MemoryStream());
 
     public string? MimeType => null;

--- a/src/Sdk/StrixMusic.Sdk.Tests/Mock/AppModels/MockPlayableCollectionGroup.cs
+++ b/src/Sdk/StrixMusic.Sdk.Tests/Mock/AppModels/MockPlayableCollectionGroup.cs
@@ -837,8 +837,5 @@ public class MockPlayableCollectionGroup : IPlayableCollectionGroup
     /// <inheritdoc/>
     public bool Equals(ICorePlayableCollectionGroup? other) => false;
 
-    /// <inheritdoc/>
-    public ValueTask DisposeAsync() => default;
-
     public event EventHandler? SourcesChanged;
 }

--- a/src/Sdk/StrixMusic.Sdk.Tests/Mock/AppModels/MockSearch.cs
+++ b/src/Sdk/StrixMusic.Sdk.Tests/Mock/AppModels/MockSearch.cs
@@ -10,8 +10,6 @@ namespace StrixMusic.Sdk.Tests.Mock.AppModels;
 
 public class MockSearch : ISearch
 {
-    public ValueTask DisposeAsync() => default;
-
     public IAsyncEnumerable<string> GetSearchAutoCompleteAsync(string query, CancellationToken cancellationToken = default) => AsyncEnumerable.Empty<string>();
 
     public bool Equals(ICoreSearch? other) => false;

--- a/src/Sdk/StrixMusic.Sdk.Tests/Mock/AppModels/MockUrl.cs
+++ b/src/Sdk/StrixMusic.Sdk.Tests/Mock/AppModels/MockUrl.cs
@@ -8,8 +8,6 @@ namespace StrixMusic.Sdk.Tests.Mock.AppModels;
 
 public class MockUrl : IUrl
 {
-    public ValueTask DisposeAsync() => default;
-
     public string Label => string.Empty;
 
     public Uri Url => new("/");

--- a/src/Sdk/StrixMusic.Sdk.Tests/Mock/Core/Items/MockCoreAlbum.cs
+++ b/src/Sdk/StrixMusic.Sdk.Tests/Mock/Core/Items/MockCoreAlbum.cs
@@ -135,11 +135,6 @@ namespace StrixMusic.Sdk.Tests.Mock.Core.Items
             throw new NotImplementedException();
         }
 
-        public ValueTask DisposeAsync()
-        {
-            throw new NotImplementedException();
-        }
-
         public async IAsyncEnumerable<ICoreArtistCollectionItem> GetArtistItemsAsync(int limit, int offset, [EnumeratorCancellation] CancellationToken cancellationToken = default)
         {
             await Task.CompletedTask;

--- a/src/Sdk/StrixMusic.Sdk.Tests/Mock/Core/Items/MockCoreArtist.cs
+++ b/src/Sdk/StrixMusic.Sdk.Tests/Mock/Core/Items/MockCoreArtist.cs
@@ -124,11 +124,6 @@ namespace StrixMusic.Sdk.Tests.Mock.Core.Items
             throw new NotImplementedException();
         }
 
-        public ValueTask DisposeAsync()
-        {
-            throw new NotImplementedException();
-        }
-
         public async IAsyncEnumerable<ICoreAlbumCollectionItem> GetAlbumItemsAsync(int limit, int offset, [EnumeratorCancellation] CancellationToken cancellationToken = default)
         {
             await Task.CompletedTask;

--- a/src/Sdk/StrixMusic.Sdk.Tests/Mock/Core/Items/MockCoreImage.cs
+++ b/src/Sdk/StrixMusic.Sdk.Tests/Mock/Core/Items/MockCoreImage.cs
@@ -20,10 +20,5 @@ namespace StrixMusic.Sdk.Tests.Mock.Core.Items
         public double? Width { get; set; }
 
         public ICore SourceCore { get; set; }
-
-        public ValueTask DisposeAsync()
-        {
-            return default;
-        }
     }
 }

--- a/src/Sdk/StrixMusic.Sdk.Tests/Mock/Core/Items/MockCorePlaylist.cs
+++ b/src/Sdk/StrixMusic.Sdk.Tests/Mock/Core/Items/MockCorePlaylist.cs
@@ -100,11 +100,6 @@ namespace StrixMusic.Sdk.Tests.Mock.Core.Items
             throw new NotImplementedException();
         }
 
-        public ValueTask DisposeAsync()
-        {
-            throw new NotImplementedException();
-        }
-
         public IAsyncEnumerable<ICoreImage> GetImagesAsync(int limit, int offset, CancellationToken cancellationToken = default)
         {
             throw new NotImplementedException();

--- a/src/Sdk/StrixMusic.Sdk.Tests/Mock/Core/Items/MockCoreTrack.cs
+++ b/src/Sdk/StrixMusic.Sdk.Tests/Mock/Core/Items/MockCoreTrack.cs
@@ -185,11 +185,6 @@ namespace StrixMusic.Sdk.Tests.Mock.Core.Items
             throw new NotImplementedException();
         }
 
-        public ValueTask DisposeAsync()
-        {
-            throw new NotImplementedException();
-        }
-
         public IAsyncEnumerable<ICoreArtistCollectionItem> GetArtistItemsAsync(int limit, int offset, CancellationToken cancellationToken = default)
         {
             throw new NotImplementedException();

--- a/src/Sdk/StrixMusic.Sdk.Tests/Mock/Core/Items/MockCoreUrl.cs
+++ b/src/Sdk/StrixMusic.Sdk.Tests/Mock/Core/Items/MockCoreUrl.cs
@@ -21,10 +21,5 @@ namespace StrixMusic.Sdk.Tests.Mock.Core.Items
         public UrlType Type { get; set; }
 
         public ICore SourceCore { get; set; }
-
-        public ValueTask DisposeAsync()
-        {
-            return default;
-        }
     }
 }

--- a/src/Sdk/StrixMusic.Sdk.Tests/Mock/Core/MockCore.cs
+++ b/src/Sdk/StrixMusic.Sdk.Tests/Mock/Core/MockCore.cs
@@ -154,10 +154,5 @@ namespace StrixMusic.Sdk.Tests.Mock.Core
                 new List<CollectionChangedItem<ICoreDevice>>(),
                 new CollectionChangedItem<ICoreDevice>(device, 0).IntoList());
         }
-
-        public ValueTask DisposeAsync()
-        {
-            return default;
-        }
     }
 }

--- a/src/Sdk/StrixMusic.Sdk.Tests/Mock/Core/MockCore.cs
+++ b/src/Sdk/StrixMusic.Sdk.Tests/Mock/Core/MockCore.cs
@@ -154,5 +154,7 @@ namespace StrixMusic.Sdk.Tests.Mock.Core
                 new List<CollectionChangedItem<ICoreDevice>>(),
                 new CollectionChangedItem<ICoreDevice>(device, 0).IntoList());
         }
+
+        public ValueTask DisposeAsync() => default;
     }
 }

--- a/src/Sdk/StrixMusic.Sdk.Tests/Mock/Core/MockCoreDevice.cs
+++ b/src/Sdk/StrixMusic.Sdk.Tests/Mock/Core/MockCoreDevice.cs
@@ -83,11 +83,6 @@ namespace StrixMusic.Sdk.Tests.Mock.Core
             throw new NotImplementedException();
         }
 
-        public ValueTask DisposeAsync()
-        {
-            throw new NotImplementedException();
-        }
-
         public Task NextAsync(CancellationToken cancellationToken = default)
         {
             throw new NotImplementedException();

--- a/src/Sdk/StrixMusic.Sdk.Tests/Mock/Core/MockCorePlayableCollectionGroupBase.cs
+++ b/src/Sdk/StrixMusic.Sdk.Tests/Mock/Core/MockCorePlayableCollectionGroupBase.cs
@@ -684,10 +684,5 @@ namespace StrixMusic.Sdk.Tests.Mock.Core
 
             return Task.CompletedTask;
         }
-
-        public ValueTask DisposeAsync()
-        {
-            throw new NotImplementedException();
-        }
     }
 }

--- a/src/Sdk/StrixMusic.Sdk.Tests/Mock/Core/MockCoreUser.cs
+++ b/src/Sdk/StrixMusic.Sdk.Tests/Mock/Core/MockCoreUser.cs
@@ -85,11 +85,6 @@ namespace StrixMusic.Sdk.Tests.Mock.Core
             throw new NotImplementedException();
         }
 
-        public ValueTask DisposeAsync()
-        {
-            throw new NotImplementedException();
-        }
-
         public IAsyncEnumerable<ICoreImage> GetImagesAsync(int limit, int offset, CancellationToken cancellationToken = default)
         {
             throw new NotImplementedException();

--- a/src/Sdk/StrixMusic.Sdk.Tests/Mock/Core/Search/MockCoreSearch.cs
+++ b/src/Sdk/StrixMusic.Sdk.Tests/Mock/Core/Search/MockCoreSearch.cs
@@ -18,11 +18,6 @@ namespace StrixMusic.Sdk.Tests.Mock.Core.Search
 
         public ICore SourceCore { get; set; }
 
-        public ValueTask DisposeAsync()
-        {
-            throw new System.NotImplementedException();
-        }
-
         public IAsyncEnumerable<ICoreSearchQuery> GetRecentSearchQueries(CancellationToken cancellationToken = default)
         {
             throw new System.NotImplementedException();

--- a/src/Sdk/StrixMusic.Sdk.Tests/Plugins/Models/AlbumCollectionPluginBaseTests.cs
+++ b/src/Sdk/StrixMusic.Sdk.Tests/Plugins/Models/AlbumCollectionPluginBaseTests.cs
@@ -115,34 +115,23 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
             Assert.AreNotSame(finalImpl, defaultImplementation);
             Assert.IsInstanceOfType(finalImpl, typeof(NoOverride));
 
-            var expectedExceptionsWhenDisposing = new List<Type>
-            {
-                typeof(AccessedException<Unimplemented>),
-            };
-
             if (data.HasFlag(PossiblePlugins.Downloadable))
             {
-                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<DownloadablePluginBaseTests.Unimplemented>));
-
                 Helpers.AssertAllMembersThrowOnAccess<AccessedException<DownloadablePluginBaseTests.Unimplemented>,
                     DownloadablePluginBaseTests.Unimplemented>(
                     finalImpl,
-                    customFilter: NoInnerOrSources,
-                    typesToExclude: typeof(IAsyncDisposable)
+                    customFilter: NoInnerOrSources
                 );
             }
 
             if (data.HasFlag(PossiblePlugins.Playable))
             {
-                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<PlayablePluginBaseTests.Unimplemented>));
-
                 Helpers.AssertAllMembersThrowOnAccess<AccessedException<PlayablePluginBaseTests.Unimplemented>,
                     PlayablePluginBaseTests.Unimplemented>(
                     finalImpl,
                     customFilter: NoInnerOrSources,
                     typesToExclude: new[]
                     {
-                        typeof(IAsyncDisposable),
                         typeof(DownloadablePluginBaseTests.Unimplemented),
                         typeof(ImageCollectionPluginBaseTests.Unimplemented),
                         typeof(UrlCollectionPluginBaseTests.Unimplemented)
@@ -152,54 +141,20 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
 
             if (data.HasFlag(PossiblePlugins.ImageCollection))
             {
-                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<ImageCollectionPluginBaseTests.Unimplemented>));
-
                 Helpers.AssertAllMembersThrowOnAccess<AccessedException<ImageCollectionPluginBaseTests.Unimplemented>,
                     ImageCollectionPluginBaseTests.Unimplemented>(
                     finalImpl,
-                    customFilter: NoInnerOrSources,
-                    typesToExclude: typeof(IAsyncDisposable)
+                    customFilter: NoInnerOrSources
                 );
             }
 
             if (data.HasFlag(PossiblePlugins.UrlCollection))
             {
-                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<UrlCollectionPluginBaseTests.Unimplemented>));
-
                 Helpers.AssertAllMembersThrowOnAccess<AccessedException<UrlCollectionPluginBaseTests.Unimplemented>, UrlCollectionPluginBaseTests.Unimplemented>(
                     finalImpl,
-                    customFilter: NoInnerOrSources,
-                    typesToExclude: typeof(IAsyncDisposable)
+                    customFilter: NoInnerOrSources
                 );
             }
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(
-                finalImpl,
-                customFilter: NoInnerOrSources,
-                expectedExceptions: expectedExceptionsWhenDisposing.ToArray()
-            );
-        }
-
-        [TestMethod, Timeout(5000)]
-        [AllEnumFlagCombinations(typeof(PossiblePlugins))]
-        public async Task DisposeAsync_AllCombinations(PossiblePlugins data)
-        {
-            var builder = new SdkModelPlugin(SdkTestPluginMetadata.Metadata).AlbumCollection;
-            var defaultImplementation = new NotBlockingDisposeAsync();
-            builder.Add(x => new NoOverride(x)
-            {
-                InnerDownloadable = data.HasFlag(PossiblePlugins.Downloadable) ? new DownloadablePluginBaseTests.NotBlockingDisposeAsync() : x,
-                InnerPlayable = data.HasFlag(PossiblePlugins.Playable) ? new PlayablePluginBaseTests.NotBlockingDisposeAsync() : x,
-                InnerImageCollection = data.HasFlag(PossiblePlugins.ImageCollection) ? new ImageCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
-                InnerUrlCollection = data.HasFlag(PossiblePlugins.UrlCollection) ? new UrlCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
-            });
-
-            var finalImpl = builder.Execute(defaultImplementation);
-
-            Assert.AreNotSame(finalImpl, defaultImplementation);
-            Assert.IsInstanceOfType(finalImpl, typeof(NoOverride));
-
-            await finalImpl.DisposeAsync();
         }
 
         internal class FullyCustom : AlbumCollectionPluginBase
@@ -252,7 +207,6 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
             public override Task ChangeDescriptionAsync(string? description, CancellationToken cancellationToken = default) => throw AccessedException;
             public override Task ChangeDurationAsync(TimeSpan duration, CancellationToken cancellationToken = default) => throw AccessedException;
             public override Task ChangeNameAsync(string name, CancellationToken cancellationToken = default) => throw AccessedException;
-            public override ValueTask DisposeAsync() => throw AccessedException;
             public override bool Equals(ICoreAlbumCollectionItem? other) => throw AccessedException;
             public override bool Equals(ICoreImageCollection? other) => throw AccessedException;
             public override bool Equals(ICoreUrlCollection? other) => throw AccessedException;
@@ -281,17 +235,6 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
                 : base(new ModelPluginMetadata("", nameof(NoOverride), "", new Version()), inner)
             {
             }
-        }
-
-        internal class NotBlockingDisposeAsync : AlbumCollectionPluginBase
-        {
-            public NotBlockingDisposeAsync()
-                : base(new ModelPluginMetadata("", nameof(NotBlockingDisposeAsync), "", new Version()), new Unimplemented())
-            {
-            }
-
-            /// <inheritdoc />
-            public override ValueTask DisposeAsync() => default;
         }
 
         internal class Unimplemented : IAlbumCollection
@@ -344,7 +287,6 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
             public Task ChangeDescriptionAsync(string? description, CancellationToken cancellationToken = default) => throw AccessedException;
             public Task ChangeDurationAsync(TimeSpan duration, CancellationToken cancellationToken = default) => throw AccessedException;
             public Task ChangeNameAsync(string name, CancellationToken cancellationToken = default) => throw AccessedException;
-            public ValueTask DisposeAsync() => throw AccessedException;
             public bool Equals(ICoreAlbumCollectionItem? other) => throw AccessedException;
             public bool Equals(ICoreImageCollection? other) => throw AccessedException;
             public bool Equals(ICoreUrlCollection? other) => throw AccessedException;

--- a/src/Sdk/StrixMusic.Sdk.Tests/Plugins/Models/AlbumPluginBaseTests.cs
+++ b/src/Sdk/StrixMusic.Sdk.Tests/Plugins/Models/AlbumPluginBaseTests.cs
@@ -129,34 +129,23 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
             Assert.AreNotSame(finalImpl, defaultImplementation);
             Assert.IsInstanceOfType(finalImpl, typeof(NoOverride));
 
-            var expectedExceptionsWhenDisposing = new List<Type>
-            {
-                typeof(AccessedException<Unimplemented>),
-            };
-
             if (data.HasFlag(PossiblePlugins.Downloadable))
             {
-                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<DownloadablePluginBaseTests.Unimplemented>));
-
                 Helpers.AssertAllMembersThrowOnAccess<AccessedException<DownloadablePluginBaseTests.Unimplemented>,
                     DownloadablePluginBaseTests.Unimplemented>(
                     finalImpl,
-                    customFilter: NoInnerOrSources,
-                    typesToExclude: typeof(IAsyncDisposable)
+                    customFilter: NoInnerOrSources
                 );
             }
 
             if (data.HasFlag(PossiblePlugins.Playable))
             {
-                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<PlayablePluginBaseTests.Unimplemented>));
-
                 Helpers.AssertAllMembersThrowOnAccess<AccessedException<PlayablePluginBaseTests.Unimplemented>,
                     PlayablePluginBaseTests.Unimplemented>(
                     finalImpl,
                     customFilter: NoInnerOrSources,
                     typesToExclude: new[]
                     {
-                        typeof(IAsyncDisposable),
                         typeof(DownloadablePluginBaseTests.Unimplemented),
                         typeof(ImageCollectionPluginBaseTests.Unimplemented),
                         typeof(UrlCollectionPluginBaseTests.Unimplemented)
@@ -166,15 +155,12 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
 
             if (data.HasFlag(PossiblePlugins.ArtistCollection))
             {
-                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<ArtistCollectionPluginBaseTests.Unimplemented>));
-
                 Helpers.AssertAllMembersThrowOnAccess<AccessedException<ArtistCollectionPluginBaseTests.Unimplemented>,
                     ArtistCollectionPluginBaseTests.Unimplemented>(
                     finalImpl,
                     customFilter: NoInnerOrSources,
                     typesToExclude: new[]
                     {
-                        typeof(IAsyncDisposable),
                         typeof(DownloadablePluginBaseTests.Unimplemented),
                         typeof(ImageCollectionPluginBaseTests.Unimplemented),
                         typeof(UrlCollectionPluginBaseTests.Unimplemented),
@@ -186,38 +172,29 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
 
             if (data.HasFlag(PossiblePlugins.GenreCollection))
             {
-                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<GenreCollectionPluginBaseTests.Unimplemented>));
-
                 Helpers.AssertAllMembersThrowOnAccess<AccessedException<GenreCollectionPluginBaseTests.Unimplemented>,
                     GenreCollectionPluginBaseTests.Unimplemented>(
                     finalImpl,
-                    customFilter: NoInnerOrSources,
-                    typesToExclude: typeof(IAsyncDisposable)
+                    customFilter: NoInnerOrSources
                 );
             }
 
             if (data.HasFlag(PossiblePlugins.ImageCollection))
             {
-                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<ImageCollectionPluginBaseTests.Unimplemented>));
-
                 Helpers.AssertAllMembersThrowOnAccess<AccessedException<ImageCollectionPluginBaseTests.Unimplemented>,
                     ImageCollectionPluginBaseTests.Unimplemented>(
                     finalImpl,
-                    customFilter: NoInnerOrSources,
-                    typesToExclude: typeof(IAsyncDisposable)
+                    customFilter: NoInnerOrSources
                 );
             }
 
             if (data.HasFlag(PossiblePlugins.TrackCollection))
             {
-                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<TrackCollectionPluginBaseTests.Unimplemented>));
-
                 Helpers.AssertAllMembersThrowOnAccess<AccessedException<TrackCollectionPluginBaseTests.Unimplemented>, TrackCollectionPluginBaseTests.Unimplemented>(
                     finalImpl,
                     customFilter: NoInnerOrSources,
                     typesToExclude: new[]
                     {
-                        typeof(IAsyncDisposable),
                         typeof(DownloadablePluginBaseTests.Unimplemented),
                         typeof(ImageCollectionPluginBaseTests.Unimplemented),
                         typeof(UrlCollectionPluginBaseTests.Unimplemented),
@@ -229,46 +206,11 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
 
             if (data.HasFlag(PossiblePlugins.UrlCollection))
             {
-                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<UrlCollectionPluginBaseTests.Unimplemented>));
-
                 Helpers.AssertAllMembersThrowOnAccess<AccessedException<UrlCollectionPluginBaseTests.Unimplemented>, UrlCollectionPluginBaseTests.Unimplemented>(
                     finalImpl,
-                    customFilter: NoInnerOrSources,
-                    typesToExclude: typeof(IAsyncDisposable)
+                    customFilter: NoInnerOrSources
                 );
             }
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(
-                finalImpl,
-                customFilter: NoInnerOrSources,
-                expectedExceptions: expectedExceptionsWhenDisposing.ToArray()
-            );
-        }
-
-        [TestMethod, Timeout(5000)]
-        [AllEnumFlagCombinations(typeof(PossiblePlugins))]
-        public async Task DisposeAsync_AllCombinations(PossiblePlugins data)
-        {
-            var builder = new SdkModelPlugin(SdkTestPluginMetadata.Metadata).Album;
-            var defaultImplementation = new NotBlockingDisposeAsync();
-            builder.Add(x => new NoOverride(x)
-                {
-                    InnerDownloadable = data.HasFlag(PossiblePlugins.Downloadable) ? new DownloadablePluginBaseTests.NotBlockingDisposeAsync() : x,
-                    InnerPlayable = data.HasFlag(PossiblePlugins.Playable) ? new PlayablePluginBaseTests.NotBlockingDisposeAsync() : x,
-                    InnerArtistCollection = data.HasFlag(PossiblePlugins.ArtistCollection) ? new ArtistCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
-                    InnerGenreCollection = data.HasFlag(PossiblePlugins.GenreCollection) ? new GenreCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
-                    InnerTrackCollection = data.HasFlag(PossiblePlugins.TrackCollection) ? new TrackCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
-                    InnerImageCollection = data.HasFlag(PossiblePlugins.ImageCollection) ? new ImageCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
-                    InnerUrlCollection = data.HasFlag(PossiblePlugins.UrlCollection) ? new UrlCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
-                }
-            );
-            
-            var finalImpl = builder.Execute(defaultImplementation);
-
-            Assert.AreNotSame(finalImpl, defaultImplementation);
-            Assert.IsInstanceOfType(finalImpl, typeof(NoOverride));
-
-            await finalImpl.DisposeAsync();
         }
 
         internal class FullyCustom : AlbumPluginBase
@@ -281,7 +223,6 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
             internal static AccessedException<FullyCustom> AccessedException { get; } =
                 new AccessedException<FullyCustom>();
 
-            public override ValueTask DisposeAsync() => throw AccessedException;
             public override Task<bool> IsAddImageAvailableAsync(int index, CancellationToken cancellationToken = default) => throw AccessedException;
             public override Task<bool> IsRemoveImageAvailableAsync(int index, CancellationToken cancellationToken = default) => throw AccessedException;
             public override Task RemoveImageAsync(int index, CancellationToken cancellationToken = default) => throw AccessedException;
@@ -518,17 +459,6 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
             }
         }
 
-        internal class NotBlockingDisposeAsync : AlbumPluginBase
-        {
-            public NotBlockingDisposeAsync()
-                : base(new ModelPluginMetadata("", nameof(NotBlockingDisposeAsync), "", new Version()), new Unimplemented())
-            {
-            }
-
-            /// <inheritdoc />
-            public override ValueTask DisposeAsync() => default;
-        }
-
         internal class Unimplemented : IAlbum
         {
             internal static AccessedException<Unimplemented> AccessedException { get; } =
@@ -536,7 +466,6 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
             
 
             public event EventHandler? SourcesChanged { add => throw AccessedException; remove => throw AccessedException; }
-            public ValueTask DisposeAsync() => throw AccessedException;
             public Task<bool> IsAddImageAvailableAsync(int index, CancellationToken cancellationToken = default) => throw AccessedException;
             public Task<bool> IsRemoveImageAvailableAsync(int index, CancellationToken cancellationToken = default) => throw AccessedException;
             public Task RemoveImageAsync(int index, CancellationToken cancellationToken = default) => throw AccessedException;

--- a/src/Sdk/StrixMusic.Sdk.Tests/Plugins/Models/ArtistCollectionPluginBaseTests.cs
+++ b/src/Sdk/StrixMusic.Sdk.Tests/Plugins/Models/ArtistCollectionPluginBaseTests.cs
@@ -115,34 +115,23 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
             Assert.AreNotSame(finalImpl, defaultImplementation);
             Assert.IsInstanceOfType(finalImpl, typeof(NoOverride));
 
-            var expectedExceptionsWhenDisposing = new List<Type>
-            {
-                typeof(AccessedException<Unimplemented>),
-            };
-
             if (data.HasFlag(PossiblePlugins.Downloadable))
             {
-                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<DownloadablePluginBaseTests.Unimplemented>));
-
                 Helpers.AssertAllMembersThrowOnAccess<AccessedException<DownloadablePluginBaseTests.Unimplemented>,
                     DownloadablePluginBaseTests.Unimplemented>(
                     finalImpl,
-                    customFilter: NoInnerOrSources,
-                    typesToExclude: typeof(IAsyncDisposable)
+                    customFilter: NoInnerOrSources
                 );
             }
 
             if (data.HasFlag(PossiblePlugins.Playable))
             {
-                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<PlayablePluginBaseTests.Unimplemented>));
-
                 Helpers.AssertAllMembersThrowOnAccess<AccessedException<PlayablePluginBaseTests.Unimplemented>,
                     PlayablePluginBaseTests.Unimplemented>(
                     finalImpl,
                     customFilter: NoInnerOrSources,
                     typesToExclude: new[]
                     {
-                        typeof(IAsyncDisposable),
                         typeof(DownloadablePluginBaseTests.Unimplemented),
                         typeof(ImageCollectionPluginBaseTests.Unimplemented),
                         typeof(UrlCollectionPluginBaseTests.Unimplemented)
@@ -152,54 +141,20 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
 
             if (data.HasFlag(PossiblePlugins.ImageCollection))
             {
-                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<ImageCollectionPluginBaseTests.Unimplemented>));
-
                 Helpers.AssertAllMembersThrowOnAccess<AccessedException<ImageCollectionPluginBaseTests.Unimplemented>,
                     ImageCollectionPluginBaseTests.Unimplemented>(
                     finalImpl,
-                    customFilter: NoInnerOrSources,
-                    typesToExclude: typeof(IAsyncDisposable)
+                    customFilter: NoInnerOrSources
                 );
             }
 
             if (data.HasFlag(PossiblePlugins.UrlCollection))
             {
-                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<UrlCollectionPluginBaseTests.Unimplemented>));
-
                 Helpers.AssertAllMembersThrowOnAccess<AccessedException<UrlCollectionPluginBaseTests.Unimplemented>, UrlCollectionPluginBaseTests.Unimplemented>(
                     finalImpl,
-                    customFilter: NoInnerOrSources,
-                    typesToExclude: typeof(IAsyncDisposable)
+                    customFilter: NoInnerOrSources
                 );
             }
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(
-                finalImpl,
-                customFilter: NoInnerOrSources,
-                expectedExceptions: expectedExceptionsWhenDisposing.ToArray()
-            );
-        }
-
-        [TestMethod, Timeout(5000)]
-        [AllEnumFlagCombinations(typeof(PossiblePlugins))]
-        public async Task DisposeAsync_AllCombinations(PossiblePlugins data)
-        {
-            var builder = new SdkModelPlugin(SdkTestPluginMetadata.Metadata).ArtistCollection;
-            var defaultImplementation = new NotBlockingDisposeAsync();
-            builder.Add(x => new NoOverride(x)
-            {
-                InnerDownloadable = data.HasFlag(PossiblePlugins.Downloadable) ? new DownloadablePluginBaseTests.NotBlockingDisposeAsync() : x,
-                InnerPlayable = data.HasFlag(PossiblePlugins.Playable) ? new PlayablePluginBaseTests.NotBlockingDisposeAsync() : x,
-                InnerImageCollection = data.HasFlag(PossiblePlugins.ImageCollection) ? new ImageCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
-                InnerUrlCollection = data.HasFlag(PossiblePlugins.UrlCollection) ? new UrlCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
-            });
-
-            var finalImpl = builder.Execute(defaultImplementation);
-
-            Assert.AreNotSame(finalImpl, defaultImplementation);
-            Assert.IsInstanceOfType(finalImpl, typeof(NoOverride));
-
-            await finalImpl.DisposeAsync();
         }
 
         internal class FullyCustom : ArtistCollectionPluginBase
@@ -252,7 +207,6 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
             public override Task ChangeDescriptionAsync(string? description, CancellationToken cancellationToken = default) => throw AccessedException;
             public override Task ChangeDurationAsync(TimeSpan duration, CancellationToken cancellationToken = default) => throw AccessedException;
             public override Task ChangeNameAsync(string name, CancellationToken cancellationToken = default) => throw AccessedException;
-            public override ValueTask DisposeAsync() => throw AccessedException;
             public override bool Equals(ICoreArtistCollectionItem? other) => throw AccessedException;
             public override bool Equals(ICoreImageCollection? other) => throw AccessedException;
             public override bool Equals(ICoreUrlCollection? other) => throw AccessedException;
@@ -281,17 +235,6 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
                 : base(new ModelPluginMetadata("", nameof(NoOverride), "", new Version()), inner)
             {
             }
-        }
-
-        internal class NotBlockingDisposeAsync : ArtistCollectionPluginBase
-        {
-            public NotBlockingDisposeAsync()
-                : base(new ModelPluginMetadata("", nameof(NotBlockingDisposeAsync), "", new Version()), new Unimplemented())
-            {
-            }
-
-            /// <inheritdoc />
-            public override ValueTask DisposeAsync() => default;
         }
 
         internal class Unimplemented : IArtistCollection
@@ -344,7 +287,6 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
             public Task ChangeDescriptionAsync(string? description, CancellationToken cancellationToken = default) => throw AccessedException;
             public Task ChangeDurationAsync(TimeSpan duration, CancellationToken cancellationToken = default) => throw AccessedException;
             public Task ChangeNameAsync(string name, CancellationToken cancellationToken = default) => throw AccessedException;
-            public ValueTask DisposeAsync() => throw AccessedException;
             public bool Equals(ICoreArtistCollectionItem? other) => throw AccessedException;
             public bool Equals(ICoreImageCollection? other) => throw AccessedException;
             public bool Equals(ICoreUrlCollection? other) => throw AccessedException;

--- a/src/Sdk/StrixMusic.Sdk.Tests/Plugins/Models/ArtistPluginBaseTests.cs
+++ b/src/Sdk/StrixMusic.Sdk.Tests/Plugins/Models/ArtistPluginBaseTests.cs
@@ -121,42 +121,30 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
                 InnerTrackCollection = data.HasFlag(PossiblePlugins.TrackCollection) ? new TrackCollectionPluginBaseTests.Unimplemented() : x,
                 InnerImageCollection = data.HasFlag(PossiblePlugins.ImageCollection) ? new ImageCollectionPluginBaseTests.Unimplemented() : x,
                 InnerUrlCollection = data.HasFlag(PossiblePlugins.UrlCollection) ? new UrlCollectionPluginBaseTests.Unimplemented() : x,
-            }
-            );
+            });
 
             var finalImpl = builder.Execute(defaultImplementation);
 
             Assert.AreNotSame(finalImpl, defaultImplementation);
             Assert.IsInstanceOfType(finalImpl, typeof(NoOverride));
 
-            var expectedExceptionsWhenDisposing = new List<Type>
-            {
-                typeof(AccessedException<Unimplemented>),
-            };
-
             if (data.HasFlag(PossiblePlugins.Downloadable))
             {
-                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<DownloadablePluginBaseTests.Unimplemented>));
-
                 Helpers.AssertAllMembersThrowOnAccess<AccessedException<DownloadablePluginBaseTests.Unimplemented>,
                     DownloadablePluginBaseTests.Unimplemented>(
                     finalImpl,
-                    customFilter: NoInnerOrSources,
-                    typesToExclude: typeof(IAsyncDisposable)
+                    customFilter: NoInnerOrSources
                 );
             }
 
             if (data.HasFlag(PossiblePlugins.Playable))
             {
-                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<PlayablePluginBaseTests.Unimplemented>));
-
                 Helpers.AssertAllMembersThrowOnAccess<AccessedException<PlayablePluginBaseTests.Unimplemented>,
                     PlayablePluginBaseTests.Unimplemented>(
                     finalImpl,
                     customFilter: NoInnerOrSources,
                     typesToExclude: new[]
                     {
-                        typeof(IAsyncDisposable),
                         typeof(DownloadablePluginBaseTests.Unimplemented),
                         typeof(ImageCollectionPluginBaseTests.Unimplemented),
                         typeof(UrlCollectionPluginBaseTests.Unimplemented)
@@ -166,15 +154,12 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
 
             if (data.HasFlag(PossiblePlugins.AlbumCollection))
             {
-                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<AlbumCollectionPluginBaseTests.Unimplemented>));
-
                 Helpers.AssertAllMembersThrowOnAccess<AccessedException<AlbumCollectionPluginBaseTests.Unimplemented>,
                     AlbumCollectionPluginBaseTests.Unimplemented>(
                     finalImpl,
                     customFilter: NoInnerOrSources,
                     typesToExclude: new[]
                     {
-                        typeof(IAsyncDisposable),
                         typeof(DownloadablePluginBaseTests.Unimplemented),
                         typeof(ImageCollectionPluginBaseTests.Unimplemented),
                         typeof(UrlCollectionPluginBaseTests.Unimplemented),
@@ -186,38 +171,29 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
 
             if (data.HasFlag(PossiblePlugins.GenreCollection))
             {
-                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<GenreCollectionPluginBaseTests.Unimplemented>));
-
                 Helpers.AssertAllMembersThrowOnAccess<AccessedException<GenreCollectionPluginBaseTests.Unimplemented>,
                     GenreCollectionPluginBaseTests.Unimplemented>(
                     finalImpl,
-                    customFilter: NoInnerOrSources,
-                    typesToExclude: typeof(IAsyncDisposable)
+                    customFilter: NoInnerOrSources
                 );
             }
 
             if (data.HasFlag(PossiblePlugins.ImageCollection))
             {
-                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<ImageCollectionPluginBaseTests.Unimplemented>));
-
                 Helpers.AssertAllMembersThrowOnAccess<AccessedException<ImageCollectionPluginBaseTests.Unimplemented>,
                     ImageCollectionPluginBaseTests.Unimplemented>(
                     finalImpl,
-                    customFilter: NoInnerOrSources,
-                    typesToExclude: typeof(IAsyncDisposable)
+                    customFilter: NoInnerOrSources
                 );
             }
 
             if (data.HasFlag(PossiblePlugins.TrackCollection))
             {
-                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<TrackCollectionPluginBaseTests.Unimplemented>));
-
                 Helpers.AssertAllMembersThrowOnAccess<AccessedException<TrackCollectionPluginBaseTests.Unimplemented>, TrackCollectionPluginBaseTests.Unimplemented>(
                     finalImpl,
                     customFilter: NoInnerOrSources,
                     typesToExclude: new[]
                     {
-                        typeof(IAsyncDisposable),
                         typeof(DownloadablePluginBaseTests.Unimplemented),
                         typeof(ImageCollectionPluginBaseTests.Unimplemented),
                         typeof(UrlCollectionPluginBaseTests.Unimplemented),
@@ -229,45 +205,11 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
 
             if (data.HasFlag(PossiblePlugins.UrlCollection))
             {
-                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<UrlCollectionPluginBaseTests.Unimplemented>));
-
                 Helpers.AssertAllMembersThrowOnAccess<AccessedException<UrlCollectionPluginBaseTests.Unimplemented>, UrlCollectionPluginBaseTests.Unimplemented>(
                     finalImpl,
-                    customFilter: NoInnerOrSources,
-                    typesToExclude: typeof(IAsyncDisposable)
+                    customFilter: NoInnerOrSources
                 );
             }
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(
-                finalImpl,
-                customFilter: NoInnerOrSources,
-                expectedExceptions: expectedExceptionsWhenDisposing.ToArray()
-            );
-        }
-
-        [TestMethod, Timeout(5000)]
-        [AllEnumFlagCombinations(typeof(PossiblePlugins))]
-        public async Task DisposeAsync_AllCombinations(PossiblePlugins data)
-        {
-            var builder = new SdkModelPlugin(SdkTestPluginMetadata.Metadata).Artist;
-            var defaultImplementation = new NotBlockingDisposeAsync();
-            builder.Add(x => new NoOverride(x)
-            {
-                InnerDownloadable = data.HasFlag(PossiblePlugins.Downloadable) ? new DownloadablePluginBaseTests.NotBlockingDisposeAsync() : x,
-                InnerPlayable = data.HasFlag(PossiblePlugins.Playable) ? new PlayablePluginBaseTests.NotBlockingDisposeAsync() : x,
-                InnerAlbumCollection = data.HasFlag(PossiblePlugins.AlbumCollection) ? new AlbumCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
-                InnerGenreCollection = data.HasFlag(PossiblePlugins.GenreCollection) ? new GenreCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
-                InnerTrackCollection = data.HasFlag(PossiblePlugins.TrackCollection) ? new TrackCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
-                InnerImageCollection = data.HasFlag(PossiblePlugins.ImageCollection) ? new ImageCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
-                InnerUrlCollection = data.HasFlag(PossiblePlugins.UrlCollection) ? new UrlCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
-            });
-
-            var finalImpl = builder.Execute(defaultImplementation);
-
-            Assert.AreNotSame(finalImpl, defaultImplementation);
-            Assert.IsInstanceOfType(finalImpl, typeof(NoOverride));
-
-            await finalImpl.DisposeAsync();
         }
 
         internal class FullyCustom : ArtistPluginBase
@@ -279,8 +221,6 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
 
             internal static AccessedException<FullyCustom> AccessedException { get; } =
                 new AccessedException<FullyCustom>();
-
-            public override ValueTask DisposeAsync() => throw AccessedException;
 
             public override Task<bool> IsAddImageAvailableAsync(int index, CancellationToken cancellationToken = default) => throw AccessedException;
 
@@ -557,24 +497,12 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
             }
         }
 
-        internal class NotBlockingDisposeAsync : ArtistPluginBase
-        {
-            public NotBlockingDisposeAsync()
-                : base(new ModelPluginMetadata("", nameof(NotBlockingDisposeAsync), "", new Version()), new Unimplemented())
-            {
-            }
-
-            /// <inheritdoc />
-            public override ValueTask DisposeAsync() => default;
-        }
-
         internal class Unimplemented : IArtist
         {
             internal static AccessedException<Unimplemented> AccessedException { get; } =
                 new AccessedException<Unimplemented>();
             
             public event EventHandler? SourcesChanged { add => throw AccessedException; remove => throw AccessedException; }
-            public ValueTask DisposeAsync() => throw AccessedException;
 
             public Task<bool> IsAddImageAvailableAsync(int index, CancellationToken cancellationToken = default) => throw AccessedException;
 

--- a/src/Sdk/StrixMusic.Sdk.Tests/Plugins/Models/DiscoverablesPluginBaseTests.cs
+++ b/src/Sdk/StrixMusic.Sdk.Tests/Plugins/Models/DiscoverablesPluginBaseTests.cs
@@ -125,34 +125,23 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
             Assert.AreNotSame(finalImpl, defaultImplementation);
             Assert.IsInstanceOfType(finalImpl, typeof(NoOverride));
 
-            var expectedExceptionsWhenDisposing = new List<Type>
-            {
-                typeof(AccessedException<Unimplemented>),
-            };
-
             if (data.HasFlag(PossiblePlugins.Downloadable))
             {
-                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<DownloadablePluginBaseTests.Unimplemented>));
-
                 Helpers.AssertAllMembersThrowOnAccess<AccessedException<DownloadablePluginBaseTests.Unimplemented>,
                     DownloadablePluginBaseTests.Unimplemented>(
                     finalImpl,
-                    customFilter: NoInnerOrSources,
-                    typesToExclude: typeof(IAsyncDisposable)
+                    customFilter: NoInnerOrSources
                 );
             }
 
             if (data.HasFlag(PossiblePlugins.Playable))
             {
-                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<PlayablePluginBaseTests.Unimplemented>));
-
                 Helpers.AssertAllMembersThrowOnAccess<AccessedException<PlayablePluginBaseTests.Unimplemented>,
                     PlayablePluginBaseTests.Unimplemented>(
                     finalImpl,
                     customFilter: NoInnerOrSources,
                     typesToExclude: new[]
                     {
-                        typeof(IAsyncDisposable),
                         typeof(DownloadablePluginBaseTests.Unimplemented),
                         typeof(ImageCollectionPluginBaseTests.Unimplemented),
                         typeof(UrlCollectionPluginBaseTests.Unimplemented)
@@ -162,15 +151,12 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
 
             if (data.HasFlag(PossiblePlugins.ArtistCollection))
             {
-                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<ArtistCollectionPluginBaseTests.Unimplemented>));
-
                 Helpers.AssertAllMembersThrowOnAccess<AccessedException<ArtistCollectionPluginBaseTests.Unimplemented>,
                     ArtistCollectionPluginBaseTests.Unimplemented>(
                     finalImpl,
                     customFilter: NoInnerOrSources,
                     typesToExclude: new[]
                     {
-                        typeof(IAsyncDisposable),
                         typeof(DownloadablePluginBaseTests.Unimplemented),
                         typeof(ImageCollectionPluginBaseTests.Unimplemented),
                         typeof(UrlCollectionPluginBaseTests.Unimplemented),
@@ -182,15 +168,12 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
 
             if (data.HasFlag(PossiblePlugins.AlbumCollection))
             {
-                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<AlbumCollectionPluginBaseTests.Unimplemented>));
-
                 Helpers.AssertAllMembersThrowOnAccess<AccessedException<AlbumCollectionPluginBaseTests.Unimplemented>,
                     AlbumCollectionPluginBaseTests.Unimplemented>(
                     finalImpl,
                     customFilter: NoInnerOrSources,
                     typesToExclude: new[]
                     {
-                        typeof(IAsyncDisposable),
                         typeof(DownloadablePluginBaseTests.Unimplemented),
                         typeof(ImageCollectionPluginBaseTests.Unimplemented),
                         typeof(UrlCollectionPluginBaseTests.Unimplemented),
@@ -202,15 +185,12 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
 
             if (data.HasFlag(PossiblePlugins.PlaylistCollection))
             {
-                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<PlaylistCollectionPluginBaseTests.Unimplemented>));
-
                 Helpers.AssertAllMembersThrowOnAccess<AccessedException<PlaylistCollectionPluginBaseTests.Unimplemented>,
                     PlaylistCollectionPluginBaseTests.Unimplemented>(
                     finalImpl,
                     customFilter: NoInnerOrSources,
                     typesToExclude: new[]
                     {
-                        typeof(IAsyncDisposable),
                         typeof(DownloadablePluginBaseTests.Unimplemented),
                         typeof(ImageCollectionPluginBaseTests.Unimplemented),
                         typeof(UrlCollectionPluginBaseTests.Unimplemented),
@@ -222,14 +202,11 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
 
             if (data.HasFlag(PossiblePlugins.TrackCollection))
             {
-                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<TrackCollectionPluginBaseTests.Unimplemented>));
-
                 Helpers.AssertAllMembersThrowOnAccess<AccessedException<TrackCollectionPluginBaseTests.Unimplemented>, TrackCollectionPluginBaseTests.Unimplemented>(
                     finalImpl,
                     customFilter: NoInnerOrSources,
                     typesToExclude: new[]
                     {
-                        typeof(IAsyncDisposable),
                         typeof(DownloadablePluginBaseTests.Unimplemented),
                         typeof(ImageCollectionPluginBaseTests.Unimplemented),
                         typeof(UrlCollectionPluginBaseTests.Unimplemented),
@@ -241,54 +218,20 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
 
             if (data.HasFlag(PossiblePlugins.ImageCollection))
             {
-                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<ImageCollectionPluginBaseTests.Unimplemented>));
-
                 Helpers.AssertAllMembersThrowOnAccess<AccessedException<ImageCollectionPluginBaseTests.Unimplemented>,
                     ImageCollectionPluginBaseTests.Unimplemented>(
                     finalImpl,
-                    customFilter: NoInnerOrSources,
-                    typesToExclude: typeof(IAsyncDisposable)
+                    customFilter: NoInnerOrSources
                 );
             }
 
             if (data.HasFlag(PossiblePlugins.UrlCollection))
             {
-                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<UrlCollectionPluginBaseTests.Unimplemented>));
-
                 Helpers.AssertAllMembersThrowOnAccess<AccessedException<UrlCollectionPluginBaseTests.Unimplemented>, UrlCollectionPluginBaseTests.Unimplemented>(
                     finalImpl,
-                    customFilter: NoInnerOrSources,
-                    typesToExclude: typeof(IAsyncDisposable)
+                    customFilter: NoInnerOrSources
                 );
             }
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(
-                finalImpl,
-                customFilter: NoInnerOrSources,
-                expectedExceptions: expectedExceptionsWhenDisposing.ToArray()
-            );
-        }
-
-        [TestMethod, Timeout(5000)]
-        [AllEnumFlagCombinations(typeof(PossiblePlugins))]
-        public async Task DisposeAsync_AllCombinations(PossiblePlugins data)
-        {
-            var builder = new SdkModelPlugin(SdkTestPluginMetadata.Metadata).Discoverables;
-            var defaultImplementation = new NotBlockingDisposeAsync();
-            builder.Add(x => new NoOverride(x)
-            {
-                InnerDownloadable = data.HasFlag(PossiblePlugins.Downloadable) ? new DownloadablePluginBaseTests.NotBlockingDisposeAsync() : x,
-                InnerPlayable = data.HasFlag(PossiblePlugins.Playable) ? new PlayablePluginBaseTests.NotBlockingDisposeAsync() : x,
-                InnerImageCollection = data.HasFlag(PossiblePlugins.ImageCollection) ? new ImageCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
-                InnerUrlCollection = data.HasFlag(PossiblePlugins.UrlCollection) ? new UrlCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
-            });
-
-            var finalImpl = builder.Execute(defaultImplementation);
-
-            Assert.AreNotSame(finalImpl, defaultImplementation);
-            Assert.IsInstanceOfType(finalImpl, typeof(NoOverride));
-
-            await finalImpl.DisposeAsync();
         }
 
         internal class FullyCustom : DiscoverablesPluginBase
@@ -300,7 +243,6 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
 
             internal static AccessedException<FullyCustom> AccessedException { get; } = new();
 
-            public override ValueTask DisposeAsync() => throw AccessedException;
             public override Task<bool> IsAddImageAvailableAsync(int index, CancellationToken cancellationToken = default) => throw AccessedException;
             public override Task<bool> IsRemoveImageAvailableAsync(int index, CancellationToken cancellationToken = default) => throw AccessedException;
             public override Task RemoveImageAsync(int index, CancellationToken cancellationToken = default) => throw AccessedException;
@@ -434,23 +376,11 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
             }
         }
 
-        internal class NotBlockingDisposeAsync : DiscoverablesPluginBase
-        {
-            public NotBlockingDisposeAsync()
-                : base(new ModelPluginMetadata("", nameof(NotBlockingDisposeAsync), "", new Version()), new Unimplemented())
-            {
-            }
-
-            /// <inheritdoc />
-            public override ValueTask DisposeAsync() => default;
-        }
-
         internal class Unimplemented : IDiscoverables
         {
             internal static AccessedException<Unimplemented> AccessedException { get; } = new();
 
             public event EventHandler? SourcesChanged { add => throw AccessedException; remove => throw AccessedException; }
-            public ValueTask DisposeAsync() => throw AccessedException;
             public Task<bool> IsAddImageAvailableAsync(int index, CancellationToken cancellationToken = default) => throw AccessedException;
             public Task<bool> IsRemoveImageAvailableAsync(int index, CancellationToken cancellationToken = default) => throw AccessedException;
             public Task RemoveImageAsync(int index, CancellationToken cancellationToken = default) => throw AccessedException;

--- a/src/Sdk/StrixMusic.Sdk.Tests/Plugins/Models/DownloadablePluginBaseTests.cs
+++ b/src/Sdk/StrixMusic.Sdk.Tests/Plugins/Models/DownloadablePluginBaseTests.cs
@@ -84,7 +84,6 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
             public override DownloadInfo DownloadInfo => throw AccessedException;
             public override event EventHandler<DownloadInfo>? DownloadInfoChanged { add => throw AccessedException; remove => throw AccessedException; }
             public override Task StartDownloadOperationAsync(DownloadOperation operation, CancellationToken cancellationToken = default) => throw AccessedException;
-            public override ValueTask DisposeAsync() => throw AccessedException;
         }
 
         public class NoOverride : DownloadablePluginBase
@@ -95,25 +94,12 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
             }
         }
 
-        internal class NotBlockingDisposeAsync : DownloadablePluginBase
-        {
-            public NotBlockingDisposeAsync()
-                : base(new ModelPluginMetadata("", nameof(NotBlockingDisposeAsync), "", new Version()), new Unimplemented())
-            {
-            }
-
-            /// <inheritdoc />
-            public override ValueTask DisposeAsync() => default;
-        }
-
         public class Unimplemented : IDownloadable
         {
             internal static AccessedException<Unimplemented> AccessedException { get; } = new();
 
             public DownloadInfo DownloadInfo => throw AccessedException;
             public event EventHandler<DownloadInfo>? DownloadInfoChanged { add => throw AccessedException; remove => throw AccessedException; }
-
-            public ValueTask DisposeAsync() => throw AccessedException;
 
             public Task StartDownloadOperationAsync(DownloadOperation operation, CancellationToken cancellationToken = default) => throw AccessedException;
         }

--- a/src/Sdk/StrixMusic.Sdk.Tests/Plugins/Models/GenreCollectionPluginBaseTests.cs
+++ b/src/Sdk/StrixMusic.Sdk.Tests/Plugins/Models/GenreCollectionPluginBaseTests.cs
@@ -95,8 +95,6 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
 
             public override Task AddGenreAsync(IGenre genre, int index, CancellationToken cancellationToken = default) => throw AccessedException;
 
-            public override ValueTask DisposeAsync() => throw AccessedException;
-
             public override bool Equals(ICoreGenreCollection? other) => throw AccessedException;
 
             public override IAsyncEnumerable<IGenre> GetGenresAsync(int limit, int offset, CancellationToken cancellationToken = default) => throw AccessedException;
@@ -116,17 +114,6 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
             }
         }
 
-        internal class NotBlockingDisposeAsync : GenreCollectionPluginBase
-        {
-            public NotBlockingDisposeAsync()
-                : base(new ModelPluginMetadata("", nameof(NotBlockingDisposeAsync), "", new Version()), new Unimplemented())
-            {
-            }
-
-            /// <inheritdoc />
-            public override ValueTask DisposeAsync() => default;
-        }
-
         public class Unimplemented : IGenreCollection
         {
             internal static AccessedException<Unimplemented> AccessedException { get; } = new();
@@ -141,8 +128,6 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
             public event EventHandler<int>? GenresCountChanged { add => throw AccessedException; remove => throw AccessedException; }
 
             public Task AddGenreAsync(IGenre genre, int index, CancellationToken cancellationToken = default) => throw AccessedException;
-
-            public ValueTask DisposeAsync() => throw AccessedException;
 
             public bool Equals(ICoreGenreCollection? other) => throw AccessedException;
 

--- a/src/Sdk/StrixMusic.Sdk.Tests/Plugins/Models/GlobalPluginConnector/AlbumCollectionTests.cs
+++ b/src/Sdk/StrixMusic.Sdk.Tests/Plugins/Models/GlobalPluginConnector/AlbumCollectionTests.cs
@@ -24,7 +24,6 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
                 customFilter: NoInnerOrSources,
                 typesToExclude: new[]
                 {
-                    typeof(IAsyncDisposable),
                     typeof(IPlayableCollectionItem)
                 });
         }
@@ -41,23 +40,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
             // Ensure an Artist plugin can still be accessed through AlbumCollection members.
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<ArtistPluginBaseTests.FullyCustom>, AlbumCollectionPluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
-        }
-
-        [TestMethod]
-        public void DisposingArtist()
-        {
-            var plugins = new Sdk.Plugins.Model.SdkModelPlugin(SdkTestPluginMetadata.Metadata);
-            plugins.AlbumCollection.Add(x => new AlbumCollectionPluginBaseTests.FullyCustom(x));
-
-            var plugin = StrixMusic.Sdk.Plugins.Model.GlobalModelPluginConnector.Create(plugins).Artist.Execute(new ArtistPluginBaseTests.Unimplemented());
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(value: plugin, expectedExceptions: new[]
-            {
-                typeof(AccessedException<AlbumCollectionPluginBaseTests.FullyCustom>),
-                typeof(AccessedException<ArtistPluginBaseTests.Unimplemented>),
-            });
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -73,7 +56,6 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
                 customFilter: NoInnerOrSources,
                 typesToExclude: new[]
                 {
-                    typeof(IAsyncDisposable),
                     typeof(IPlayableCollectionItem)
                 });
         }
@@ -90,23 +72,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
             // Ensure an PlayableCollectionGroup plugin can still be accessed through AlbumCollection members.
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<PlayableCollectionGroupPluginBaseTests.FullyCustom>, AlbumCollectionPluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
-        }
-
-        [TestMethod]
-        public void DisposingPlayableCollectionGroup()
-        {
-            var plugins = new Sdk.Plugins.Model.SdkModelPlugin(SdkTestPluginMetadata.Metadata);
-            plugins.AlbumCollection.Add(x => new AlbumCollectionPluginBaseTests.FullyCustom(x));
-
-            var plugin = StrixMusic.Sdk.Plugins.Model.GlobalModelPluginConnector.Create(plugins).PlayableCollectionGroup.Execute(new PlayableCollectionGroupPluginBaseTests.Unimplemented());
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(value: plugin, expectedExceptions: new[]
-            {
-                typeof(AccessedException<AlbumCollectionPluginBaseTests.FullyCustom>),
-                typeof(AccessedException<PlayableCollectionGroupPluginBaseTests.Unimplemented>),
-            });
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -122,7 +88,6 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
                 customFilter: NoInnerOrSources,
                 typesToExclude: new[]
                 {
-                    typeof(IAsyncDisposable),
                     typeof(IPlayableCollectionItem)
                 });
         }
@@ -139,23 +104,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
             // Ensure an Library plugin can still be accessed through AlbumCollection members.
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<LibraryPluginBaseTests.FullyCustom>, AlbumCollectionPluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
-        }
-
-        [TestMethod]
-        public void DisposingLibrary()
-        {
-            var plugins = new Sdk.Plugins.Model.SdkModelPlugin(SdkTestPluginMetadata.Metadata);
-            plugins.AlbumCollection.Add(x => new AlbumCollectionPluginBaseTests.FullyCustom(x));
-
-            var plugin = StrixMusic.Sdk.Plugins.Model.GlobalModelPluginConnector.Create(plugins).Library.Execute(new LibraryPluginBaseTests.Unimplemented());
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(value: plugin, expectedExceptions: new[]
-            {
-                typeof(AccessedException<AlbumCollectionPluginBaseTests.FullyCustom>),
-                typeof(AccessedException<LibraryPluginBaseTests.Unimplemented>),
-            });
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -171,7 +120,6 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
                 customFilter: NoInnerOrSources,
                 typesToExclude: new[]
                 {
-                    typeof(IAsyncDisposable),
                     typeof(IPlayableCollectionItem)
                 });
         }
@@ -188,23 +136,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
             // Ensure an Discoverables plugin can still be accessed through AlbumCollection members.
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<DiscoverablesPluginBaseTests.FullyCustom>, AlbumCollectionPluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
-        }
-
-        [TestMethod]
-        public void DisposingDiscoverables()
-        {
-            var plugins = new Sdk.Plugins.Model.SdkModelPlugin(SdkTestPluginMetadata.Metadata);
-            plugins.AlbumCollection.Add(x => new AlbumCollectionPluginBaseTests.FullyCustom(x));
-
-            var plugin = StrixMusic.Sdk.Plugins.Model.GlobalModelPluginConnector.Create(plugins).Discoverables.Execute(new DiscoverablesPluginBaseTests.Unimplemented());
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(value: plugin, expectedExceptions: new[]
-            {
-                typeof(AccessedException<AlbumCollectionPluginBaseTests.FullyCustom>),
-                typeof(AccessedException<DiscoverablesPluginBaseTests.Unimplemented>),
-            });
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -220,7 +152,6 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
                 customFilter: NoInnerOrSources,
                 typesToExclude: new[]
                 {
-                    typeof(IAsyncDisposable),
                     typeof(IPlayableCollectionItem)
                 });
         }
@@ -237,23 +168,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
             // Ensure an SearchHistory plugin can still be accessed through AlbumCollection members.
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<SearchHistoryPluginBaseTests.FullyCustom>, AlbumCollectionPluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
-        }
-
-        [TestMethod]
-        public void DisposingSearchHistory()
-        {
-            var plugins = new Sdk.Plugins.Model.SdkModelPlugin(SdkTestPluginMetadata.Metadata);
-            plugins.AlbumCollection.Add(x => new AlbumCollectionPluginBaseTests.FullyCustom(x));
-
-            var plugin = StrixMusic.Sdk.Plugins.Model.GlobalModelPluginConnector.Create(plugins).SearchHistory.Execute(new SearchHistoryPluginBaseTests.Unimplemented());
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(value: plugin, expectedExceptions: new[]
-            {
-                typeof(AccessedException<AlbumCollectionPluginBaseTests.FullyCustom>),
-                typeof(AccessedException<SearchHistoryPluginBaseTests.Unimplemented>),
-            });
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -269,7 +184,6 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
                 customFilter: NoInnerOrSources,
                 typesToExclude: new[]
                 {
-                    typeof(IAsyncDisposable),
                     typeof(IPlayableCollectionItem)
                 });
         }
@@ -286,23 +200,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
             // Ensure an SearchResults plugin can still be accessed through AlbumCollection members.
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<SearchResultsPluginBaseTests.FullyCustom>, AlbumCollectionPluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
-        }
-
-        [TestMethod]
-        public void DisposingSearchResults()
-        {
-            var plugins = new Sdk.Plugins.Model.SdkModelPlugin(SdkTestPluginMetadata.Metadata);
-            plugins.AlbumCollection.Add(x => new AlbumCollectionPluginBaseTests.FullyCustom(x));
-
-            var plugin = StrixMusic.Sdk.Plugins.Model.GlobalModelPluginConnector.Create(plugins).SearchResults.Execute(new SearchResultsPluginBaseTests.Unimplemented());
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(value: plugin, expectedExceptions: new[]
-            {
-                typeof(AccessedException<AlbumCollectionPluginBaseTests.FullyCustom>),
-                typeof(AccessedException<SearchResultsPluginBaseTests.Unimplemented>),
-            });
+                customFilter: NoInnerOrSources);
         }
     }
 }

--- a/src/Sdk/StrixMusic.Sdk.Tests/Plugins/Models/GlobalPluginConnector/ArtistCollectionTests.cs
+++ b/src/Sdk/StrixMusic.Sdk.Tests/Plugins/Models/GlobalPluginConnector/ArtistCollectionTests.cs
@@ -24,7 +24,6 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
                 customFilter: NoInnerOrSources,
                 typesToExclude: new[]
                 {
-                    typeof(IAsyncDisposable),
                     typeof(IPlayableCollectionItem)
                 });
         }
@@ -41,23 +40,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
             // Ensure an Album plugin can still be accessed through ArtistCollection members.
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<AlbumPluginBaseTests.FullyCustom>, ArtistCollectionPluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
-        }
-
-        [TestMethod]
-        public void DisposingAlbum()
-        {
-            var plugins = new Sdk.Plugins.Model.SdkModelPlugin(SdkTestPluginMetadata.Metadata);
-            plugins.ArtistCollection.Add(x => new ArtistCollectionPluginBaseTests.FullyCustom(x));
-
-            var plugin = StrixMusic.Sdk.Plugins.Model.GlobalModelPluginConnector.Create(plugins).Album.Execute(new AlbumPluginBaseTests.Unimplemented());
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(value: plugin, expectedExceptions: new[]
-            {
-                typeof(AccessedException<ArtistCollectionPluginBaseTests.FullyCustom>),
-                typeof(AccessedException<AlbumPluginBaseTests.Unimplemented>),
-            });
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -73,7 +56,6 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
                 customFilter: NoInnerOrSources,
                 typesToExclude: new[]
                 {
-                    typeof(IAsyncDisposable),
                     typeof(IPlayableCollectionItem)
                 });
         }
@@ -90,23 +72,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
             // Ensure an Track plugin can still be accessed through ArtistCollection members.
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<TrackPluginBaseTests.FullyCustom>, ArtistCollectionPluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
-        }
-
-        [TestMethod]
-        public void DisposingTrack()
-        {
-            var plugins = new Sdk.Plugins.Model.SdkModelPlugin(SdkTestPluginMetadata.Metadata);
-            plugins.ArtistCollection.Add(x => new ArtistCollectionPluginBaseTests.FullyCustom(x));
-
-            var plugin = StrixMusic.Sdk.Plugins.Model.GlobalModelPluginConnector.Create(plugins).Track.Execute(new TrackPluginBaseTests.Unimplemented());
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(value: plugin, expectedExceptions: new[]
-            {
-                typeof(AccessedException<ArtistCollectionPluginBaseTests.FullyCustom>),
-                typeof(AccessedException<TrackPluginBaseTests.Unimplemented>),
-            });
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -122,7 +88,6 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
                 customFilter: NoInnerOrSources,
                 typesToExclude: new[]
                 {
-                    typeof(IAsyncDisposable),
                     typeof(IPlayableCollectionItem)
                 });
         }
@@ -139,23 +104,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
             // Ensure an PlayableCollectionGroup plugin can still be accessed through ArtistCollection members.
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<PlayableCollectionGroupPluginBaseTests.FullyCustom>, ArtistCollectionPluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
-        }
-
-        [TestMethod]
-        public void DisposingPlayableCollectionGroup()
-        {
-            var plugins = new Sdk.Plugins.Model.SdkModelPlugin(SdkTestPluginMetadata.Metadata);
-            plugins.ArtistCollection.Add(x => new ArtistCollectionPluginBaseTests.FullyCustom(x));
-
-            var plugin = StrixMusic.Sdk.Plugins.Model.GlobalModelPluginConnector.Create(plugins).PlayableCollectionGroup.Execute(new PlayableCollectionGroupPluginBaseTests.Unimplemented());
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(value: plugin, expectedExceptions: new[]
-            {
-                typeof(AccessedException<ArtistCollectionPluginBaseTests.FullyCustom>),
-                typeof(AccessedException<PlayableCollectionGroupPluginBaseTests.Unimplemented>),
-            });
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -171,7 +120,6 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
                 customFilter: NoInnerOrSources,
                 typesToExclude: new[]
                 {
-                    typeof(IAsyncDisposable),
                     typeof(IPlayableCollectionItem)
                 });
         }
@@ -188,23 +136,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
             // Ensure an Library plugin can still be accessed through ArtistCollection members.
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<LibraryPluginBaseTests.FullyCustom>, ArtistCollectionPluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
-        }
-
-        [TestMethod]
-        public void DisposingLibrary()
-        {
-            var plugins = new Sdk.Plugins.Model.SdkModelPlugin(SdkTestPluginMetadata.Metadata);
-            plugins.ArtistCollection.Add(x => new ArtistCollectionPluginBaseTests.FullyCustom(x));
-
-            var plugin = StrixMusic.Sdk.Plugins.Model.GlobalModelPluginConnector.Create(plugins).Library.Execute(new LibraryPluginBaseTests.Unimplemented());
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(value: plugin, expectedExceptions: new[]
-            {
-                typeof(AccessedException<ArtistCollectionPluginBaseTests.FullyCustom>),
-                typeof(AccessedException<LibraryPluginBaseTests.Unimplemented>),
-            });
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -220,7 +152,6 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
                 customFilter: NoInnerOrSources,
                 typesToExclude: new[]
                 {
-                    typeof(IAsyncDisposable),
                     typeof(IPlayableCollectionItem)
                 });
         }
@@ -237,23 +168,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
             // Ensure an Discoverables plugin can still be accessed through ArtistCollection members.
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<DiscoverablesPluginBaseTests.FullyCustom>, ArtistCollectionPluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
-        }
-
-        [TestMethod]
-        public void DisposingDiscoverables()
-        {
-            var plugins = new Sdk.Plugins.Model.SdkModelPlugin(SdkTestPluginMetadata.Metadata);
-            plugins.ArtistCollection.Add(x => new ArtistCollectionPluginBaseTests.FullyCustom(x));
-
-            var plugin = StrixMusic.Sdk.Plugins.Model.GlobalModelPluginConnector.Create(plugins).Discoverables.Execute(new DiscoverablesPluginBaseTests.Unimplemented());
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(value: plugin, expectedExceptions: new[]
-            {
-                typeof(AccessedException<ArtistCollectionPluginBaseTests.FullyCustom>),
-                typeof(AccessedException<DiscoverablesPluginBaseTests.Unimplemented>),
-            });
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -269,7 +184,6 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
                 customFilter: NoInnerOrSources,
                 typesToExclude: new[]
                 {
-                    typeof(IAsyncDisposable),
                     typeof(IPlayableCollectionItem)
                 });
         }
@@ -286,23 +200,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
             // Ensure an RecentlyPlayed plugin can still be accessed through ArtistCollection members.
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<RecentlyPlayedPluginBaseTests.FullyCustom>, ArtistCollectionPluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
-        }
-
-        [TestMethod]
-        public void DisposingRecentlyPlayed()
-        {
-            var plugins = new Sdk.Plugins.Model.SdkModelPlugin(SdkTestPluginMetadata.Metadata);
-            plugins.ArtistCollection.Add(x => new ArtistCollectionPluginBaseTests.FullyCustom(x));
-
-            var plugin = StrixMusic.Sdk.Plugins.Model.GlobalModelPluginConnector.Create(plugins).RecentlyPlayed.Execute(new RecentlyPlayedPluginBaseTests.Unimplemented());
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(value: plugin, expectedExceptions: new[]
-            {
-                typeof(AccessedException<ArtistCollectionPluginBaseTests.FullyCustom>),
-                typeof(AccessedException<RecentlyPlayedPluginBaseTests.Unimplemented>),
-            });
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -318,7 +216,6 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
                 customFilter: NoInnerOrSources,
                 typesToExclude: new[]
                 {
-                    typeof(IAsyncDisposable),
                     typeof(IPlayableCollectionItem)
                 });
         }
@@ -335,23 +232,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
             // Ensure an SearchHistory plugin can still be accessed through ArtistCollection members.
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<SearchHistoryPluginBaseTests.FullyCustom>, ArtistCollectionPluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
-        }
-
-        [TestMethod]
-        public void DisposingSearchHistory()
-        {
-            var plugins = new Sdk.Plugins.Model.SdkModelPlugin(SdkTestPluginMetadata.Metadata);
-            plugins.ArtistCollection.Add(x => new ArtistCollectionPluginBaseTests.FullyCustom(x));
-
-            var plugin = StrixMusic.Sdk.Plugins.Model.GlobalModelPluginConnector.Create(plugins).SearchHistory.Execute(new SearchHistoryPluginBaseTests.Unimplemented());
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(value: plugin, expectedExceptions: new[]
-            {
-                typeof(AccessedException<ArtistCollectionPluginBaseTests.FullyCustom>),
-                typeof(AccessedException<SearchHistoryPluginBaseTests.Unimplemented>),
-            });
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -367,7 +248,6 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
                 customFilter: NoInnerOrSources,
                 typesToExclude: new[]
                 {
-                    typeof(IAsyncDisposable),
                     typeof(IPlayableCollectionItem)
                 });
         }
@@ -384,23 +264,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
             // Ensure an SearchResults plugin can still be accessed through ArtistCollection members.
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<SearchResultsPluginBaseTests.FullyCustom>, ArtistCollectionPluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
-        }
-
-        [TestMethod]
-        public void DisposingSearchResults()
-        {
-            var plugins = new Sdk.Plugins.Model.SdkModelPlugin(SdkTestPluginMetadata.Metadata);
-            plugins.ArtistCollection.Add(x => new ArtistCollectionPluginBaseTests.FullyCustom(x));
-
-            var plugin = StrixMusic.Sdk.Plugins.Model.GlobalModelPluginConnector.Create(plugins).SearchResults.Execute(new SearchResultsPluginBaseTests.Unimplemented());
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(value: plugin, expectedExceptions: new[]
-            {
-                typeof(AccessedException<ArtistCollectionPluginBaseTests.FullyCustom>),
-                typeof(AccessedException<SearchResultsPluginBaseTests.Unimplemented>),
-            });
+                customFilter: NoInnerOrSources);
         }
     }
 }

--- a/src/Sdk/StrixMusic.Sdk.Tests/Plugins/Models/GlobalPluginConnector/DownloadableTests.cs
+++ b/src/Sdk/StrixMusic.Sdk.Tests/Plugins/Models/GlobalPluginConnector/DownloadableTests.cs
@@ -18,7 +18,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
 
             var plugin = StrixMusic.Sdk.Plugins.Model.GlobalModelPluginConnector.Create(plugins).Playable.Execute(new PlayablePluginBaseTests.Unimplemented());
 
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<DownloadablePluginBaseTests.FullyCustom>, DownloadablePluginBaseTests.FullyCustom>(plugin, typesToExclude: typeof(IAsyncDisposable));
+            Helpers.AssertAllMembersThrowOnAccess<AccessedException<DownloadablePluginBaseTests.FullyCustom>, DownloadablePluginBaseTests.FullyCustom>(plugin);
         }
 
         [TestMethod]
@@ -31,22 +31,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
             var plugin = StrixMusic.Sdk.Plugins.Model.GlobalModelPluginConnector.Create(plugins).Playable.Execute(new PlayablePluginBaseTests.Unimplemented());
 
             // Ensure a Playable plugin can still be accessed through Downloadable members.
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<PlayablePluginBaseTests.FullyCustom>, DownloadablePluginBaseTests.FullyCustom>(plugin, typesToExclude: typeof(IAsyncDisposable));
-        }
-
-        [TestMethod]
-        public void DisposingPlayable()
-        {
-            var plugins = new Sdk.Plugins.Model.SdkModelPlugin(SdkTestPluginMetadata.Metadata);
-            plugins.Downloadable.Add(x => new DownloadablePluginBaseTests.FullyCustom(x));
-
-            var plugin = StrixMusic.Sdk.Plugins.Model.GlobalModelPluginConnector.Create(plugins).Playable.Execute(new PlayablePluginBaseTests.Unimplemented());
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(plugin, expectedExceptions: new[]
-            {
-                typeof(AccessedException<DownloadablePluginBaseTests.FullyCustom>),
-                typeof(AccessedException<PlayablePluginBaseTests.Unimplemented>),
-            });
+            Helpers.AssertAllMembersThrowOnAccess<AccessedException<PlayablePluginBaseTests.FullyCustom>, DownloadablePluginBaseTests.FullyCustom>(plugin);
         }
 
         [TestMethod]
@@ -57,7 +42,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
 
             var plugin = StrixMusic.Sdk.Plugins.Model.GlobalModelPluginConnector.Create(plugins).TrackCollection.Execute(new TrackCollectionPluginBaseTests.Unimplemented());
 
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<DownloadablePluginBaseTests.FullyCustom>, DownloadablePluginBaseTests.FullyCustom>(plugin, typesToExclude: typeof(IAsyncDisposable));
+            Helpers.AssertAllMembersThrowOnAccess<AccessedException<DownloadablePluginBaseTests.FullyCustom>, DownloadablePluginBaseTests.FullyCustom>(plugin);
         }
 
         [TestMethod]
@@ -70,22 +55,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
             var plugin = StrixMusic.Sdk.Plugins.Model.GlobalModelPluginConnector.Create(plugins).TrackCollection.Execute(new TrackCollectionPluginBaseTests.Unimplemented());
 
             // Ensure a TrackCollection plugin can still be accessed through Downloadable members.
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<TrackCollectionPluginBaseTests.FullyCustom>, DownloadablePluginBaseTests.FullyCustom>(plugin, typesToExclude: typeof(IAsyncDisposable));
-        }
-
-        [TestMethod]
-        public void DisposingTrackCollection()
-        {
-            var plugins = new Sdk.Plugins.Model.SdkModelPlugin(SdkTestPluginMetadata.Metadata);
-            plugins.Downloadable.Add(x => new DownloadablePluginBaseTests.FullyCustom(x));
-
-            var plugin = StrixMusic.Sdk.Plugins.Model.GlobalModelPluginConnector.Create(plugins).TrackCollection.Execute(new TrackCollectionPluginBaseTests.Unimplemented());
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(plugin, expectedExceptions: new[]
-            {
-                typeof(AccessedException<DownloadablePluginBaseTests.FullyCustom>),
-                typeof(AccessedException<TrackCollectionPluginBaseTests.Unimplemented>),
-            });
+            Helpers.AssertAllMembersThrowOnAccess<AccessedException<TrackCollectionPluginBaseTests.FullyCustom>, DownloadablePluginBaseTests.FullyCustom>(plugin);
         }
 
         [TestMethod]
@@ -96,7 +66,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
 
             var plugin = StrixMusic.Sdk.Plugins.Model.GlobalModelPluginConnector.Create(plugins).ArtistCollection.Execute(new ArtistCollectionPluginBaseTests.Unimplemented());
 
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<DownloadablePluginBaseTests.FullyCustom>, DownloadablePluginBaseTests.FullyCustom>(plugin, typesToExclude: typeof(IAsyncDisposable));
+            Helpers.AssertAllMembersThrowOnAccess<AccessedException<DownloadablePluginBaseTests.FullyCustom>, DownloadablePluginBaseTests.FullyCustom>(plugin);
         }
 
         [TestMethod]
@@ -109,22 +79,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
             var plugin = StrixMusic.Sdk.Plugins.Model.GlobalModelPluginConnector.Create(plugins).ArtistCollection.Execute(new ArtistCollectionPluginBaseTests.Unimplemented());
 
             // Ensure an ArtistCollection plugin can still be accessed through Downloadable members.
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<ArtistCollectionPluginBaseTests.FullyCustom>, DownloadablePluginBaseTests.FullyCustom>(plugin, typesToExclude: typeof(IAsyncDisposable));
-        }
-
-        [TestMethod]
-        public void DisposingArtistCollection()
-        {
-            var plugins = new Sdk.Plugins.Model.SdkModelPlugin(SdkTestPluginMetadata.Metadata);
-            plugins.Downloadable.Add(x => new DownloadablePluginBaseTests.FullyCustom(x));
-
-            var plugin = StrixMusic.Sdk.Plugins.Model.GlobalModelPluginConnector.Create(plugins).ArtistCollection.Execute(new ArtistCollectionPluginBaseTests.Unimplemented());
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(plugin, expectedExceptions: new[]
-            {
-                typeof(AccessedException<DownloadablePluginBaseTests.FullyCustom>),
-                typeof(AccessedException<ArtistCollectionPluginBaseTests.Unimplemented>),
-            });
+            Helpers.AssertAllMembersThrowOnAccess<AccessedException<ArtistCollectionPluginBaseTests.FullyCustom>, DownloadablePluginBaseTests.FullyCustom>(plugin);
         }
 
         [TestMethod]
@@ -135,7 +90,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
 
             var plugin = StrixMusic.Sdk.Plugins.Model.GlobalModelPluginConnector.Create(plugins).AlbumCollection.Execute(new AlbumCollectionPluginBaseTests.Unimplemented());
 
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<DownloadablePluginBaseTests.FullyCustom>, DownloadablePluginBaseTests.FullyCustom>(plugin, typesToExclude: typeof(IAsyncDisposable));
+            Helpers.AssertAllMembersThrowOnAccess<AccessedException<DownloadablePluginBaseTests.FullyCustom>, DownloadablePluginBaseTests.FullyCustom>(plugin);
         }
 
         [TestMethod]
@@ -148,22 +103,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
             var plugin = StrixMusic.Sdk.Plugins.Model.GlobalModelPluginConnector.Create(plugins).AlbumCollection.Execute(new AlbumCollectionPluginBaseTests.Unimplemented());
 
             // Ensure an AlbumCollection plugin can still be accessed through Downloadable members.
-            Helpers.AssertAllMembersThrowOnAccess<AccessedException<AlbumCollectionPluginBaseTests.FullyCustom>, DownloadablePluginBaseTests.FullyCustom>(plugin, typesToExclude: typeof(IAsyncDisposable));
-        }
-
-        [TestMethod]
-        public void DisposingAlbumCollection()
-        {
-            var plugins = new Sdk.Plugins.Model.SdkModelPlugin(SdkTestPluginMetadata.Metadata);
-            plugins.Downloadable.Add(x => new DownloadablePluginBaseTests.FullyCustom(x));
-
-            var plugin = StrixMusic.Sdk.Plugins.Model.GlobalModelPluginConnector.Create(plugins).AlbumCollection.Execute(new AlbumCollectionPluginBaseTests.Unimplemented());
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(plugin, expectedExceptions: new[]
-            {
-                typeof(AccessedException<DownloadablePluginBaseTests.FullyCustom>),
-                typeof(AccessedException<AlbumCollectionPluginBaseTests.Unimplemented>),
-            });
+            Helpers.AssertAllMembersThrowOnAccess<AccessedException<AlbumCollectionPluginBaseTests.FullyCustom>, DownloadablePluginBaseTests.FullyCustom>(plugin);
         }
 
         [TestMethod]
@@ -176,8 +116,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
 
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<DownloadablePluginBaseTests.FullyCustom>, DownloadablePluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -192,23 +131,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
             // Ensure an Album plugin can still be accessed through Downloadable members.
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<AlbumPluginBaseTests.FullyCustom>, DownloadablePluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
-        }
-
-        [TestMethod]
-        public void DisposingAlbum()
-        {
-            var plugins = new Sdk.Plugins.Model.SdkModelPlugin(SdkTestPluginMetadata.Metadata);
-            plugins.Downloadable.Add(x => new DownloadablePluginBaseTests.FullyCustom(x));
-
-            var plugin = StrixMusic.Sdk.Plugins.Model.GlobalModelPluginConnector.Create(plugins).Album.Execute(new AlbumPluginBaseTests.Unimplemented());
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(value: plugin, expectedExceptions: new[]
-            {
-                typeof(AccessedException<DownloadablePluginBaseTests.FullyCustom>),
-                typeof(AccessedException<AlbumPluginBaseTests.Unimplemented>),
-            });
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -221,8 +144,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
 
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<DownloadablePluginBaseTests.FullyCustom>, DownloadablePluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -237,23 +159,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
             // Ensure an Artist plugin can still be accessed through Downloadable members.
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<ArtistPluginBaseTests.FullyCustom>, DownloadablePluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
-        }
-
-        [TestMethod]
-        public void DisposingArtist()
-        {
-            var plugins = new Sdk.Plugins.Model.SdkModelPlugin(SdkTestPluginMetadata.Metadata);
-            plugins.Downloadable.Add(x => new DownloadablePluginBaseTests.FullyCustom(x));
-
-            var plugin = StrixMusic.Sdk.Plugins.Model.GlobalModelPluginConnector.Create(plugins).Artist.Execute(new ArtistPluginBaseTests.Unimplemented());
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(value: plugin, expectedExceptions: new[]
-            {
-                typeof(AccessedException<DownloadablePluginBaseTests.FullyCustom>),
-                typeof(AccessedException<ArtistPluginBaseTests.Unimplemented>),
-            });
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -266,8 +172,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
 
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<DownloadablePluginBaseTests.FullyCustom>, DownloadablePluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -282,23 +187,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
             // Ensure an Playlist plugin can still be accessed through Downloadable members.
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<PlaylistPluginBaseTests.FullyCustom>, DownloadablePluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
-        }
-
-        [TestMethod]
-        public void DisposingPlaylist()
-        {
-            var plugins = new Sdk.Plugins.Model.SdkModelPlugin(SdkTestPluginMetadata.Metadata);
-            plugins.Downloadable.Add(x => new DownloadablePluginBaseTests.FullyCustom(x));
-
-            var plugin = StrixMusic.Sdk.Plugins.Model.GlobalModelPluginConnector.Create(plugins).Playlist.Execute(new PlaylistPluginBaseTests.Unimplemented());
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(value: plugin, expectedExceptions: new[]
-            {
-                typeof(AccessedException<DownloadablePluginBaseTests.FullyCustom>),
-                typeof(AccessedException<PlaylistPluginBaseTests.Unimplemented>),
-            });
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -311,8 +200,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
 
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<DownloadablePluginBaseTests.FullyCustom>, DownloadablePluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -327,23 +215,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
             // Ensure an Track plugin can still be accessed through Downloadable members.
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<TrackPluginBaseTests.FullyCustom>, DownloadablePluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
-        }
-
-        [TestMethod]
-        public void DisposingTrack()
-        {
-            var plugins = new Sdk.Plugins.Model.SdkModelPlugin(SdkTestPluginMetadata.Metadata);
-            plugins.Downloadable.Add(x => new DownloadablePluginBaseTests.FullyCustom(x));
-
-            var plugin = StrixMusic.Sdk.Plugins.Model.GlobalModelPluginConnector.Create(plugins).Track.Execute(new TrackPluginBaseTests.Unimplemented());
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(value: plugin, expectedExceptions: new[]
-            {
-                typeof(AccessedException<DownloadablePluginBaseTests.FullyCustom>),
-                typeof(AccessedException<TrackPluginBaseTests.Unimplemented>),
-            });
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -356,8 +228,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
 
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<DownloadablePluginBaseTests.FullyCustom>, DownloadablePluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -372,23 +243,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
             // Ensure an PlayableCollectionGroup plugin can still be accessed through Downloadable members.
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<PlayableCollectionGroupPluginBaseTests.FullyCustom>, DownloadablePluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
-        }
-
-        [TestMethod]
-        public void DisposingPlayableCollectionGroup()
-        {
-            var plugins = new Sdk.Plugins.Model.SdkModelPlugin(SdkTestPluginMetadata.Metadata);
-            plugins.Downloadable.Add(x => new DownloadablePluginBaseTests.FullyCustom(x));
-
-            var plugin = StrixMusic.Sdk.Plugins.Model.GlobalModelPluginConnector.Create(plugins).PlayableCollectionGroup.Execute(new PlayableCollectionGroupPluginBaseTests.Unimplemented());
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(value: plugin, expectedExceptions: new[]
-            {
-                typeof(AccessedException<DownloadablePluginBaseTests.FullyCustom>),
-                typeof(AccessedException<PlayableCollectionGroupPluginBaseTests.Unimplemented>),
-            });
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -401,8 +256,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
 
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<DownloadablePluginBaseTests.FullyCustom>, DownloadablePluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -417,23 +271,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
             // Ensure an Library plugin can still be accessed through Downloadable members.
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<LibraryPluginBaseTests.FullyCustom>, DownloadablePluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
-        }
-
-        [TestMethod]
-        public void DisposingLibrary()
-        {
-            var plugins = new Sdk.Plugins.Model.SdkModelPlugin(SdkTestPluginMetadata.Metadata);
-            plugins.Downloadable.Add(x => new DownloadablePluginBaseTests.FullyCustom(x));
-
-            var plugin = StrixMusic.Sdk.Plugins.Model.GlobalModelPluginConnector.Create(plugins).Library.Execute(new LibraryPluginBaseTests.Unimplemented());
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(value: plugin, expectedExceptions: new[]
-            {
-                typeof(AccessedException<DownloadablePluginBaseTests.FullyCustom>),
-                typeof(AccessedException<LibraryPluginBaseTests.Unimplemented>),
-            });
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -446,8 +284,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
 
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<DownloadablePluginBaseTests.FullyCustom>, DownloadablePluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -462,23 +299,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
             // Ensure an Discoverables plugin can still be accessed through Downloadable members.
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<DiscoverablesPluginBaseTests.FullyCustom>, DownloadablePluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
-        }
-
-        [TestMethod]
-        public void DisposingDiscoverables()
-        {
-            var plugins = new Sdk.Plugins.Model.SdkModelPlugin(SdkTestPluginMetadata.Metadata);
-            plugins.Downloadable.Add(x => new DownloadablePluginBaseTests.FullyCustom(x));
-
-            var plugin = StrixMusic.Sdk.Plugins.Model.GlobalModelPluginConnector.Create(plugins).Discoverables.Execute(new DiscoverablesPluginBaseTests.Unimplemented());
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(value: plugin, expectedExceptions: new[]
-            {
-                typeof(AccessedException<DownloadablePluginBaseTests.FullyCustom>),
-                typeof(AccessedException<DiscoverablesPluginBaseTests.Unimplemented>),
-            });
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -491,8 +312,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
 
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<DownloadablePluginBaseTests.FullyCustom>, DownloadablePluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -507,23 +327,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
             // Ensure an RecentlyPlayed plugin can still be accessed through Downloadable members.
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<RecentlyPlayedPluginBaseTests.FullyCustom>, DownloadablePluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
-        }
-
-        [TestMethod]
-        public void DisposingRecentlyPlayed()
-        {
-            var plugins = new Sdk.Plugins.Model.SdkModelPlugin(SdkTestPluginMetadata.Metadata);
-            plugins.Downloadable.Add(x => new DownloadablePluginBaseTests.FullyCustom(x));
-
-            var plugin = StrixMusic.Sdk.Plugins.Model.GlobalModelPluginConnector.Create(plugins).RecentlyPlayed.Execute(new RecentlyPlayedPluginBaseTests.Unimplemented());
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(value: plugin, expectedExceptions: new[]
-            {
-                typeof(AccessedException<DownloadablePluginBaseTests.FullyCustom>),
-                typeof(AccessedException<RecentlyPlayedPluginBaseTests.Unimplemented>),
-            });
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -536,8 +340,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
 
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<DownloadablePluginBaseTests.FullyCustom>, DownloadablePluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -552,23 +355,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
             // Ensure an SearchHistory plugin can still be accessed through Downloadable members.
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<SearchHistoryPluginBaseTests.FullyCustom>, DownloadablePluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
-        }
-
-        [TestMethod]
-        public void DisposingSearchHistory()
-        {
-            var plugins = new Sdk.Plugins.Model.SdkModelPlugin(SdkTestPluginMetadata.Metadata);
-            plugins.Downloadable.Add(x => new DownloadablePluginBaseTests.FullyCustom(x));
-
-            var plugin = StrixMusic.Sdk.Plugins.Model.GlobalModelPluginConnector.Create(plugins).SearchHistory.Execute(new SearchHistoryPluginBaseTests.Unimplemented());
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(value: plugin, expectedExceptions: new[]
-            {
-                typeof(AccessedException<DownloadablePluginBaseTests.FullyCustom>),
-                typeof(AccessedException<SearchHistoryPluginBaseTests.Unimplemented>),
-            });
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -581,8 +368,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
 
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<DownloadablePluginBaseTests.FullyCustom>, DownloadablePluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -597,23 +383,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
             // Ensure an SearchResults plugin can still be accessed through Downloadable members.
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<SearchResultsPluginBaseTests.FullyCustom>, DownloadablePluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
-        }
-
-        [TestMethod]
-        public void DisposingSearchResults()
-        {
-            var plugins = new Sdk.Plugins.Model.SdkModelPlugin(SdkTestPluginMetadata.Metadata);
-            plugins.Downloadable.Add(x => new DownloadablePluginBaseTests.FullyCustom(x));
-
-            var plugin = StrixMusic.Sdk.Plugins.Model.GlobalModelPluginConnector.Create(plugins).SearchResults.Execute(new SearchResultsPluginBaseTests.Unimplemented());
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(value: plugin, expectedExceptions: new[]
-            {
-                typeof(AccessedException<DownloadablePluginBaseTests.FullyCustom>),
-                typeof(AccessedException<SearchResultsPluginBaseTests.Unimplemented>),
-            });
+                customFilter: NoInnerOrSources);
         }
     }
 }

--- a/src/Sdk/StrixMusic.Sdk.Tests/Plugins/Models/GlobalPluginConnector/GenreCollectionTests.cs
+++ b/src/Sdk/StrixMusic.Sdk.Tests/Plugins/Models/GlobalPluginConnector/GenreCollectionTests.cs
@@ -20,8 +20,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
 
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<GenreCollectionPluginBaseTests.FullyCustom>, GenreCollectionPluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -36,23 +35,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
             // Ensure an Album plugin can still be accessed through GenreCollection members.
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<AlbumPluginBaseTests.FullyCustom>, GenreCollectionPluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
-        }
-
-        [TestMethod]
-        public void DisposingAlbum()
-        {
-            var plugins = new Sdk.Plugins.Model.SdkModelPlugin(SdkTestPluginMetadata.Metadata);
-            plugins.GenreCollection.Add(x => new GenreCollectionPluginBaseTests.FullyCustom(x));
-
-            var plugin = StrixMusic.Sdk.Plugins.Model.GlobalModelPluginConnector.Create(plugins).Album.Execute(new AlbumPluginBaseTests.Unimplemented());
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(value: plugin, expectedExceptions: new[]
-            {
-                typeof(AccessedException<GenreCollectionPluginBaseTests.FullyCustom>),
-                typeof(AccessedException<AlbumPluginBaseTests.Unimplemented>),
-            });
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -65,8 +48,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
 
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<GenreCollectionPluginBaseTests.FullyCustom>, GenreCollectionPluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -81,23 +63,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
             // Ensure an Artist plugin can still be accessed through GenreCollection members.
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<ArtistPluginBaseTests.FullyCustom>, GenreCollectionPluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
-        }
-
-        [TestMethod]
-        public void DisposingArtist()
-        {
-            var plugins = new Sdk.Plugins.Model.SdkModelPlugin(SdkTestPluginMetadata.Metadata);
-            plugins.GenreCollection.Add(x => new GenreCollectionPluginBaseTests.FullyCustom(x));
-
-            var plugin = StrixMusic.Sdk.Plugins.Model.GlobalModelPluginConnector.Create(plugins).Artist.Execute(new ArtistPluginBaseTests.Unimplemented());
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(value: plugin, expectedExceptions: new[]
-            {
-                typeof(AccessedException<GenreCollectionPluginBaseTests.FullyCustom>),
-                typeof(AccessedException<ArtistPluginBaseTests.Unimplemented>),
-            });
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -110,8 +76,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
 
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<GenreCollectionPluginBaseTests.FullyCustom>, GenreCollectionPluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -126,23 +91,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
             // Ensure an Track plugin can still be accessed through GenreCollection members.
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<TrackPluginBaseTests.FullyCustom>, GenreCollectionPluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
-        }
-
-        [TestMethod]
-        public void DisposingTrack()
-        {
-            var plugins = new Sdk.Plugins.Model.SdkModelPlugin(SdkTestPluginMetadata.Metadata);
-            plugins.GenreCollection.Add(x => new GenreCollectionPluginBaseTests.FullyCustom(x));
-
-            var plugin = StrixMusic.Sdk.Plugins.Model.GlobalModelPluginConnector.Create(plugins).Track.Execute(new TrackPluginBaseTests.Unimplemented());
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(value: plugin, expectedExceptions: new[]
-            {
-                typeof(AccessedException<GenreCollectionPluginBaseTests.FullyCustom>),
-                typeof(AccessedException<TrackPluginBaseTests.Unimplemented>),
-            });
+                customFilter: NoInnerOrSources);
         }
     }
 }

--- a/src/Sdk/StrixMusic.Sdk.Tests/Plugins/Models/GlobalPluginConnector/ImageCollectionTests.cs
+++ b/src/Sdk/StrixMusic.Sdk.Tests/Plugins/Models/GlobalPluginConnector/ImageCollectionTests.cs
@@ -20,8 +20,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
 
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<ImageCollectionPluginBaseTests.FullyCustom>, ImageCollectionPluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -36,22 +35,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
             // Ensure a Playable plugin can still be accessed through ImageCollection members.
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<PlayablePluginBaseTests.FullyCustom>, ImageCollectionPluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
-        }
-
-        [TestMethod]
-        public void DisposingPlayable()
-        {
-            var plugins = new Sdk.Plugins.Model.SdkModelPlugin(SdkTestPluginMetadata.Metadata);
-            plugins.ImageCollection.Add(x => new ImageCollectionPluginBaseTests.FullyCustom(x));
-
-            var plugin = StrixMusic.Sdk.Plugins.Model.GlobalModelPluginConnector.Create(plugins).Playable.Execute(new PlayablePluginBaseTests.Unimplemented());
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(plugin, expectedExceptions: new[] {
-                typeof(AccessedException<ImageCollectionPluginBaseTests.FullyCustom>),
-                typeof(AccessedException<PlayablePluginBaseTests.Unimplemented>),
-            });
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -64,8 +48,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
 
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<ImageCollectionPluginBaseTests.FullyCustom>, ImageCollectionPluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -80,21 +63,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
             // Ensure a TrackCollection plugin can still be accessed through ImageCollection members.
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<TrackCollectionPluginBaseTests.FullyCustom>, ImageCollectionPluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
-        }
-
-        [TestMethod]
-        public void DisposingTrackCollection()
-        {
-            var plugins = new Sdk.Plugins.Model.SdkModelPlugin(SdkTestPluginMetadata.Metadata);
-            plugins.ImageCollection.Add(x => new ImageCollectionPluginBaseTests.FullyCustom(x));
-            var plugin = StrixMusic.Sdk.Plugins.Model.GlobalModelPluginConnector.Create(plugins).TrackCollection.Execute(new TrackCollectionPluginBaseTests.Unimplemented());
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(plugin, customFilter: NoInnerOrSources, expectedExceptions: new[] {
-                typeof(AccessedException<ImageCollectionPluginBaseTests.FullyCustom>),
-                typeof(AccessedException<TrackCollectionPluginBaseTests.Unimplemented>),
-            });
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -107,8 +76,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
 
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<ImageCollectionPluginBaseTests.FullyCustom>, ImageCollectionPluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -123,22 +91,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
             // Ensure an ArtistCollection plugin can still be accessed through ImageCollection members.
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<ArtistCollectionPluginBaseTests.FullyCustom>, ImageCollectionPluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
-        }
-
-        [TestMethod]
-        public void DisposingArtistCollection()
-        {
-            var plugins = new Sdk.Plugins.Model.SdkModelPlugin(SdkTestPluginMetadata.Metadata);
-            plugins.ImageCollection.Add(x => new ImageCollectionPluginBaseTests.FullyCustom(x));
-
-            var plugin = StrixMusic.Sdk.Plugins.Model.GlobalModelPluginConnector.Create(plugins).ArtistCollection.Execute(new ArtistCollectionPluginBaseTests.Unimplemented());
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(plugin, customFilter: NoInnerOrSources, expectedExceptions: new[] {
-                typeof(AccessedException<ImageCollectionPluginBaseTests.FullyCustom>),
-                typeof(AccessedException<ArtistCollectionPluginBaseTests.Unimplemented>),
-            });
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -151,8 +104,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
 
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<ImageCollectionPluginBaseTests.FullyCustom>, ImageCollectionPluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -167,22 +119,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
             // Ensure an AlbumCollection plugin can still be accessed through ImageCollection members.
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<AlbumCollectionPluginBaseTests.FullyCustom>, ImageCollectionPluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
-        }
-
-        [TestMethod]
-        public void DisposingAlbumCollection()
-        {
-            var plugins = new Sdk.Plugins.Model.SdkModelPlugin(SdkTestPluginMetadata.Metadata);
-            plugins.ImageCollection.Add(x => new ImageCollectionPluginBaseTests.FullyCustom(x));
-
-            var plugin = StrixMusic.Sdk.Plugins.Model.GlobalModelPluginConnector.Create(plugins).AlbumCollection.Execute(new AlbumCollectionPluginBaseTests.Unimplemented());
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(value: plugin, expectedExceptions: new[] {
-                typeof(AccessedException<ImageCollectionPluginBaseTests.FullyCustom>),
-                typeof(AccessedException<AlbumCollectionPluginBaseTests.Unimplemented>),
-            });
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -195,8 +132,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
 
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<ImageCollectionPluginBaseTests.FullyCustom>, ImageCollectionPluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -211,22 +147,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
             // Ensure an Album plugin can still be accessed through ImageCollection members.
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<AlbumPluginBaseTests.FullyCustom>, ImageCollectionPluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
-        }
-
-        [TestMethod]
-        public void DisposingAlbum()
-        {
-            var plugins = new Sdk.Plugins.Model.SdkModelPlugin(SdkTestPluginMetadata.Metadata);
-            plugins.ImageCollection.Add(x => new ImageCollectionPluginBaseTests.FullyCustom(x));
-
-            var plugin = StrixMusic.Sdk.Plugins.Model.GlobalModelPluginConnector.Create(plugins).Album.Execute(new AlbumPluginBaseTests.Unimplemented());
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(value: plugin, expectedExceptions: new[] {
-                typeof(AccessedException<ImageCollectionPluginBaseTests.FullyCustom>),
-                typeof(AccessedException<AlbumPluginBaseTests.Unimplemented>),
-            });
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -239,8 +160,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
 
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<ImageCollectionPluginBaseTests.FullyCustom>, ImageCollectionPluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -255,22 +175,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
             // Ensure an Artist plugin can still be accessed through ImageCollection members.
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<ArtistPluginBaseTests.FullyCustom>, ImageCollectionPluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
-        }
-
-        [TestMethod]
-        public void DisposingArtist()
-        {
-            var plugins = new Sdk.Plugins.Model.SdkModelPlugin(SdkTestPluginMetadata.Metadata);
-            plugins.ImageCollection.Add(x => new ImageCollectionPluginBaseTests.FullyCustom(x));
-
-            var plugin = StrixMusic.Sdk.Plugins.Model.GlobalModelPluginConnector.Create(plugins).Artist.Execute(new ArtistPluginBaseTests.Unimplemented());
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(value: plugin, expectedExceptions: new[] {
-                typeof(AccessedException<ImageCollectionPluginBaseTests.FullyCustom>),
-                typeof(AccessedException<ArtistPluginBaseTests.Unimplemented>),
-            });
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -283,8 +188,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
 
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<ImageCollectionPluginBaseTests.FullyCustom>, ImageCollectionPluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -299,22 +203,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
             // Ensure an Playlist plugin can still be accessed through ImageCollection members.
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<PlaylistPluginBaseTests.FullyCustom>, ImageCollectionPluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
-        }
-
-        [TestMethod]
-        public void DisposingPlaylist()
-        {
-            var plugins = new Sdk.Plugins.Model.SdkModelPlugin(SdkTestPluginMetadata.Metadata);
-            plugins.ImageCollection.Add(x => new ImageCollectionPluginBaseTests.FullyCustom(x));
-
-            var plugin = StrixMusic.Sdk.Plugins.Model.GlobalModelPluginConnector.Create(plugins).Playlist.Execute(new PlaylistPluginBaseTests.Unimplemented());
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(value: plugin, expectedExceptions: new[] {
-                typeof(AccessedException<ImageCollectionPluginBaseTests.FullyCustom>),
-                typeof(AccessedException<PlaylistPluginBaseTests.Unimplemented>),
-            });
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -327,8 +216,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
 
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<ImageCollectionPluginBaseTests.FullyCustom>, ImageCollectionPluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -343,22 +231,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
             // Ensure an Track plugin can still be accessed through ImageCollection members.
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<TrackPluginBaseTests.FullyCustom>, ImageCollectionPluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
-        }
-
-        [TestMethod]
-        public void DisposingTrack()
-        {
-            var plugins = new Sdk.Plugins.Model.SdkModelPlugin(SdkTestPluginMetadata.Metadata);
-            plugins.ImageCollection.Add(x => new ImageCollectionPluginBaseTests.FullyCustom(x));
-
-            var plugin = StrixMusic.Sdk.Plugins.Model.GlobalModelPluginConnector.Create(plugins).Track.Execute(new TrackPluginBaseTests.Unimplemented());
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(value: plugin, expectedExceptions: new[] {
-                typeof(AccessedException<ImageCollectionPluginBaseTests.FullyCustom>),
-                typeof(AccessedException<TrackPluginBaseTests.Unimplemented>),
-            });
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -371,8 +244,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
 
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<ImageCollectionPluginBaseTests.FullyCustom>, ImageCollectionPluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -387,22 +259,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
             // Ensure an PlayableCollectionGroup plugin can still be accessed through ImageCollection members.
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<PlayableCollectionGroupPluginBaseTests.FullyCustom>, ImageCollectionPluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
-        }
-
-        [TestMethod]
-        public void DisposingPlayableCollectionGroup()
-        {
-            var plugins = new Sdk.Plugins.Model.SdkModelPlugin(SdkTestPluginMetadata.Metadata);
-            plugins.ImageCollection.Add(x => new ImageCollectionPluginBaseTests.FullyCustom(x));
-
-            var plugin = StrixMusic.Sdk.Plugins.Model.GlobalModelPluginConnector.Create(plugins).PlayableCollectionGroup.Execute(new PlayableCollectionGroupPluginBaseTests.Unimplemented());
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(value: plugin, expectedExceptions: new[] {
-                typeof(AccessedException<ImageCollectionPluginBaseTests.FullyCustom>),
-                typeof(AccessedException<PlayableCollectionGroupPluginBaseTests.Unimplemented>),
-            });
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -415,8 +272,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
 
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<ImageCollectionPluginBaseTests.FullyCustom>, ImageCollectionPluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -431,22 +287,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
             // Ensure an Library plugin can still be accessed through ImageCollection members.
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<LibraryPluginBaseTests.FullyCustom>, ImageCollectionPluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
-        }
-
-        [TestMethod]
-        public void DisposingLibrary()
-        {
-            var plugins = new Sdk.Plugins.Model.SdkModelPlugin(SdkTestPluginMetadata.Metadata);
-            plugins.ImageCollection.Add(x => new ImageCollectionPluginBaseTests.FullyCustom(x));
-
-            var plugin = StrixMusic.Sdk.Plugins.Model.GlobalModelPluginConnector.Create(plugins).Library.Execute(new LibraryPluginBaseTests.Unimplemented());
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(value: plugin, expectedExceptions: new[] {
-                typeof(AccessedException<ImageCollectionPluginBaseTests.FullyCustom>),
-                typeof(AccessedException<LibraryPluginBaseTests.Unimplemented>),
-            });
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -459,8 +300,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
 
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<ImageCollectionPluginBaseTests.FullyCustom>, ImageCollectionPluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -475,22 +315,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
             // Ensure an Discoverables plugin can still be accessed through ImageCollection members.
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<DiscoverablesPluginBaseTests.FullyCustom>, ImageCollectionPluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
-        }
-
-        [TestMethod]
-        public void DisposingDiscoverables()
-        {
-            var plugins = new Sdk.Plugins.Model.SdkModelPlugin(SdkTestPluginMetadata.Metadata);
-            plugins.ImageCollection.Add(x => new ImageCollectionPluginBaseTests.FullyCustom(x));
-
-            var plugin = StrixMusic.Sdk.Plugins.Model.GlobalModelPluginConnector.Create(plugins).Discoverables.Execute(new DiscoverablesPluginBaseTests.Unimplemented());
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(value: plugin, expectedExceptions: new[] {
-                typeof(AccessedException<ImageCollectionPluginBaseTests.FullyCustom>),
-                typeof(AccessedException<DiscoverablesPluginBaseTests.Unimplemented>),
-            });
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -503,8 +328,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
 
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<ImageCollectionPluginBaseTests.FullyCustom>, ImageCollectionPluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -519,22 +343,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
             // Ensure an RecentlyPlayed plugin can still be accessed through ImageCollection members.
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<RecentlyPlayedPluginBaseTests.FullyCustom>, ImageCollectionPluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
-        }
-
-        [TestMethod]
-        public void DisposingRecentlyPlayed()
-        {
-            var plugins = new Sdk.Plugins.Model.SdkModelPlugin(SdkTestPluginMetadata.Metadata);
-            plugins.ImageCollection.Add(x => new ImageCollectionPluginBaseTests.FullyCustom(x));
-
-            var plugin = StrixMusic.Sdk.Plugins.Model.GlobalModelPluginConnector.Create(plugins).RecentlyPlayed.Execute(new RecentlyPlayedPluginBaseTests.Unimplemented());
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(value: plugin, expectedExceptions: new[] {
-                typeof(AccessedException<ImageCollectionPluginBaseTests.FullyCustom>),
-                typeof(AccessedException<RecentlyPlayedPluginBaseTests.Unimplemented>),
-            });
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -547,8 +356,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
 
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<ImageCollectionPluginBaseTests.FullyCustom>, ImageCollectionPluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -563,22 +371,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
             // Ensure an SearchHistory plugin can still be accessed through ImageCollection members.
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<SearchHistoryPluginBaseTests.FullyCustom>, ImageCollectionPluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
-        }
-
-        [TestMethod]
-        public void DisposingSearchHistory()
-        {
-            var plugins = new Sdk.Plugins.Model.SdkModelPlugin(SdkTestPluginMetadata.Metadata);
-            plugins.ImageCollection.Add(x => new ImageCollectionPluginBaseTests.FullyCustom(x));
-
-            var plugin = StrixMusic.Sdk.Plugins.Model.GlobalModelPluginConnector.Create(plugins).SearchHistory.Execute(new SearchHistoryPluginBaseTests.Unimplemented());
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(value: plugin, expectedExceptions: new[] {
-                typeof(AccessedException<ImageCollectionPluginBaseTests.FullyCustom>),
-                typeof(AccessedException<SearchHistoryPluginBaseTests.Unimplemented>),
-            });
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -591,8 +384,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
 
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<ImageCollectionPluginBaseTests.FullyCustom>, ImageCollectionPluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -607,22 +399,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
             // Ensure an SearchResults plugin can still be accessed through ImageCollection members.
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<SearchResultsPluginBaseTests.FullyCustom>, ImageCollectionPluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
-        }
-
-        [TestMethod]
-        public void DisposingSearchResults()
-        {
-            var plugins = new Sdk.Plugins.Model.SdkModelPlugin(SdkTestPluginMetadata.Metadata);
-            plugins.ImageCollection.Add(x => new ImageCollectionPluginBaseTests.FullyCustom(x));
-
-            var plugin = StrixMusic.Sdk.Plugins.Model.GlobalModelPluginConnector.Create(plugins).SearchResults.Execute(new SearchResultsPluginBaseTests.Unimplemented());
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(value: plugin, expectedExceptions: new[] {
-                typeof(AccessedException<ImageCollectionPluginBaseTests.FullyCustom>),
-                typeof(AccessedException<SearchResultsPluginBaseTests.Unimplemented>),
-            });
+                customFilter: NoInnerOrSources);
         }
     }
 }

--- a/src/Sdk/StrixMusic.Sdk.Tests/Plugins/Models/GlobalPluginConnector/PlayableTests.cs
+++ b/src/Sdk/StrixMusic.Sdk.Tests/Plugins/Models/GlobalPluginConnector/PlayableTests.cs
@@ -20,8 +20,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
 
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<PlayablePluginBaseTests.FullyCustom>, PlayablePluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -36,22 +35,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
             // Ensure a TrackCollection plugin can still be accessed through Playable members.
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<TrackCollectionPluginBaseTests.FullyCustom>, PlayablePluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
-        }
-
-        [TestMethod]
-        public void DisposingTrackCollection()
-        {
-            var plugins = new Sdk.Plugins.Model.SdkModelPlugin(SdkTestPluginMetadata.Metadata);
-            plugins.Playable.Add(x => new PlayablePluginBaseTests.FullyCustom(x));
-
-            var plugin = StrixMusic.Sdk.Plugins.Model.GlobalModelPluginConnector.Create(plugins).TrackCollection.Execute(new TrackCollectionPluginBaseTests.Unimplemented());
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(plugin, expectedExceptions: new[] {
-                typeof(AccessedException<PlayablePluginBaseTests.FullyCustom>),
-                typeof(AccessedException<TrackCollectionPluginBaseTests.Unimplemented>),
-            });
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -64,8 +48,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
 
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<PlayablePluginBaseTests.FullyCustom>, PlayablePluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -80,22 +63,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
             // Ensure an ArtistCollection plugin can still be accessed through Playable members.
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<ArtistCollectionPluginBaseTests.FullyCustom>, PlayablePluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
-        }
-
-        [TestMethod]
-        public void DisposingArtistCollection()
-        {
-            var plugins = new Sdk.Plugins.Model.SdkModelPlugin(SdkTestPluginMetadata.Metadata);
-            plugins.Playable.Add(x => new PlayablePluginBaseTests.FullyCustom(x));
-
-            var plugin = StrixMusic.Sdk.Plugins.Model.GlobalModelPluginConnector.Create(plugins).ArtistCollection.Execute(new ArtistCollectionPluginBaseTests.Unimplemented());
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(plugin, customFilter: NoInnerOrSources, expectedExceptions: new[] {
-                typeof(AccessedException<PlayablePluginBaseTests.FullyCustom>),
-                typeof(AccessedException<ArtistCollectionPluginBaseTests.Unimplemented>),
-            });
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -108,8 +76,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
 
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<PlayablePluginBaseTests.FullyCustom>, PlayablePluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -124,22 +91,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
             // Ensure an AlbumCollection plugin can still be accessed through Playable members.
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<AlbumCollectionPluginBaseTests.FullyCustom>, PlayablePluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources, 
-                typesToExclude: typeof(IAsyncDisposable));
-        }
-
-        [TestMethod]
-        public void DisposingAlbumCollection()
-        {
-            var plugins = new Sdk.Plugins.Model.SdkModelPlugin(SdkTestPluginMetadata.Metadata);
-            plugins.Playable.Add(x => new PlayablePluginBaseTests.FullyCustom(x));
-
-            var plugin = StrixMusic.Sdk.Plugins.Model.GlobalModelPluginConnector.Create(plugins).AlbumCollection.Execute(new AlbumCollectionPluginBaseTests.Unimplemented());
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(plugin, expectedExceptions: new[] {
-                typeof(AccessedException<PlayablePluginBaseTests.FullyCustom>),
-                typeof(AccessedException<AlbumCollectionPluginBaseTests.Unimplemented>),
-            });
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -152,8 +104,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
 
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<PlayablePluginBaseTests.FullyCustom>, PlayablePluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -168,22 +119,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
             // Ensure an Album plugin can still be accessed through Playable members.
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<AlbumPluginBaseTests.FullyCustom>, PlayablePluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources, 
-                typesToExclude: typeof(IAsyncDisposable));
-        }
-
-        [TestMethod]
-        public void DisposingAlbum()
-        {
-            var plugins = new Sdk.Plugins.Model.SdkModelPlugin(SdkTestPluginMetadata.Metadata);
-            plugins.Playable.Add(x => new PlayablePluginBaseTests.FullyCustom(x));
-
-            var plugin = StrixMusic.Sdk.Plugins.Model.GlobalModelPluginConnector.Create(plugins).Album.Execute(new AlbumPluginBaseTests.Unimplemented());
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(plugin, expectedExceptions: new[] {
-                typeof(AccessedException<PlayablePluginBaseTests.FullyCustom>),
-                typeof(AccessedException<AlbumPluginBaseTests.Unimplemented>),
-            });
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -196,8 +132,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
 
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<PlayablePluginBaseTests.FullyCustom>, PlayablePluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -212,22 +147,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
             // Ensure an Artist plugin can still be accessed through Playable members.
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<ArtistPluginBaseTests.FullyCustom>, PlayablePluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources, 
-                typesToExclude: typeof(IAsyncDisposable));
-        }
-
-        [TestMethod]
-        public void DisposingArtist()
-        {
-            var plugins = new Sdk.Plugins.Model.SdkModelPlugin(SdkTestPluginMetadata.Metadata);
-            plugins.Playable.Add(x => new PlayablePluginBaseTests.FullyCustom(x));
-
-            var plugin = StrixMusic.Sdk.Plugins.Model.GlobalModelPluginConnector.Create(plugins).Artist.Execute(new ArtistPluginBaseTests.Unimplemented());
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(plugin, expectedExceptions: new[] {
-                typeof(AccessedException<PlayablePluginBaseTests.FullyCustom>),
-                typeof(AccessedException<ArtistPluginBaseTests.Unimplemented>),
-            });
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -240,8 +160,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
 
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<PlayablePluginBaseTests.FullyCustom>, PlayablePluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -256,22 +175,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
             // Ensure an Playlist plugin can still be accessed through Playable members.
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<PlaylistPluginBaseTests.FullyCustom>, PlayablePluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources, 
-                typesToExclude: typeof(IAsyncDisposable));
-        }
-
-        [TestMethod]
-        public void DisposingPlaylist()
-        {
-            var plugins = new Sdk.Plugins.Model.SdkModelPlugin(SdkTestPluginMetadata.Metadata);
-            plugins.Playable.Add(x => new PlayablePluginBaseTests.FullyCustom(x));
-
-            var plugin = StrixMusic.Sdk.Plugins.Model.GlobalModelPluginConnector.Create(plugins).Playlist.Execute(new PlaylistPluginBaseTests.Unimplemented());
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(plugin, expectedExceptions: new[] {
-                typeof(AccessedException<PlayablePluginBaseTests.FullyCustom>),
-                typeof(AccessedException<PlaylistPluginBaseTests.Unimplemented>),
-            });
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -284,8 +188,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
 
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<PlayablePluginBaseTests.FullyCustom>, PlayablePluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -300,22 +203,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
             // Ensure an Track plugin can still be accessed through Playable members.
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<TrackPluginBaseTests.FullyCustom>, PlayablePluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources, 
-                typesToExclude: typeof(IAsyncDisposable));
-        }
-
-        [TestMethod]
-        public void DisposingTrack()
-        {
-            var plugins = new Sdk.Plugins.Model.SdkModelPlugin(SdkTestPluginMetadata.Metadata);
-            plugins.Playable.Add(x => new PlayablePluginBaseTests.FullyCustom(x));
-
-            var plugin = StrixMusic.Sdk.Plugins.Model.GlobalModelPluginConnector.Create(plugins).Track.Execute(new TrackPluginBaseTests.Unimplemented());
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(plugin, expectedExceptions: new[] {
-                typeof(AccessedException<PlayablePluginBaseTests.FullyCustom>),
-                typeof(AccessedException<TrackPluginBaseTests.Unimplemented>),
-            });
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -328,8 +216,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
 
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<PlayablePluginBaseTests.FullyCustom>, PlayablePluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -344,22 +231,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
             // Ensure an PlayableCollectionGroup plugin can still be accessed through Playable members.
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<PlayableCollectionGroupPluginBaseTests.FullyCustom>, PlayablePluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources, 
-                typesToExclude: typeof(IAsyncDisposable));
-        }
-
-        [TestMethod]
-        public void DisposingPlayableCollectionGroup()
-        {
-            var plugins = new Sdk.Plugins.Model.SdkModelPlugin(SdkTestPluginMetadata.Metadata);
-            plugins.Playable.Add(x => new PlayablePluginBaseTests.FullyCustom(x));
-
-            var plugin = StrixMusic.Sdk.Plugins.Model.GlobalModelPluginConnector.Create(plugins).PlayableCollectionGroup.Execute(new PlayableCollectionGroupPluginBaseTests.Unimplemented());
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(plugin, expectedExceptions: new[] {
-                typeof(AccessedException<PlayablePluginBaseTests.FullyCustom>),
-                typeof(AccessedException<PlayableCollectionGroupPluginBaseTests.Unimplemented>),
-            });
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -372,8 +244,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
 
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<PlayablePluginBaseTests.FullyCustom>, PlayablePluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -388,22 +259,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
             // Ensure an Library plugin can still be accessed through Playable members.
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<LibraryPluginBaseTests.FullyCustom>, PlayablePluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources, 
-                typesToExclude: typeof(IAsyncDisposable));
-        }
-
-        [TestMethod]
-        public void DisposingLibrary()
-        {
-            var plugins = new Sdk.Plugins.Model.SdkModelPlugin(SdkTestPluginMetadata.Metadata);
-            plugins.Playable.Add(x => new PlayablePluginBaseTests.FullyCustom(x));
-
-            var plugin = StrixMusic.Sdk.Plugins.Model.GlobalModelPluginConnector.Create(plugins).Library.Execute(new LibraryPluginBaseTests.Unimplemented());
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(plugin, expectedExceptions: new[] {
-                typeof(AccessedException<PlayablePluginBaseTests.FullyCustom>),
-                typeof(AccessedException<LibraryPluginBaseTests.Unimplemented>),
-            });
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -416,8 +272,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
 
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<PlayablePluginBaseTests.FullyCustom>, PlayablePluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -432,22 +287,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
             // Ensure an Discoverables plugin can still be accessed through Playable members.
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<DiscoverablesPluginBaseTests.FullyCustom>, PlayablePluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources, 
-                typesToExclude: typeof(IAsyncDisposable));
-        }
-
-        [TestMethod]
-        public void DisposingDiscoverables()
-        {
-            var plugins = new Sdk.Plugins.Model.SdkModelPlugin(SdkTestPluginMetadata.Metadata);
-            plugins.Playable.Add(x => new PlayablePluginBaseTests.FullyCustom(x));
-
-            var plugin = StrixMusic.Sdk.Plugins.Model.GlobalModelPluginConnector.Create(plugins).Discoverables.Execute(new DiscoverablesPluginBaseTests.Unimplemented());
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(plugin, expectedExceptions: new[] {
-                typeof(AccessedException<PlayablePluginBaseTests.FullyCustom>),
-                typeof(AccessedException<DiscoverablesPluginBaseTests.Unimplemented>),
-            });
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -460,8 +300,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
 
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<PlayablePluginBaseTests.FullyCustom>, PlayablePluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -476,22 +315,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
             // Ensure an RecentlyPlayed plugin can still be accessed through Playable members.
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<RecentlyPlayedPluginBaseTests.FullyCustom>, PlayablePluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources, 
-                typesToExclude: typeof(IAsyncDisposable));
-        }
-
-        [TestMethod]
-        public void DisposingRecentlyPlayed()
-        {
-            var plugins = new Sdk.Plugins.Model.SdkModelPlugin(SdkTestPluginMetadata.Metadata);
-            plugins.Playable.Add(x => new PlayablePluginBaseTests.FullyCustom(x));
-
-            var plugin = StrixMusic.Sdk.Plugins.Model.GlobalModelPluginConnector.Create(plugins).RecentlyPlayed.Execute(new RecentlyPlayedPluginBaseTests.Unimplemented());
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(plugin, expectedExceptions: new[] {
-                typeof(AccessedException<PlayablePluginBaseTests.FullyCustom>),
-                typeof(AccessedException<RecentlyPlayedPluginBaseTests.Unimplemented>),
-            });
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -504,8 +328,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
 
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<PlayablePluginBaseTests.FullyCustom>, PlayablePluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -520,22 +343,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
             // Ensure an SearchHistory plugin can still be accessed through Playable members.
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<SearchHistoryPluginBaseTests.FullyCustom>, PlayablePluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources, 
-                typesToExclude: typeof(IAsyncDisposable));
-        }
-
-        [TestMethod]
-        public void DisposingSearchHistory()
-        {
-            var plugins = new Sdk.Plugins.Model.SdkModelPlugin(SdkTestPluginMetadata.Metadata);
-            plugins.Playable.Add(x => new PlayablePluginBaseTests.FullyCustom(x));
-
-            var plugin = StrixMusic.Sdk.Plugins.Model.GlobalModelPluginConnector.Create(plugins).SearchHistory.Execute(new SearchHistoryPluginBaseTests.Unimplemented());
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(plugin, expectedExceptions: new[] {
-                typeof(AccessedException<PlayablePluginBaseTests.FullyCustom>),
-                typeof(AccessedException<SearchHistoryPluginBaseTests.Unimplemented>),
-            });
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -548,8 +356,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
 
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<PlayablePluginBaseTests.FullyCustom>, PlayablePluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -564,22 +371,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
             // Ensure an SearchResults plugin can still be accessed through Playable members.
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<SearchResultsPluginBaseTests.FullyCustom>, PlayablePluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources, 
-                typesToExclude: typeof(IAsyncDisposable));
-        }
-
-        [TestMethod]
-        public void DisposingSearchResults()
-        {
-            var plugins = new Sdk.Plugins.Model.SdkModelPlugin(SdkTestPluginMetadata.Metadata);
-            plugins.Playable.Add(x => new PlayablePluginBaseTests.FullyCustom(x));
-
-            var plugin = StrixMusic.Sdk.Plugins.Model.GlobalModelPluginConnector.Create(plugins).SearchResults.Execute(new SearchResultsPluginBaseTests.Unimplemented());
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(plugin, expectedExceptions: new[] {
-                typeof(AccessedException<PlayablePluginBaseTests.FullyCustom>),
-                typeof(AccessedException<SearchResultsPluginBaseTests.Unimplemented>),
-            });
+                customFilter: NoInnerOrSources);
         }
     }
 }

--- a/src/Sdk/StrixMusic.Sdk.Tests/Plugins/Models/GlobalPluginConnector/PlaylistCollectionTests.cs
+++ b/src/Sdk/StrixMusic.Sdk.Tests/Plugins/Models/GlobalPluginConnector/PlaylistCollectionTests.cs
@@ -24,7 +24,6 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
                 customFilter: NoInnerOrSources,
                 typesToExclude: new[]
                 {
-                    typeof(IAsyncDisposable),
                     typeof(IPlayableCollectionItem)
                 });
         }
@@ -41,23 +40,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
             // Ensure an PlayableCollectionGroup plugin can still be accessed through PlaylistCollection members.
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<PlayableCollectionGroupPluginBaseTests.FullyCustom>, PlaylistCollectionPluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
-        }
-
-        [TestMethod]
-        public void DisposingPlayableCollectionGroup()
-        {
-            var plugins = new Sdk.Plugins.Model.SdkModelPlugin(SdkTestPluginMetadata.Metadata);
-            plugins.PlaylistCollection.Add(x => new PlaylistCollectionPluginBaseTests.FullyCustom(x));
-
-            var plugin = StrixMusic.Sdk.Plugins.Model.GlobalModelPluginConnector.Create(plugins).PlayableCollectionGroup.Execute(new PlayableCollectionGroupPluginBaseTests.Unimplemented());
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(value: plugin, expectedExceptions: new[]
-            {
-                typeof(AccessedException<PlaylistCollectionPluginBaseTests.FullyCustom>),
-                typeof(AccessedException<PlayableCollectionGroupPluginBaseTests.Unimplemented>),
-            });
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -73,7 +56,6 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
                 customFilter: NoInnerOrSources,
                 typesToExclude: new[]
                 {
-                    typeof(IAsyncDisposable),
                     typeof(IPlayableCollectionItem)
                 });
         }
@@ -90,23 +72,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
             // Ensure an Library plugin can still be accessed through PlaylistCollection members.
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<LibraryPluginBaseTests.FullyCustom>, PlaylistCollectionPluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
-        }
-
-        [TestMethod]
-        public void DisposingLibrary()
-        {
-            var plugins = new Sdk.Plugins.Model.SdkModelPlugin(SdkTestPluginMetadata.Metadata);
-            plugins.PlaylistCollection.Add(x => new PlaylistCollectionPluginBaseTests.FullyCustom(x));
-
-            var plugin = StrixMusic.Sdk.Plugins.Model.GlobalModelPluginConnector.Create(plugins).Library.Execute(new LibraryPluginBaseTests.Unimplemented());
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(value: plugin, expectedExceptions: new[]
-            {
-                typeof(AccessedException<PlaylistCollectionPluginBaseTests.FullyCustom>),
-                typeof(AccessedException<LibraryPluginBaseTests.Unimplemented>),
-            });
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -122,7 +88,6 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
                 customFilter: NoInnerOrSources,
                 typesToExclude: new[]
                 {
-                    typeof(IAsyncDisposable),
                     typeof(IPlayableCollectionItem)
                 });
         }
@@ -139,23 +104,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
             // Ensure an Discoverables plugin can still be accessed through PlaylistCollection members.
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<DiscoverablesPluginBaseTests.FullyCustom>, PlaylistCollectionPluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
-        }
-
-        [TestMethod]
-        public void DisposingDiscoverables()
-        {
-            var plugins = new Sdk.Plugins.Model.SdkModelPlugin(SdkTestPluginMetadata.Metadata);
-            plugins.PlaylistCollection.Add(x => new PlaylistCollectionPluginBaseTests.FullyCustom(x));
-
-            var plugin = StrixMusic.Sdk.Plugins.Model.GlobalModelPluginConnector.Create(plugins).Discoverables.Execute(new DiscoverablesPluginBaseTests.Unimplemented());
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(value: plugin, expectedExceptions: new[]
-            {
-                typeof(AccessedException<PlaylistCollectionPluginBaseTests.FullyCustom>),
-                typeof(AccessedException<DiscoverablesPluginBaseTests.Unimplemented>),
-            });
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -171,7 +120,6 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
                 customFilter: NoInnerOrSources,
                 typesToExclude: new[]
                 {
-                    typeof(IAsyncDisposable),
                     typeof(IPlayableCollectionItem)
                 });
         }
@@ -188,23 +136,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
             // Ensure an SearchHistory plugin can still be accessed through PlaylistCollection members.
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<SearchHistoryPluginBaseTests.FullyCustom>, PlaylistCollectionPluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
-        }
-
-        [TestMethod]
-        public void DisposingSearchHistory()
-        {
-            var plugins = new Sdk.Plugins.Model.SdkModelPlugin(SdkTestPluginMetadata.Metadata);
-            plugins.PlaylistCollection.Add(x => new PlaylistCollectionPluginBaseTests.FullyCustom(x));
-
-            var plugin = StrixMusic.Sdk.Plugins.Model.GlobalModelPluginConnector.Create(plugins).SearchHistory.Execute(new SearchHistoryPluginBaseTests.Unimplemented());
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(value: plugin, expectedExceptions: new[]
-            {
-                typeof(AccessedException<PlaylistCollectionPluginBaseTests.FullyCustom>),
-                typeof(AccessedException<SearchHistoryPluginBaseTests.Unimplemented>),
-            });
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -220,7 +152,6 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
                 customFilter: NoInnerOrSources,
                 typesToExclude: new[]
                 {
-                    typeof(IAsyncDisposable),
                     typeof(IPlayableCollectionItem)
                 });
         }
@@ -237,23 +168,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
             // Ensure an SearchResults plugin can still be accessed through PlaylistCollection members.
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<SearchResultsPluginBaseTests.FullyCustom>, PlaylistCollectionPluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
-        }
-
-        [TestMethod]
-        public void DisposingSearchResults()
-        {
-            var plugins = new Sdk.Plugins.Model.SdkModelPlugin(SdkTestPluginMetadata.Metadata);
-            plugins.PlaylistCollection.Add(x => new PlaylistCollectionPluginBaseTests.FullyCustom(x));
-
-            var plugin = StrixMusic.Sdk.Plugins.Model.GlobalModelPluginConnector.Create(plugins).SearchResults.Execute(new SearchResultsPluginBaseTests.Unimplemented());
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(value: plugin, expectedExceptions: new[]
-            {
-                typeof(AccessedException<PlaylistCollectionPluginBaseTests.FullyCustom>),
-                typeof(AccessedException<SearchResultsPluginBaseTests.Unimplemented>),
-            });
+                customFilter: NoInnerOrSources);
         }
     }
 }

--- a/src/Sdk/StrixMusic.Sdk.Tests/Plugins/Models/GlobalPluginConnector/TrackCollectionTests.cs
+++ b/src/Sdk/StrixMusic.Sdk.Tests/Plugins/Models/GlobalPluginConnector/TrackCollectionTests.cs
@@ -24,7 +24,6 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
                 customFilter: NoInnerOrSources,
                 typesToExclude: new[]
                 {
-                    typeof(IAsyncDisposable),
                     typeof(IPlayableCollectionItem)
                 });
         }
@@ -41,23 +40,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
             // Ensure an Album plugin can still be accessed through TrackCollection members.
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<AlbumPluginBaseTests.FullyCustom>, TrackCollectionPluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
-        }
-
-        [TestMethod]
-        public void DisposingAlbum()
-        {
-            var plugins = new Sdk.Plugins.Model.SdkModelPlugin(SdkTestPluginMetadata.Metadata);
-            plugins.TrackCollection.Add(x => new TrackCollectionPluginBaseTests.FullyCustom(x));
-
-            var plugin = StrixMusic.Sdk.Plugins.Model.GlobalModelPluginConnector.Create(plugins).Album.Execute(new AlbumPluginBaseTests.Unimplemented());
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(value: plugin, expectedExceptions: new[]
-            {
-                typeof(AccessedException<TrackCollectionPluginBaseTests.FullyCustom>),
-                typeof(AccessedException<AlbumPluginBaseTests.Unimplemented>),
-            });
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -73,7 +56,6 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
                 customFilter: NoInnerOrSources,
                 typesToExclude: new[]
                 {
-                    typeof(IAsyncDisposable),
                     typeof(IPlayableCollectionItem)
                 });
         }
@@ -90,23 +72,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
             // Ensure an Artist plugin can still be accessed through TrackCollection members.
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<ArtistPluginBaseTests.FullyCustom>, TrackCollectionPluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
-        }
-
-        [TestMethod]
-        public void DisposingArtist()
-        {
-            var plugins = new Sdk.Plugins.Model.SdkModelPlugin(SdkTestPluginMetadata.Metadata);
-            plugins.TrackCollection.Add(x => new TrackCollectionPluginBaseTests.FullyCustom(x));
-
-            var plugin = StrixMusic.Sdk.Plugins.Model.GlobalModelPluginConnector.Create(plugins).Artist.Execute(new ArtistPluginBaseTests.Unimplemented());
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(value: plugin, expectedExceptions: new[]
-            {
-                typeof(AccessedException<TrackCollectionPluginBaseTests.FullyCustom>),
-                typeof(AccessedException<ArtistPluginBaseTests.Unimplemented>),
-            });
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -122,7 +88,6 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
                 customFilter: NoInnerOrSources,
                 typesToExclude: new[]
                 {
-                    typeof(IAsyncDisposable),
                     typeof(IPlayableCollectionItem)
                 });
         }
@@ -139,23 +104,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
             // Ensure an Playlist plugin can still be accessed through TrackCollection members.
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<PlaylistPluginBaseTests.FullyCustom>, TrackCollectionPluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
-        }
-
-        [TestMethod]
-        public void DisposingPlaylist()
-        {
-            var plugins = new Sdk.Plugins.Model.SdkModelPlugin(SdkTestPluginMetadata.Metadata);
-            plugins.TrackCollection.Add(x => new TrackCollectionPluginBaseTests.FullyCustom(x));
-
-            var plugin = StrixMusic.Sdk.Plugins.Model.GlobalModelPluginConnector.Create(plugins).Playlist.Execute(new PlaylistPluginBaseTests.Unimplemented());
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(value: plugin, expectedExceptions: new[]
-            {
-                typeof(AccessedException<TrackCollectionPluginBaseTests.FullyCustom>),
-                typeof(AccessedException<PlaylistPluginBaseTests.Unimplemented>),
-            });
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -171,7 +120,6 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
                 customFilter: NoInnerOrSources,
                 typesToExclude: new[]
                 {
-                    typeof(IAsyncDisposable),
                     typeof(IPlayableCollectionItem)
                 });
         }
@@ -188,23 +136,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
             // Ensure an PlayableCollectionGroup plugin can still be accessed through TrackCollection members.
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<PlayableCollectionGroupPluginBaseTests.FullyCustom>, TrackCollectionPluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
-        }
-
-        [TestMethod]
-        public void DisposingPlayableCollectionGroup()
-        {
-            var plugins = new Sdk.Plugins.Model.SdkModelPlugin(SdkTestPluginMetadata.Metadata);
-            plugins.TrackCollection.Add(x => new TrackCollectionPluginBaseTests.FullyCustom(x));
-
-            var plugin = StrixMusic.Sdk.Plugins.Model.GlobalModelPluginConnector.Create(plugins).PlayableCollectionGroup.Execute(new PlayableCollectionGroupPluginBaseTests.Unimplemented());
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(value: plugin, expectedExceptions: new[]
-            {
-                typeof(AccessedException<TrackCollectionPluginBaseTests.FullyCustom>),
-                typeof(AccessedException<PlayableCollectionGroupPluginBaseTests.Unimplemented>),
-            });
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -220,7 +152,6 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
                 customFilter: NoInnerOrSources,
                 typesToExclude: new[]
                 {
-                    typeof(IAsyncDisposable),
                     typeof(IPlayableCollectionItem)
                 });
         }
@@ -237,23 +168,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
             // Ensure an Library plugin can still be accessed through TrackCollection members.
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<LibraryPluginBaseTests.FullyCustom>, TrackCollectionPluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
-        }
-
-        [TestMethod]
-        public void DisposingLibrary()
-        {
-            var plugins = new Sdk.Plugins.Model.SdkModelPlugin(SdkTestPluginMetadata.Metadata);
-            plugins.TrackCollection.Add(x => new TrackCollectionPluginBaseTests.FullyCustom(x));
-
-            var plugin = StrixMusic.Sdk.Plugins.Model.GlobalModelPluginConnector.Create(plugins).Library.Execute(new LibraryPluginBaseTests.Unimplemented());
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(value: plugin, expectedExceptions: new[]
-            {
-                typeof(AccessedException<TrackCollectionPluginBaseTests.FullyCustom>),
-                typeof(AccessedException<LibraryPluginBaseTests.Unimplemented>),
-            });
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -269,7 +184,6 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
                 customFilter: NoInnerOrSources,
                 typesToExclude: new[]
                 {
-                    typeof(IAsyncDisposable),
                     typeof(IPlayableCollectionItem)
                 });
         }
@@ -286,23 +200,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
             // Ensure an Discoverables plugin can still be accessed through TrackCollection members.
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<DiscoverablesPluginBaseTests.FullyCustom>, TrackCollectionPluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
-        }
-
-        [TestMethod]
-        public void DisposingDiscoverables()
-        {
-            var plugins = new Sdk.Plugins.Model.SdkModelPlugin(SdkTestPluginMetadata.Metadata);
-            plugins.TrackCollection.Add(x => new TrackCollectionPluginBaseTests.FullyCustom(x));
-
-            var plugin = StrixMusic.Sdk.Plugins.Model.GlobalModelPluginConnector.Create(plugins).Discoverables.Execute(new DiscoverablesPluginBaseTests.Unimplemented());
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(value: plugin, expectedExceptions: new[]
-            {
-                typeof(AccessedException<TrackCollectionPluginBaseTests.FullyCustom>),
-                typeof(AccessedException<DiscoverablesPluginBaseTests.Unimplemented>),
-            });
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -318,7 +216,6 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
                 customFilter: NoInnerOrSources,
                 typesToExclude: new[]
                 {
-                    typeof(IAsyncDisposable),
                     typeof(IPlayableCollectionItem)
                 });
         }
@@ -335,23 +232,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
             // Ensure an RecentlyPlayed plugin can still be accessed through TrackCollection members.
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<RecentlyPlayedPluginBaseTests.FullyCustom>, TrackCollectionPluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
-        }
-
-        [TestMethod]
-        public void DisposingRecentlyPlayed()
-        {
-            var plugins = new Sdk.Plugins.Model.SdkModelPlugin(SdkTestPluginMetadata.Metadata);
-            plugins.TrackCollection.Add(x => new TrackCollectionPluginBaseTests.FullyCustom(x));
-
-            var plugin = StrixMusic.Sdk.Plugins.Model.GlobalModelPluginConnector.Create(plugins).RecentlyPlayed.Execute(new RecentlyPlayedPluginBaseTests.Unimplemented());
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(value: plugin, expectedExceptions: new[]
-            {
-                typeof(AccessedException<TrackCollectionPluginBaseTests.FullyCustom>),
-                typeof(AccessedException<RecentlyPlayedPluginBaseTests.Unimplemented>),
-            });
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -367,7 +248,6 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
                 customFilter: NoInnerOrSources,
                 typesToExclude: new[]
                 {
-                    typeof(IAsyncDisposable),
                     typeof(IPlayableCollectionItem)
                 });
         }
@@ -384,23 +264,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
             // Ensure an SearchHistory plugin can still be accessed through TrackCollection members.
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<SearchHistoryPluginBaseTests.FullyCustom>, TrackCollectionPluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
-        }
-
-        [TestMethod]
-        public void DisposingSearchHistory()
-        {
-            var plugins = new Sdk.Plugins.Model.SdkModelPlugin(SdkTestPluginMetadata.Metadata);
-            plugins.TrackCollection.Add(x => new TrackCollectionPluginBaseTests.FullyCustom(x));
-
-            var plugin = StrixMusic.Sdk.Plugins.Model.GlobalModelPluginConnector.Create(plugins).SearchHistory.Execute(new SearchHistoryPluginBaseTests.Unimplemented());
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(value: plugin, expectedExceptions: new[]
-            {
-                typeof(AccessedException<TrackCollectionPluginBaseTests.FullyCustom>),
-                typeof(AccessedException<SearchHistoryPluginBaseTests.Unimplemented>),
-            });
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -416,7 +280,6 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
                 customFilter: NoInnerOrSources,
                 typesToExclude: new[]
                 {
-                    typeof(IAsyncDisposable),
                     typeof(IPlayableCollectionItem)
                 });
         }
@@ -433,23 +296,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
             // Ensure an SearchResults plugin can still be accessed through TrackCollection members.
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<SearchResultsPluginBaseTests.FullyCustom>, TrackCollectionPluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
-        }
-
-        [TestMethod]
-        public void DisposingSearchResults()
-        {
-            var plugins = new Sdk.Plugins.Model.SdkModelPlugin(SdkTestPluginMetadata.Metadata);
-            plugins.TrackCollection.Add(x => new TrackCollectionPluginBaseTests.FullyCustom(x));
-
-            var plugin = StrixMusic.Sdk.Plugins.Model.GlobalModelPluginConnector.Create(plugins).SearchResults.Execute(new SearchResultsPluginBaseTests.Unimplemented());
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(value: plugin, expectedExceptions: new[]
-            {
-                typeof(AccessedException<TrackCollectionPluginBaseTests.FullyCustom>),
-                typeof(AccessedException<SearchResultsPluginBaseTests.Unimplemented>),
-            });
+                customFilter: NoInnerOrSources);
         }
     }
 }

--- a/src/Sdk/StrixMusic.Sdk.Tests/Plugins/Models/GlobalPluginConnector/UrlCollectionTests.cs
+++ b/src/Sdk/StrixMusic.Sdk.Tests/Plugins/Models/GlobalPluginConnector/UrlCollectionTests.cs
@@ -20,8 +20,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
 
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<UrlCollectionPluginBaseTests.FullyCustom>, UrlCollectionPluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -36,22 +35,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
             // Ensure a Playable plugin can still be accessed through UrlCollection members.
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<PlayablePluginBaseTests.FullyCustom>, UrlCollectionPluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
-        }
-
-        [TestMethod]
-        public void DisposingPlayable()
-        {
-            var plugins = new Sdk.Plugins.Model.SdkModelPlugin(SdkTestPluginMetadata.Metadata);
-            plugins.UrlCollection.Add(x => new UrlCollectionPluginBaseTests.FullyCustom(x));
-
-            var plugin = StrixMusic.Sdk.Plugins.Model.GlobalModelPluginConnector.Create(plugins).Playable.Execute(new PlayablePluginBaseTests.Unimplemented());
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(plugin, expectedExceptions: new[] {
-                typeof(AccessedException<UrlCollectionPluginBaseTests.FullyCustom>),
-                typeof(AccessedException<PlayablePluginBaseTests.Unimplemented>),
-            });
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -64,8 +48,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
 
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<UrlCollectionPluginBaseTests.FullyCustom>, UrlCollectionPluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -80,22 +63,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
             // Ensure a TrackCollection plugin can still be accessed through UrlCollection members.
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<TrackCollectionPluginBaseTests.FullyCustom>, UrlCollectionPluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
-        }
-
-        [TestMethod]
-        public void DisposingTrackCollection()
-        {
-            var plugins = new Sdk.Plugins.Model.SdkModelPlugin(SdkTestPluginMetadata.Metadata);
-            plugins.UrlCollection.Add(x => new UrlCollectionPluginBaseTests.FullyCustom(x));
-
-            var plugin = StrixMusic.Sdk.Plugins.Model.GlobalModelPluginConnector.Create(plugins).TrackCollection.Execute(new TrackCollectionPluginBaseTests.Unimplemented());
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(plugin, customFilter: NoInnerOrSources, expectedExceptions: new[] {
-                typeof(AccessedException<UrlCollectionPluginBaseTests.FullyCustom>),
-                typeof(AccessedException<TrackCollectionPluginBaseTests.Unimplemented>),
-            });
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -108,8 +76,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
 
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<UrlCollectionPluginBaseTests.FullyCustom>, UrlCollectionPluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -124,22 +91,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
             // Ensure an ArtistCollection plugin can still be accessed through UrlCollection members.
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<ArtistCollectionPluginBaseTests.FullyCustom>, UrlCollectionPluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
-        }
-
-        [TestMethod]
-        public void DisposingArtistCollection()
-        {
-            var plugins = new Sdk.Plugins.Model.SdkModelPlugin(SdkTestPluginMetadata.Metadata);
-            plugins.UrlCollection.Add(x => new UrlCollectionPluginBaseTests.FullyCustom(x));
-
-            var plugin = StrixMusic.Sdk.Plugins.Model.GlobalModelPluginConnector.Create(plugins).ArtistCollection.Execute(new ArtistCollectionPluginBaseTests.Unimplemented());
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(plugin, customFilter: NoInnerOrSources, expectedExceptions: new[] {
-                typeof(AccessedException<UrlCollectionPluginBaseTests.FullyCustom>),
-                typeof(AccessedException<ArtistCollectionPluginBaseTests.Unimplemented>),
-            });
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -152,8 +104,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
 
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<UrlCollectionPluginBaseTests.FullyCustom>, UrlCollectionPluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -168,22 +119,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
             // Ensure an AlbumCollection plugin can still be accessed through UrlCollection members.
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<AlbumCollectionPluginBaseTests.FullyCustom>, UrlCollectionPluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
-        }
-
-        [TestMethod]
-        public void DisposingAlbumCollection()
-        {
-            var plugins = new Sdk.Plugins.Model.SdkModelPlugin(SdkTestPluginMetadata.Metadata);
-            plugins.UrlCollection.Add(x => new UrlCollectionPluginBaseTests.FullyCustom(x));
-
-            var plugin = StrixMusic.Sdk.Plugins.Model.GlobalModelPluginConnector.Create(plugins).AlbumCollection.Execute(new AlbumCollectionPluginBaseTests.Unimplemented());
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(value: plugin, expectedExceptions: new[] {
-                typeof(AccessedException<UrlCollectionPluginBaseTests.FullyCustom>),
-                typeof(AccessedException<AlbumCollectionPluginBaseTests.Unimplemented>),
-            });
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -196,8 +132,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
 
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<UrlCollectionPluginBaseTests.FullyCustom>, UrlCollectionPluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -212,22 +147,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
             // Ensure an Album plugin can still be accessed through UrlCollection members.
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<AlbumPluginBaseTests.FullyCustom>, UrlCollectionPluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
-        }
-
-        [TestMethod]
-        public void DisposingAlbum()
-        {
-            var plugins = new Sdk.Plugins.Model.SdkModelPlugin(SdkTestPluginMetadata.Metadata);
-            plugins.UrlCollection.Add(x => new UrlCollectionPluginBaseTests.FullyCustom(x));
-
-            var plugin = StrixMusic.Sdk.Plugins.Model.GlobalModelPluginConnector.Create(plugins).Album.Execute(new AlbumPluginBaseTests.Unimplemented());
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(value: plugin, expectedExceptions: new[] {
-                typeof(AccessedException<UrlCollectionPluginBaseTests.FullyCustom>),
-                typeof(AccessedException<AlbumPluginBaseTests.Unimplemented>),
-            });
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -240,8 +160,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
 
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<UrlCollectionPluginBaseTests.FullyCustom>, UrlCollectionPluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -256,22 +175,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
             // Ensure an Artist plugin can still be accessed through UrlCollection members.
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<ArtistPluginBaseTests.FullyCustom>, UrlCollectionPluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
-        }
-
-        [TestMethod]
-        public void DisposingArtist()
-        {
-            var plugins = new Sdk.Plugins.Model.SdkModelPlugin(SdkTestPluginMetadata.Metadata);
-            plugins.UrlCollection.Add(x => new UrlCollectionPluginBaseTests.FullyCustom(x));
-
-            var plugin = StrixMusic.Sdk.Plugins.Model.GlobalModelPluginConnector.Create(plugins).Artist.Execute(new ArtistPluginBaseTests.Unimplemented());
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(value: plugin, expectedExceptions: new[] {
-                typeof(AccessedException<UrlCollectionPluginBaseTests.FullyCustom>),
-                typeof(AccessedException<ArtistPluginBaseTests.Unimplemented>),
-            });
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -284,8 +188,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
 
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<UrlCollectionPluginBaseTests.FullyCustom>, UrlCollectionPluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -300,22 +203,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
             // Ensure an Playlist plugin can still be accessed through UrlCollection members.
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<PlaylistPluginBaseTests.FullyCustom>, UrlCollectionPluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
-        }
-
-        [TestMethod]
-        public void DisposingPlaylist()
-        {
-            var plugins = new Sdk.Plugins.Model.SdkModelPlugin(SdkTestPluginMetadata.Metadata);
-            plugins.UrlCollection.Add(x => new UrlCollectionPluginBaseTests.FullyCustom(x));
-
-            var plugin = StrixMusic.Sdk.Plugins.Model.GlobalModelPluginConnector.Create(plugins).Playlist.Execute(new PlaylistPluginBaseTests.Unimplemented());
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(value: plugin, expectedExceptions: new[] {
-                typeof(AccessedException<UrlCollectionPluginBaseTests.FullyCustom>),
-                typeof(AccessedException<PlaylistPluginBaseTests.Unimplemented>),
-            });
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -328,8 +216,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
 
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<UrlCollectionPluginBaseTests.FullyCustom>, UrlCollectionPluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -344,22 +231,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
             // Ensure an Track plugin can still be accessed through UrlCollection members.
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<TrackPluginBaseTests.FullyCustom>, UrlCollectionPluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
-        }
-
-        [TestMethod]
-        public void DisposingTrack()
-        {
-            var plugins = new Sdk.Plugins.Model.SdkModelPlugin(SdkTestPluginMetadata.Metadata);
-            plugins.UrlCollection.Add(x => new UrlCollectionPluginBaseTests.FullyCustom(x));
-
-            var plugin = StrixMusic.Sdk.Plugins.Model.GlobalModelPluginConnector.Create(plugins).Track.Execute(new TrackPluginBaseTests.Unimplemented());
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(value: plugin, expectedExceptions: new[] {
-                typeof(AccessedException<UrlCollectionPluginBaseTests.FullyCustom>),
-                typeof(AccessedException<TrackPluginBaseTests.Unimplemented>),
-            });
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -372,8 +244,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
 
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<UrlCollectionPluginBaseTests.FullyCustom>, UrlCollectionPluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -388,22 +259,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
             // Ensure an PlayableCollectionGroup plugin can still be accessed through UrlCollection members.
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<PlayableCollectionGroupPluginBaseTests.FullyCustom>, UrlCollectionPluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
-        }
-
-        [TestMethod]
-        public void DisposingPlayableCollectionGroup()
-        {
-            var plugins = new Sdk.Plugins.Model.SdkModelPlugin(SdkTestPluginMetadata.Metadata);
-            plugins.UrlCollection.Add(x => new UrlCollectionPluginBaseTests.FullyCustom(x));
-
-            var plugin = StrixMusic.Sdk.Plugins.Model.GlobalModelPluginConnector.Create(plugins).PlayableCollectionGroup.Execute(new PlayableCollectionGroupPluginBaseTests.Unimplemented());
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(value: plugin, expectedExceptions: new[] {
-                typeof(AccessedException<UrlCollectionPluginBaseTests.FullyCustom>),
-                typeof(AccessedException<PlayableCollectionGroupPluginBaseTests.Unimplemented>),
-            });
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -416,8 +272,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
 
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<UrlCollectionPluginBaseTests.FullyCustom>, UrlCollectionPluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -432,22 +287,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
             // Ensure an Library plugin can still be accessed through UrlCollection members.
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<LibraryPluginBaseTests.FullyCustom>, UrlCollectionPluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
-        }
-
-        [TestMethod]
-        public void DisposingLibrary()
-        {
-            var plugins = new Sdk.Plugins.Model.SdkModelPlugin(SdkTestPluginMetadata.Metadata);
-            plugins.UrlCollection.Add(x => new UrlCollectionPluginBaseTests.FullyCustom(x));
-
-            var plugin = StrixMusic.Sdk.Plugins.Model.GlobalModelPluginConnector.Create(plugins).Library.Execute(new LibraryPluginBaseTests.Unimplemented());
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(value: plugin, expectedExceptions: new[] {
-                typeof(AccessedException<UrlCollectionPluginBaseTests.FullyCustom>),
-                typeof(AccessedException<LibraryPluginBaseTests.Unimplemented>),
-            });
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -460,8 +300,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
 
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<UrlCollectionPluginBaseTests.FullyCustom>, UrlCollectionPluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -476,22 +315,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
             // Ensure an Discoverables plugin can still be accessed through UrlCollection members.
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<DiscoverablesPluginBaseTests.FullyCustom>, UrlCollectionPluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
-        }
-
-        [TestMethod]
-        public void DisposingDiscoverables()
-        {
-            var plugins = new Sdk.Plugins.Model.SdkModelPlugin(SdkTestPluginMetadata.Metadata);
-            plugins.UrlCollection.Add(x => new UrlCollectionPluginBaseTests.FullyCustom(x));
-
-            var plugin = StrixMusic.Sdk.Plugins.Model.GlobalModelPluginConnector.Create(plugins).Discoverables.Execute(new DiscoverablesPluginBaseTests.Unimplemented());
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(value: plugin, expectedExceptions: new[] {
-                typeof(AccessedException<UrlCollectionPluginBaseTests.FullyCustom>),
-                typeof(AccessedException<DiscoverablesPluginBaseTests.Unimplemented>),
-            });
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -504,8 +328,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
 
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<UrlCollectionPluginBaseTests.FullyCustom>, UrlCollectionPluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -520,22 +343,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
             // Ensure an RecentlyPlayed plugin can still be accessed through UrlCollection members.
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<RecentlyPlayedPluginBaseTests.FullyCustom>, UrlCollectionPluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
-        }
-
-        [TestMethod]
-        public void DisposingRecentlyPlayed()
-        {
-            var plugins = new Sdk.Plugins.Model.SdkModelPlugin(SdkTestPluginMetadata.Metadata);
-            plugins.UrlCollection.Add(x => new UrlCollectionPluginBaseTests.FullyCustom(x));
-
-            var plugin = StrixMusic.Sdk.Plugins.Model.GlobalModelPluginConnector.Create(plugins).RecentlyPlayed.Execute(new RecentlyPlayedPluginBaseTests.Unimplemented());
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(value: plugin, expectedExceptions: new[] {
-                typeof(AccessedException<UrlCollectionPluginBaseTests.FullyCustom>),
-                typeof(AccessedException<RecentlyPlayedPluginBaseTests.Unimplemented>),
-            });
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -548,8 +356,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
 
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<UrlCollectionPluginBaseTests.FullyCustom>, UrlCollectionPluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -564,8 +371,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
             // Ensure an SearchHistory plugin can still be accessed through UrlCollection members.
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<SearchHistoryPluginBaseTests.FullyCustom>, UrlCollectionPluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -592,8 +398,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
 
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<UrlCollectionPluginBaseTests.FullyCustom>, UrlCollectionPluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
+                customFilter: NoInnerOrSources);
         }
 
         [TestMethod]
@@ -608,22 +413,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
             // Ensure an SearchResults plugin can still be accessed through UrlCollection members.
             Helpers.AssertAllMembersThrowOnAccess<AccessedException<SearchResultsPluginBaseTests.FullyCustom>, UrlCollectionPluginBaseTests.FullyCustom>(
                 value: plugin,
-                customFilter: NoInnerOrSources,
-                typesToExclude: typeof(IAsyncDisposable));
-        }
-
-        [TestMethod]
-        public void DisposingSearchResults()
-        {
-            var plugins = new Sdk.Plugins.Model.SdkModelPlugin(SdkTestPluginMetadata.Metadata);
-            plugins.UrlCollection.Add(x => new UrlCollectionPluginBaseTests.FullyCustom(x));
-
-            var plugin = StrixMusic.Sdk.Plugins.Model.GlobalModelPluginConnector.Create(plugins).SearchResults.Execute(new SearchResultsPluginBaseTests.Unimplemented());
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(value: plugin, expectedExceptions: new[] {
-                typeof(AccessedException<UrlCollectionPluginBaseTests.FullyCustom>),
-                typeof(AccessedException<SearchResultsPluginBaseTests.Unimplemented>),
-            });
+                customFilter: NoInnerOrSources);
         }
     }
 }

--- a/src/Sdk/StrixMusic.Sdk.Tests/Plugins/Models/GlobalPluginConnector/UrlCollectionTests.cs
+++ b/src/Sdk/StrixMusic.Sdk.Tests/Plugins/Models/GlobalPluginConnector/UrlCollectionTests.cs
@@ -375,20 +375,6 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models.GlobalModelPluginConnector
         }
 
         [TestMethod]
-        public void DisposingSearchHistory()
-        {
-            var plugins = new Sdk.Plugins.Model.SdkModelPlugin(SdkTestPluginMetadata.Metadata);
-            plugins.UrlCollection.Add(x => new UrlCollectionPluginBaseTests.FullyCustom(x));
-
-            var plugin = StrixMusic.Sdk.Plugins.Model.GlobalModelPluginConnector.Create(plugins).SearchHistory.Execute(new SearchHistoryPluginBaseTests.Unimplemented());
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(value: plugin, expectedExceptions: new[] {
-                typeof(AccessedException<UrlCollectionPluginBaseTests.FullyCustom>),
-                typeof(AccessedException<SearchHistoryPluginBaseTests.Unimplemented>),
-            });
-        }
-
-        [TestMethod]
         public void AccessedThroughSearchResults()
         {
             var plugins = new Sdk.Plugins.Model.SdkModelPlugin(SdkTestPluginMetadata.Metadata);

--- a/src/Sdk/StrixMusic.Sdk.Tests/Plugins/Models/ImageCollectionPluginBaseTests.cs
+++ b/src/Sdk/StrixMusic.Sdk.Tests/Plugins/Models/ImageCollectionPluginBaseTests.cs
@@ -95,8 +95,6 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
 
             public override Task AddImageAsync(IImage image, int index, CancellationToken cancellationToken = default) => throw AccessedException;
 
-            public override ValueTask DisposeAsync() => throw AccessedException;
-
             public override bool Equals(ICoreImageCollection? other) => throw AccessedException;
 
             public override IAsyncEnumerable<IImage> GetImagesAsync(int limit, int offset, CancellationToken cancellationToken = default) => throw AccessedException;
@@ -116,17 +114,6 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
             }
         }
 
-        internal class NotBlockingDisposeAsync : ImageCollectionPluginBase
-        {
-            public NotBlockingDisposeAsync()
-                : base(new ModelPluginMetadata("", nameof(NotBlockingDisposeAsync), "", new Version()), new Unimplemented())
-            {
-            }
-
-            /// <inheritdoc />
-            public override ValueTask DisposeAsync() => default;
-        }
-
         public class Unimplemented : IImageCollection
         {
             internal static AccessedException<Unimplemented> AccessedException { get; } = new();
@@ -140,8 +127,6 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
             public event EventHandler<int>? ImagesCountChanged { add => throw AccessedException; remove => throw AccessedException; }
 
             public Task AddImageAsync(IImage image, int index, CancellationToken cancellationToken = default) => throw AccessedException;
-
-            public ValueTask DisposeAsync() => throw AccessedException;
 
             public bool Equals(ICoreImageCollection? other) => throw AccessedException;
 

--- a/src/Sdk/StrixMusic.Sdk.Tests/Plugins/Models/ImagePluginBaseTests.cs
+++ b/src/Sdk/StrixMusic.Sdk.Tests/Plugins/Models/ImagePluginBaseTests.cs
@@ -95,8 +95,6 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
 
             public override double? Width => throw AccessedException;
 
-            public override ValueTask DisposeAsync() => throw AccessedException;
-
             public override bool Equals(ICoreImage? other) => throw AccessedException;
         }
 
@@ -106,17 +104,6 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
                 : base(new ModelPluginMetadata("", nameof(NoOverride), "", new Version()), inner)
             {
             }
-        }
-
-        internal class NotBlockingDisposeAsync : ImagePluginBase
-        {
-            public NotBlockingDisposeAsync()
-                : base(new ModelPluginMetadata("", nameof(NotBlockingDisposeAsync), "", new Version()), new Unimplemented())
-            {
-            }
-
-            /// <inheritdoc />
-            public override ValueTask DisposeAsync() => default;
         }
 
         public class Unimplemented : IImage
@@ -134,8 +121,6 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
             public double? Width => throw AccessedException;
 
             public IReadOnlyList<ICoreImage> Sources => throw AccessedException;
-
-            public ValueTask DisposeAsync() => throw AccessedException;
 
             public bool Equals(ICoreImage? other) => throw AccessedException;
         }

--- a/src/Sdk/StrixMusic.Sdk.Tests/Plugins/Models/LibraryPluginBaseTests.cs
+++ b/src/Sdk/StrixMusic.Sdk.Tests/Plugins/Models/LibraryPluginBaseTests.cs
@@ -125,34 +125,23 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
             Assert.AreNotSame(finalImpl, defaultImplementation);
             Assert.IsInstanceOfType(finalImpl, typeof(NoOverride));
 
-            var expectedExceptionsWhenDisposing = new List<Type>
-            {
-                typeof(AccessedException<Unimplemented>),
-            };
-
             if (data.HasFlag(PossiblePlugins.Downloadable))
             {
-                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<DownloadablePluginBaseTests.Unimplemented>));
-
                 Helpers.AssertAllMembersThrowOnAccess<AccessedException<DownloadablePluginBaseTests.Unimplemented>,
                     DownloadablePluginBaseTests.Unimplemented>(
                     finalImpl,
-                    customFilter: NoInnerOrSources,
-                    typesToExclude: typeof(IAsyncDisposable)
+                    customFilter: NoInnerOrSources
                 );
             }
 
             if (data.HasFlag(PossiblePlugins.Playable))
             {
-                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<PlayablePluginBaseTests.Unimplemented>));
-
                 Helpers.AssertAllMembersThrowOnAccess<AccessedException<PlayablePluginBaseTests.Unimplemented>,
                     PlayablePluginBaseTests.Unimplemented>(
                     finalImpl,
                     customFilter: NoInnerOrSources,
                     typesToExclude: new[]
                     {
-                        typeof(IAsyncDisposable),
                         typeof(DownloadablePluginBaseTests.Unimplemented),
                         typeof(ImageCollectionPluginBaseTests.Unimplemented),
                         typeof(UrlCollectionPluginBaseTests.Unimplemented)
@@ -162,15 +151,12 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
 
             if (data.HasFlag(PossiblePlugins.ArtistCollection))
             {
-                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<ArtistCollectionPluginBaseTests.Unimplemented>));
-
                 Helpers.AssertAllMembersThrowOnAccess<AccessedException<ArtistCollectionPluginBaseTests.Unimplemented>,
                     ArtistCollectionPluginBaseTests.Unimplemented>(
                     finalImpl,
                     customFilter: NoInnerOrSources,
                     typesToExclude: new[]
                     {
-                        typeof(IAsyncDisposable),
                         typeof(DownloadablePluginBaseTests.Unimplemented),
                         typeof(ImageCollectionPluginBaseTests.Unimplemented),
                         typeof(UrlCollectionPluginBaseTests.Unimplemented),
@@ -182,15 +168,12 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
 
             if (data.HasFlag(PossiblePlugins.AlbumCollection))
             {
-                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<AlbumCollectionPluginBaseTests.Unimplemented>));
-
                 Helpers.AssertAllMembersThrowOnAccess<AccessedException<AlbumCollectionPluginBaseTests.Unimplemented>,
                     AlbumCollectionPluginBaseTests.Unimplemented>(
                     finalImpl,
                     customFilter: NoInnerOrSources,
                     typesToExclude: new[]
                     {
-                        typeof(IAsyncDisposable),
                         typeof(DownloadablePluginBaseTests.Unimplemented),
                         typeof(ImageCollectionPluginBaseTests.Unimplemented),
                         typeof(UrlCollectionPluginBaseTests.Unimplemented),
@@ -202,15 +185,12 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
 
             if (data.HasFlag(PossiblePlugins.PlaylistCollection))
             {
-                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<PlaylistCollectionPluginBaseTests.Unimplemented>));
-
                 Helpers.AssertAllMembersThrowOnAccess<AccessedException<PlaylistCollectionPluginBaseTests.Unimplemented>,
                     PlaylistCollectionPluginBaseTests.Unimplemented>(
                     finalImpl,
                     customFilter: NoInnerOrSources,
                     typesToExclude: new[]
                     {
-                        typeof(IAsyncDisposable),
                         typeof(DownloadablePluginBaseTests.Unimplemented),
                         typeof(ImageCollectionPluginBaseTests.Unimplemented),
                         typeof(UrlCollectionPluginBaseTests.Unimplemented),
@@ -222,14 +202,11 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
 
             if (data.HasFlag(PossiblePlugins.TrackCollection))
             {
-                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<TrackCollectionPluginBaseTests.Unimplemented>));
-
                 Helpers.AssertAllMembersThrowOnAccess<AccessedException<TrackCollectionPluginBaseTests.Unimplemented>, TrackCollectionPluginBaseTests.Unimplemented>(
                     finalImpl,
                     customFilter: NoInnerOrSources,
                     typesToExclude: new[]
                     {
-                        typeof(IAsyncDisposable),
                         typeof(DownloadablePluginBaseTests.Unimplemented),
                         typeof(ImageCollectionPluginBaseTests.Unimplemented),
                         typeof(UrlCollectionPluginBaseTests.Unimplemented),
@@ -241,58 +218,20 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
 
             if (data.HasFlag(PossiblePlugins.ImageCollection))
             {
-                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<ImageCollectionPluginBaseTests.Unimplemented>));
-
                 Helpers.AssertAllMembersThrowOnAccess<AccessedException<ImageCollectionPluginBaseTests.Unimplemented>,
                     ImageCollectionPluginBaseTests.Unimplemented>(
                     finalImpl,
-                    customFilter: NoInnerOrSources,
-                    typesToExclude: typeof(IAsyncDisposable)
+                    customFilter: NoInnerOrSources
                 );
             }
 
             if (data.HasFlag(PossiblePlugins.UrlCollection))
             {
-                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<UrlCollectionPluginBaseTests.Unimplemented>));
-
                 Helpers.AssertAllMembersThrowOnAccess<AccessedException<UrlCollectionPluginBaseTests.Unimplemented>, UrlCollectionPluginBaseTests.Unimplemented>(
                     finalImpl,
-                    customFilter: NoInnerOrSources,
-                    typesToExclude: typeof(IAsyncDisposable)
+                    customFilter: NoInnerOrSources
                 );
             }
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(
-                finalImpl,
-                customFilter: NoInnerOrSources,
-                expectedExceptions: expectedExceptionsWhenDisposing.ToArray()
-            );
-        }
-
-        [TestMethod, Timeout(5000)]
-        [AllEnumFlagCombinations(typeof(PossiblePlugins))]
-        public async Task DisposeAsync_AllCombinations(PossiblePlugins data)
-        {
-            var builder = new SdkModelPlugin(SdkTestPluginMetadata.Metadata).Library;
-            var defaultImplementation = new NotBlockingDisposeAsync();
-            builder.Add(x => new NoOverride(x)
-            {
-                InnerDownloadable = data.HasFlag(PossiblePlugins.Downloadable) ? new DownloadablePluginBaseTests.NotBlockingDisposeAsync() : x,
-                InnerPlayable = data.HasFlag(PossiblePlugins.Playable) ? new PlayablePluginBaseTests.NotBlockingDisposeAsync() : x,
-                InnerArtistCollection = data.HasFlag(PossiblePlugins.ArtistCollection) ? new ArtistCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
-                InnerAlbumCollection = data.HasFlag(PossiblePlugins.AlbumCollection) ? new AlbumCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
-                InnerTrackCollection = data.HasFlag(PossiblePlugins.TrackCollection) ? new TrackCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
-                InnerPlaylistCollection = data.HasFlag(PossiblePlugins.PlaylistCollection) ? new PlaylistCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
-                InnerImageCollection = data.HasFlag(PossiblePlugins.ImageCollection) ? new ImageCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
-                InnerUrlCollection = data.HasFlag(PossiblePlugins.UrlCollection) ? new UrlCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
-            });
-
-            var finalImpl = builder.Execute(defaultImplementation);
-
-            Assert.AreNotSame(finalImpl, defaultImplementation);
-            Assert.IsInstanceOfType(finalImpl, typeof(NoOverride));
-
-            await finalImpl.DisposeAsync();
         }
 
         internal class FullyCustom : LibraryPluginBase
@@ -304,7 +243,6 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
 
             internal static AccessedException<FullyCustom> AccessedException { get; } = new();
 
-            public override ValueTask DisposeAsync() => throw AccessedException;
             public override Task<bool> IsAddImageAvailableAsync(int index, CancellationToken cancellationToken = default) => throw AccessedException;
             public override Task<bool> IsRemoveImageAvailableAsync(int index, CancellationToken cancellationToken = default) => throw AccessedException;
             public override Task RemoveImageAsync(int index, CancellationToken cancellationToken = default) => throw AccessedException;
@@ -438,23 +376,11 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
             }
         }
 
-        internal class NotBlockingDisposeAsync : LibraryPluginBase
-        {
-            public NotBlockingDisposeAsync()
-                : base(new ModelPluginMetadata("", nameof(NotBlockingDisposeAsync), "", new Version()), new Unimplemented())
-            {
-            }
-
-            /// <inheritdoc />
-            public override ValueTask DisposeAsync() => default;
-        }
-
         internal class Unimplemented : ILibrary
         {
             internal static AccessedException<Unimplemented> AccessedException { get; } = new();
 
             public event EventHandler? SourcesChanged { add => throw AccessedException; remove => throw AccessedException; }
-            public ValueTask DisposeAsync() => throw AccessedException;
             public Task<bool> IsAddImageAvailableAsync(int index, CancellationToken cancellationToken = default) => throw AccessedException;
             public Task<bool> IsRemoveImageAvailableAsync(int index, CancellationToken cancellationToken = default) => throw AccessedException;
             public Task RemoveImageAsync(int index, CancellationToken cancellationToken = default) => throw AccessedException;

--- a/src/Sdk/StrixMusic.Sdk.Tests/Plugins/Models/PlayableCollectionGroupPluginBaseTests.cs
+++ b/src/Sdk/StrixMusic.Sdk.Tests/Plugins/Models/PlayableCollectionGroupPluginBaseTests.cs
@@ -124,34 +124,23 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
             Assert.AreNotSame(finalImpl, defaultImplementation);
             Assert.IsInstanceOfType(finalImpl, typeof(NoOverride));
 
-            var expectedExceptionsWhenDisposing = new List<Type>
-            {
-                typeof(AccessedException<Unimplemented>),
-            };
-
             if (data.HasFlag(PossiblePlugins.Downloadable))
             {
-                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<DownloadablePluginBaseTests.Unimplemented>));
-
                 Helpers.AssertAllMembersThrowOnAccess<AccessedException<DownloadablePluginBaseTests.Unimplemented>,
                     DownloadablePluginBaseTests.Unimplemented>(
                     finalImpl,
-                    customFilter: NoInnerOrSources,
-                    typesToExclude: typeof(IAsyncDisposable)
+                    customFilter: NoInnerOrSources
                 );
             }
 
             if (data.HasFlag(PossiblePlugins.Playable))
             {
-                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<PlayablePluginBaseTests.Unimplemented>));
-
                 Helpers.AssertAllMembersThrowOnAccess<AccessedException<PlayablePluginBaseTests.Unimplemented>,
                     PlayablePluginBaseTests.Unimplemented>(
                     finalImpl,
                     customFilter: NoInnerOrSources,
                     typesToExclude: new[]
                     {
-                        typeof(IAsyncDisposable),
                         typeof(DownloadablePluginBaseTests.Unimplemented),
                         typeof(ImageCollectionPluginBaseTests.Unimplemented),
                         typeof(UrlCollectionPluginBaseTests.Unimplemented)
@@ -161,15 +150,12 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
 
             if (data.HasFlag(PossiblePlugins.ArtistCollection))
             {
-                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<ArtistCollectionPluginBaseTests.Unimplemented>));
-
                 Helpers.AssertAllMembersThrowOnAccess<AccessedException<ArtistCollectionPluginBaseTests.Unimplemented>,
                     ArtistCollectionPluginBaseTests.Unimplemented>(
                     finalImpl,
                     customFilter: NoInnerOrSources,
                     typesToExclude: new[]
                     {
-                        typeof(IAsyncDisposable),
                         typeof(DownloadablePluginBaseTests.Unimplemented),
                         typeof(ImageCollectionPluginBaseTests.Unimplemented),
                         typeof(UrlCollectionPluginBaseTests.Unimplemented),
@@ -181,15 +167,12 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
 
             if (data.HasFlag(PossiblePlugins.AlbumCollection))
             {
-                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<AlbumCollectionPluginBaseTests.Unimplemented>));
-
                 Helpers.AssertAllMembersThrowOnAccess<AccessedException<AlbumCollectionPluginBaseTests.Unimplemented>,
                     AlbumCollectionPluginBaseTests.Unimplemented>(
                     finalImpl,
                     customFilter: NoInnerOrSources,
                     typesToExclude: new[]
                     {
-                        typeof(IAsyncDisposable),
                         typeof(DownloadablePluginBaseTests.Unimplemented),
                         typeof(ImageCollectionPluginBaseTests.Unimplemented),
                         typeof(UrlCollectionPluginBaseTests.Unimplemented),
@@ -201,15 +184,12 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
 
             if (data.HasFlag(PossiblePlugins.PlaylistCollection))
             {
-                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<PlaylistCollectionPluginBaseTests.Unimplemented>));
-
                 Helpers.AssertAllMembersThrowOnAccess<AccessedException<PlaylistCollectionPluginBaseTests.Unimplemented>,
                     PlaylistCollectionPluginBaseTests.Unimplemented>(
                     finalImpl,
                     customFilter: NoInnerOrSources,
                     typesToExclude: new[]
                     {
-                        typeof(IAsyncDisposable),
                         typeof(DownloadablePluginBaseTests.Unimplemented),
                         typeof(ImageCollectionPluginBaseTests.Unimplemented),
                         typeof(UrlCollectionPluginBaseTests.Unimplemented),
@@ -221,14 +201,11 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
 
             if (data.HasFlag(PossiblePlugins.TrackCollection))
             {
-                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<TrackCollectionPluginBaseTests.Unimplemented>));
-
                 Helpers.AssertAllMembersThrowOnAccess<AccessedException<TrackCollectionPluginBaseTests.Unimplemented>, TrackCollectionPluginBaseTests.Unimplemented>(
                     finalImpl,
                     customFilter: NoInnerOrSources,
                     typesToExclude: new[]
                     {
-                        typeof(IAsyncDisposable),
                         typeof(DownloadablePluginBaseTests.Unimplemented),
                         typeof(ImageCollectionPluginBaseTests.Unimplemented),
                         typeof(UrlCollectionPluginBaseTests.Unimplemented),
@@ -240,58 +217,20 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
 
             if (data.HasFlag(PossiblePlugins.ImageCollection))
             {
-                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<ImageCollectionPluginBaseTests.Unimplemented>));
-
                 Helpers.AssertAllMembersThrowOnAccess<AccessedException<ImageCollectionPluginBaseTests.Unimplemented>,
                     ImageCollectionPluginBaseTests.Unimplemented>(
                     finalImpl,
-                    customFilter: NoInnerOrSources,
-                    typesToExclude: typeof(IAsyncDisposable)
+                    customFilter: NoInnerOrSources
                 );
             }
 
             if (data.HasFlag(PossiblePlugins.UrlCollection))
             {
-                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<UrlCollectionPluginBaseTests.Unimplemented>));
-
                 Helpers.AssertAllMembersThrowOnAccess<AccessedException<UrlCollectionPluginBaseTests.Unimplemented>, UrlCollectionPluginBaseTests.Unimplemented>(
                     finalImpl,
-                    customFilter: NoInnerOrSources,
-                    typesToExclude: typeof(IAsyncDisposable)
+                    customFilter: NoInnerOrSources
                 );
             }
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(
-                finalImpl,
-                customFilter: NoInnerOrSources,
-                expectedExceptions: expectedExceptionsWhenDisposing.ToArray()
-            );
-        }
-
-        [TestMethod, Timeout(5000)]
-        [AllEnumFlagCombinations(typeof(PossiblePlugins))]
-        public async Task DisposeAsync_AllCombinations(PossiblePlugins data)
-        {
-            var builder = new SdkModelPlugin(SdkTestPluginMetadata.Metadata).PlayableCollectionGroup;
-            var defaultImplementation = new NotBlockingDisposeAsync();
-            builder.Add(x => new NoOverride(x)
-            {
-                InnerDownloadable = data.HasFlag(PossiblePlugins.Downloadable) ? new DownloadablePluginBaseTests.NotBlockingDisposeAsync() : x,
-                InnerPlayable = data.HasFlag(PossiblePlugins.Playable) ? new PlayablePluginBaseTests.NotBlockingDisposeAsync() : x,
-                InnerArtistCollection = data.HasFlag(PossiblePlugins.ArtistCollection) ? new ArtistCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
-                InnerAlbumCollection = data.HasFlag(PossiblePlugins.AlbumCollection) ? new AlbumCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
-                InnerTrackCollection = data.HasFlag(PossiblePlugins.TrackCollection) ? new TrackCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
-                InnerPlaylistCollection = data.HasFlag(PossiblePlugins.PlaylistCollection) ? new PlaylistCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
-                InnerImageCollection = data.HasFlag(PossiblePlugins.ImageCollection) ? new ImageCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
-                InnerUrlCollection = data.HasFlag(PossiblePlugins.UrlCollection) ? new UrlCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
-            });
-
-            var finalImpl = builder.Execute(defaultImplementation);
-
-            Assert.AreNotSame(finalImpl, defaultImplementation);
-            Assert.IsInstanceOfType(finalImpl, typeof(NoOverride));
-
-            await finalImpl.DisposeAsync();
         }
 
         internal class FullyCustom : PlayableCollectionGroupPluginBase
@@ -303,7 +242,6 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
 
             internal static AccessedException<FullyCustom> AccessedException { get; } = new();
 
-            public override ValueTask DisposeAsync() => throw AccessedException;
             public override Task<bool> IsAddImageAvailableAsync(int index, CancellationToken cancellationToken = default) => throw AccessedException;
             public override Task<bool> IsRemoveImageAvailableAsync(int index, CancellationToken cancellationToken = default) => throw AccessedException;
             public override Task RemoveImageAsync(int index, CancellationToken cancellationToken = default) => throw AccessedException;
@@ -436,23 +374,11 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
             }
         }
 
-        internal class NotBlockingDisposeAsync : PlayableCollectionGroupPluginBase
-        {
-            public NotBlockingDisposeAsync()
-                : base(new ModelPluginMetadata("", nameof(NotBlockingDisposeAsync), "", new Version()), new Unimplemented())
-            {
-            }
-
-            /// <inheritdoc />
-            public override ValueTask DisposeAsync() => default;
-        }
-
         internal class Unimplemented : IPlayableCollectionGroup
         {
             internal static AccessedException<Unimplemented> AccessedException { get; } = new();
 
             public event EventHandler? SourcesChanged { add => throw AccessedException; remove => throw AccessedException; }
-            public ValueTask DisposeAsync() => throw AccessedException;
             public Task<bool> IsAddImageAvailableAsync(int index, CancellationToken cancellationToken = default) => throw AccessedException;
             public Task<bool> IsRemoveImageAvailableAsync(int index, CancellationToken cancellationToken = default) => throw AccessedException;
             public Task RemoveImageAsync(int index, CancellationToken cancellationToken = default) => throw AccessedException;

--- a/src/Sdk/StrixMusic.Sdk.Tests/Plugins/Models/PlayablePluginBaseTests.cs
+++ b/src/Sdk/StrixMusic.Sdk.Tests/Plugins/Models/PlayablePluginBaseTests.cs
@@ -114,34 +114,23 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
             Assert.AreNotSame(finalImpl, defaultImplementation);
             Assert.IsInstanceOfType(finalImpl, typeof(NoOverride));
 
-            var expectedExceptionsWhenDisposing = new List<Type>
-            {
-                typeof(AccessedException<Unimplemented>),
-            };
-
             if (data.HasFlag(PossiblePlugins.Downloadable))
             {
-                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<DownloadablePluginBaseTests.Unimplemented>));
-
                 Helpers.AssertAllMembersThrowOnAccess<AccessedException<DownloadablePluginBaseTests.Unimplemented>,
                     DownloadablePluginBaseTests.Unimplemented>(
                     finalImpl,
-                    customFilter: NoInnerOrSources,
-                    typesToExclude: typeof(IAsyncDisposable)
+                    customFilter: NoInnerOrSources
                 );
             }
 
             if (data.HasFlag(PossiblePlugins.Playable))
             {
-                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<PlayablePluginBaseTests.Unimplemented>));
-
                 Helpers.AssertAllMembersThrowOnAccess<AccessedException<PlayablePluginBaseTests.Unimplemented>,
                     PlayablePluginBaseTests.Unimplemented>(
                     finalImpl,
                     customFilter: NoInnerOrSources,
                     typesToExclude: new[]
                     {
-                        typeof(IAsyncDisposable),
                         typeof(DownloadablePluginBaseTests.Unimplemented),
                         typeof(ImageCollectionPluginBaseTests.Unimplemented),
                         typeof(UrlCollectionPluginBaseTests.Unimplemented)
@@ -151,32 +140,20 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
 
             if (data.HasFlag(PossiblePlugins.ImageCollection))
             {
-                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<ImageCollectionPluginBaseTests.Unimplemented>));
-
                 Helpers.AssertAllMembersThrowOnAccess<AccessedException<ImageCollectionPluginBaseTests.Unimplemented>,
                     ImageCollectionPluginBaseTests.Unimplemented>(
                     finalImpl,
-                    customFilter: NoInnerOrSources,
-                    typesToExclude: typeof(IAsyncDisposable)
+                    customFilter: NoInnerOrSources
                 );
             }
 
             if (data.HasFlag(PossiblePlugins.UrlCollection))
             {
-                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<UrlCollectionPluginBaseTests.Unimplemented>));
-
                 Helpers.AssertAllMembersThrowOnAccess<AccessedException<UrlCollectionPluginBaseTests.Unimplemented>, UrlCollectionPluginBaseTests.Unimplemented>(
                     finalImpl,
-                    customFilter: NoInnerOrSources,
-                    typesToExclude: typeof(IAsyncDisposable)
+                    customFilter: NoInnerOrSources
                 );
             }
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(
-                finalImpl,
-                customFilter: NoInnerOrSources,
-                expectedExceptions: expectedExceptionsWhenDisposing.ToArray()
-            );
         }
 
         internal class FullyCustom : PlayablePluginBase
@@ -220,7 +197,6 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
             public override Task ChangeDescriptionAsync(string? description, CancellationToken cancellationToken = default) => throw AccessedException;
             public override Task ChangeDurationAsync(TimeSpan duration, CancellationToken cancellationToken = default) => throw AccessedException;
             public override Task ChangeNameAsync(string name, CancellationToken cancellationToken = default) => throw AccessedException;
-            public override ValueTask DisposeAsync() => throw AccessedException;
             public override bool Equals(ICoreImageCollection? other) => throw AccessedException;
             public override bool Equals(ICoreUrlCollection? other) => throw AccessedException;
             public override IAsyncEnumerable<IImage> GetImagesAsync(int limit, int offset, CancellationToken cancellationToken = default) => throw AccessedException;
@@ -240,17 +216,6 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
                 : base(new ModelPluginMetadata("", nameof(NoOverride), "", new Version()), inner)
             {
             }
-        }
-
-        internal class NotBlockingDisposeAsync : PlayablePluginBase
-        {
-            public NotBlockingDisposeAsync()
-                : base(new ModelPluginMetadata("", nameof(NotBlockingDisposeAsync), "", new Version()), new Unimplemented())
-            {
-            }
-
-            /// <inheritdoc />
-            public override ValueTask DisposeAsync() => default;
         }
 
         internal class Unimplemented : IPlayable
@@ -292,7 +257,6 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
             public Task ChangeDescriptionAsync(string? description, CancellationToken cancellationToken = default) => throw AccessedException;
             public Task ChangeDurationAsync(TimeSpan duration, CancellationToken cancellationToken = default) => throw AccessedException;
             public Task ChangeNameAsync(string name, CancellationToken cancellationToken = default) => throw AccessedException;
-            public ValueTask DisposeAsync() => throw AccessedException;
             public bool Equals(ICoreImageCollection? other) => throw AccessedException;
             public bool Equals(ICoreUrlCollection? other) => throw AccessedException;
             public IAsyncEnumerable<IImage> GetImagesAsync(int limit, int offset, CancellationToken cancellationToken = default) => throw AccessedException;

--- a/src/Sdk/StrixMusic.Sdk.Tests/Plugins/Models/PlaylistCollectionPluginBaseTests.cs
+++ b/src/Sdk/StrixMusic.Sdk.Tests/Plugins/Models/PlaylistCollectionPluginBaseTests.cs
@@ -115,34 +115,23 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
             Assert.AreNotSame(finalImpl, defaultImplementation);
             Assert.IsInstanceOfType(finalImpl, typeof(NoOverride));
 
-            var expectedExceptionsWhenDisposing = new List<Type>
-            {
-                typeof(AccessedException<Unimplemented>),
-            };
-
             if (data.HasFlag(PossiblePlugins.Downloadable))
             {
-                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<DownloadablePluginBaseTests.Unimplemented>));
-
                 Helpers.AssertAllMembersThrowOnAccess<AccessedException<DownloadablePluginBaseTests.Unimplemented>,
                     DownloadablePluginBaseTests.Unimplemented>(
                     finalImpl,
-                    customFilter: NoInnerOrSources,
-                    typesToExclude: typeof(IAsyncDisposable)
+                    customFilter: NoInnerOrSources
                 );
             }
 
             if (data.HasFlag(PossiblePlugins.Playable))
             {
-                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<PlayablePluginBaseTests.Unimplemented>));
-
                 Helpers.AssertAllMembersThrowOnAccess<AccessedException<PlayablePluginBaseTests.Unimplemented>,
                     PlayablePluginBaseTests.Unimplemented>(
                     finalImpl,
                     customFilter: NoInnerOrSources,
                     typesToExclude: new[]
                     {
-                        typeof(IAsyncDisposable),
                         typeof(DownloadablePluginBaseTests.Unimplemented),
                         typeof(ImageCollectionPluginBaseTests.Unimplemented),
                         typeof(UrlCollectionPluginBaseTests.Unimplemented)
@@ -152,54 +141,20 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
 
             if (data.HasFlag(PossiblePlugins.ImageCollection))
             {
-                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<ImageCollectionPluginBaseTests.Unimplemented>));
-
                 Helpers.AssertAllMembersThrowOnAccess<AccessedException<ImageCollectionPluginBaseTests.Unimplemented>,
                     ImageCollectionPluginBaseTests.Unimplemented>(
                     finalImpl,
-                    customFilter: NoInnerOrSources,
-                    typesToExclude: typeof(IAsyncDisposable)
+                    customFilter: NoInnerOrSources
                 );
             }
 
             if (data.HasFlag(PossiblePlugins.UrlCollection))
             {
-                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<UrlCollectionPluginBaseTests.Unimplemented>));
-
                 Helpers.AssertAllMembersThrowOnAccess<AccessedException<UrlCollectionPluginBaseTests.Unimplemented>, UrlCollectionPluginBaseTests.Unimplemented>(
                     finalImpl,
-                    customFilter: NoInnerOrSources,
-                    typesToExclude: typeof(IAsyncDisposable)
+                    customFilter: NoInnerOrSources
                 );
             }
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(
-                finalImpl,
-                customFilter: NoInnerOrSources,
-                expectedExceptions: expectedExceptionsWhenDisposing.ToArray()
-            );
-        }
-
-        [TestMethod, Timeout(5000)]
-        [AllEnumFlagCombinations(typeof(PossiblePlugins))]
-        public async Task DisposeAsync_AllCombinations(PossiblePlugins data)
-        {
-            var builder = new SdkModelPlugin(SdkTestPluginMetadata.Metadata).PlaylistCollection;
-            var defaultImplementation = new NotBlockingDisposeAsync();
-            builder.Add(x => new NoOverride(x)
-            {
-                InnerDownloadable = data.HasFlag(PossiblePlugins.Downloadable) ? new DownloadablePluginBaseTests.NotBlockingDisposeAsync() : x,
-                InnerPlayable = data.HasFlag(PossiblePlugins.Playable) ? new PlayablePluginBaseTests.NotBlockingDisposeAsync() : x,
-                InnerImageCollection = data.HasFlag(PossiblePlugins.ImageCollection) ? new ImageCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
-                InnerUrlCollection = data.HasFlag(PossiblePlugins.UrlCollection) ? new UrlCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
-            });
-
-            var finalImpl = builder.Execute(defaultImplementation);
-
-            Assert.AreNotSame(finalImpl, defaultImplementation);
-            Assert.IsInstanceOfType(finalImpl, typeof(NoOverride));
-
-            await finalImpl.DisposeAsync();
         }
 
 
@@ -253,7 +208,6 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
             public override Task ChangeDescriptionAsync(string? description, CancellationToken cancellationToken = default) => throw AccessedException;
             public override Task ChangeDurationAsync(TimeSpan duration, CancellationToken cancellationToken = default) => throw AccessedException;
             public override Task ChangeNameAsync(string name, CancellationToken cancellationToken = default) => throw AccessedException;
-            public override ValueTask DisposeAsync() => throw AccessedException;
             public override bool Equals(ICorePlaylistCollectionItem? other) => throw AccessedException;
             public override bool Equals(ICoreImageCollection? other) => throw AccessedException;
             public override bool Equals(ICoreUrlCollection? other) => throw AccessedException;
@@ -282,17 +236,6 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
                 : base(new ModelPluginMetadata("", nameof(NoOverride), "", new Version()), inner)
             {
             }
-        }
-
-        internal class NotBlockingDisposeAsync : PlaylistCollectionPluginBase
-        {
-            public NotBlockingDisposeAsync()
-                : base(new ModelPluginMetadata("", nameof(NotBlockingDisposeAsync), "", new Version()), new Unimplemented())
-            {
-            }
-
-            /// <inheritdoc />
-            public override ValueTask DisposeAsync() => default;
         }
 
         internal class Unimplemented : IPlaylistCollection
@@ -345,7 +288,6 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
             public Task ChangeDescriptionAsync(string? description, CancellationToken cancellationToken = default) => throw AccessedException;
             public Task ChangeDurationAsync(TimeSpan duration, CancellationToken cancellationToken = default) => throw AccessedException;
             public Task ChangeNameAsync(string name, CancellationToken cancellationToken = default) => throw AccessedException;
-            public ValueTask DisposeAsync() => throw AccessedException;
             public bool Equals(ICorePlaylistCollectionItem? other) => throw AccessedException;
             public bool Equals(ICoreImageCollection? other) => throw AccessedException;
             public bool Equals(ICoreUrlCollection? other) => throw AccessedException;

--- a/src/Sdk/StrixMusic.Sdk.Tests/Plugins/Models/PlaylistPluginBaseTests.cs
+++ b/src/Sdk/StrixMusic.Sdk.Tests/Plugins/Models/PlaylistPluginBaseTests.cs
@@ -125,34 +125,23 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
             Assert.AreNotSame(finalImpl, defaultImplementation);
             Assert.IsInstanceOfType(finalImpl, typeof(NoOverride));
 
-            var expectedExceptionsWhenDisposing = new List<Type>
-            {
-                typeof(AccessedException<Unimplemented>),
-            };
-
             if (data.HasFlag(PossiblePlugins.Downloadable))
             {
-                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<DownloadablePluginBaseTests.Unimplemented>));
-
                 Helpers.AssertAllMembersThrowOnAccess<AccessedException<DownloadablePluginBaseTests.Unimplemented>,
                     DownloadablePluginBaseTests.Unimplemented>(
                     finalImpl,
-                    customFilter: NoInnerOrSources,
-                    typesToExclude: typeof(IAsyncDisposable)
+                    customFilter: NoInnerOrSources
                 );
             }
 
             if (data.HasFlag(PossiblePlugins.Playable))
             {
-                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<PlayablePluginBaseTests.Unimplemented>));
-
                 Helpers.AssertAllMembersThrowOnAccess<AccessedException<PlayablePluginBaseTests.Unimplemented>,
                     PlayablePluginBaseTests.Unimplemented>(
                     finalImpl,
                     customFilter: NoInnerOrSources,
                     typesToExclude: new[]
                     {
-                        typeof(IAsyncDisposable),
                         typeof(DownloadablePluginBaseTests.Unimplemented),
                         typeof(ImageCollectionPluginBaseTests.Unimplemented),
                         typeof(UrlCollectionPluginBaseTests.Unimplemented)
@@ -162,26 +151,20 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
 
             if (data.HasFlag(PossiblePlugins.ImageCollection))
             {
-                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<ImageCollectionPluginBaseTests.Unimplemented>));
-
                 Helpers.AssertAllMembersThrowOnAccess<AccessedException<ImageCollectionPluginBaseTests.Unimplemented>,
                     ImageCollectionPluginBaseTests.Unimplemented>(
                     finalImpl,
-                    customFilter: NoInnerOrSources,
-                    typesToExclude: typeof(IAsyncDisposable)
+                    customFilter: NoInnerOrSources
                 );
             }
 
             if (data.HasFlag(PossiblePlugins.TrackCollection))
             {
-                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<TrackCollectionPluginBaseTests.Unimplemented>));
-
                 Helpers.AssertAllMembersThrowOnAccess<AccessedException<TrackCollectionPluginBaseTests.Unimplemented>, TrackCollectionPluginBaseTests.Unimplemented>(
                     finalImpl,
                     customFilter: NoInnerOrSources,
                     typesToExclude: new[]
                     {
-                        typeof(IAsyncDisposable),
                         typeof(DownloadablePluginBaseTests.Unimplemented),
                         typeof(ImageCollectionPluginBaseTests.Unimplemented),
                         typeof(UrlCollectionPluginBaseTests.Unimplemented),
@@ -193,43 +176,11 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
 
             if (data.HasFlag(PossiblePlugins.UrlCollection))
             {
-                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<UrlCollectionPluginBaseTests.Unimplemented>));
-
                 Helpers.AssertAllMembersThrowOnAccess<AccessedException<UrlCollectionPluginBaseTests.Unimplemented>, UrlCollectionPluginBaseTests.Unimplemented>(
                     finalImpl,
-                    customFilter: NoInnerOrSources,
-                    typesToExclude: typeof(IAsyncDisposable)
+                    customFilter: NoInnerOrSources
                 );
             }
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(
-                finalImpl,
-                customFilter: NoInnerOrSources,
-                expectedExceptions: expectedExceptionsWhenDisposing.ToArray()
-            );
-        }
-
-        [TestMethod, Timeout(5000)]
-        [AllEnumFlagCombinations(typeof(PossiblePlugins))]
-        public async Task DisposeAsync_AllCombinations(PossiblePlugins data)
-        {
-            var builder = new SdkModelPlugin(SdkTestPluginMetadata.Metadata).Playlist;
-            var defaultImplementation = new NotBlockingDisposeAsync();
-            builder.Add(x => new NoOverride(x)
-            {
-                InnerDownloadable = data.HasFlag(PossiblePlugins.Downloadable) ? new DownloadablePluginBaseTests.NotBlockingDisposeAsync() : x,
-                InnerPlayable = data.HasFlag(PossiblePlugins.Playable) ? new PlayablePluginBaseTests.NotBlockingDisposeAsync() : x,
-                InnerTrackCollection = data.HasFlag(PossiblePlugins.TrackCollection) ? new TrackCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
-                InnerImageCollection = data.HasFlag(PossiblePlugins.ImageCollection) ? new ImageCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
-                InnerUrlCollection = data.HasFlag(PossiblePlugins.UrlCollection) ? new UrlCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
-            });
-
-            var finalImpl = builder.Execute(defaultImplementation);
-
-            Assert.AreNotSame(finalImpl, defaultImplementation);
-            Assert.IsInstanceOfType(finalImpl, typeof(NoOverride));
-
-            await finalImpl.DisposeAsync();
         }
 
         internal class FullyCustom : PlaylistPluginBase
@@ -241,7 +192,6 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
 
             internal static AccessedException<FullyCustom> AccessedException { get; } = new();
 
-            public override ValueTask DisposeAsync() => throw AccessedException;
             public override Task<bool> IsAddImageAvailableAsync(int index, CancellationToken cancellationToken = default) => throw AccessedException;
             public override Task<bool> IsRemoveImageAvailableAsync(int index, CancellationToken cancellationToken = default) => throw AccessedException;
             public override Task RemoveImageAsync(int index, CancellationToken cancellationToken = default) => throw AccessedException;
@@ -314,23 +264,11 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
             }
         }
 
-        internal class NotBlockingDisposeAsync : PlaylistPluginBase
-        {
-            public NotBlockingDisposeAsync()
-                : base(new ModelPluginMetadata("", nameof(NotBlockingDisposeAsync), "", new Version()), new Unimplemented())
-            {
-            }
-
-            /// <inheritdoc />
-            public override ValueTask DisposeAsync() => default;
-        }
-
         internal class Unimplemented : IPlaylist
         {
             internal static AccessedException<Unimplemented> AccessedException { get; } = new();
             
             public event EventHandler? SourcesChanged { add => throw AccessedException; remove => throw AccessedException; }
-            public ValueTask DisposeAsync() => throw AccessedException;
             public Task<bool> IsAddImageAvailableAsync(int index, CancellationToken cancellationToken = default) => throw AccessedException;
             public Task<bool> IsRemoveImageAvailableAsync(int index, CancellationToken cancellationToken = default) => throw AccessedException;
             public Task RemoveImageAsync(int index, CancellationToken cancellationToken = default) => throw AccessedException;

--- a/src/Sdk/StrixMusic.Sdk.Tests/Plugins/Models/RecentlyPlayedPluginBaseTests.cs
+++ b/src/Sdk/StrixMusic.Sdk.Tests/Plugins/Models/RecentlyPlayedPluginBaseTests.cs
@@ -125,15 +125,8 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
             Assert.AreNotSame(finalImpl, defaultImplementation);
             Assert.IsInstanceOfType(finalImpl, typeof(NoOverride));
 
-            var expectedExceptionsWhenDisposing = new List<Type>
-            {
-                typeof(AccessedException<Unimplemented>),
-            };
-
             if (data.HasFlag(PossiblePlugins.Downloadable))
             {
-                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<DownloadablePluginBaseTests.Unimplemented>));
-
                 Helpers.AssertAllMembersThrowOnAccess<AccessedException<DownloadablePluginBaseTests.Unimplemented>,
                     DownloadablePluginBaseTests.Unimplemented>(
                     finalImpl,
@@ -144,8 +137,6 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
 
             if (data.HasFlag(PossiblePlugins.Playable))
             {
-                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<PlayablePluginBaseTests.Unimplemented>));
-
                 Helpers.AssertAllMembersThrowOnAccess<AccessedException<PlayablePluginBaseTests.Unimplemented>,
                     PlayablePluginBaseTests.Unimplemented>(
                     finalImpl,
@@ -162,8 +153,6 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
 
             if (data.HasFlag(PossiblePlugins.ArtistCollection))
             {
-                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<ArtistCollectionPluginBaseTests.Unimplemented>));
-
                 Helpers.AssertAllMembersThrowOnAccess<AccessedException<ArtistCollectionPluginBaseTests.Unimplemented>,
                     ArtistCollectionPluginBaseTests.Unimplemented>(
                     finalImpl,
@@ -182,8 +171,6 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
 
             if (data.HasFlag(PossiblePlugins.AlbumCollection))
             {
-                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<AlbumCollectionPluginBaseTests.Unimplemented>));
-
                 Helpers.AssertAllMembersThrowOnAccess<AccessedException<AlbumCollectionPluginBaseTests.Unimplemented>,
                     AlbumCollectionPluginBaseTests.Unimplemented>(
                     finalImpl,
@@ -202,8 +189,6 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
 
             if (data.HasFlag(PossiblePlugins.PlaylistCollection))
             {
-                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<PlaylistCollectionPluginBaseTests.Unimplemented>));
-
                 Helpers.AssertAllMembersThrowOnAccess<AccessedException<PlaylistCollectionPluginBaseTests.Unimplemented>,
                     PlaylistCollectionPluginBaseTests.Unimplemented>(
                     finalImpl,
@@ -222,8 +207,6 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
 
             if (data.HasFlag(PossiblePlugins.TrackCollection))
             {
-                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<TrackCollectionPluginBaseTests.Unimplemented>));
-
                 Helpers.AssertAllMembersThrowOnAccess<AccessedException<TrackCollectionPluginBaseTests.Unimplemented>, TrackCollectionPluginBaseTests.Unimplemented>(
                     finalImpl,
                     customFilter: NoInnerOrSources,
@@ -241,8 +224,6 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
 
             if (data.HasFlag(PossiblePlugins.ImageCollection))
             {
-                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<ImageCollectionPluginBaseTests.Unimplemented>));
-
                 Helpers.AssertAllMembersThrowOnAccess<AccessedException<ImageCollectionPluginBaseTests.Unimplemented>,
                     ImageCollectionPluginBaseTests.Unimplemented>(
                     finalImpl,
@@ -253,46 +234,12 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
 
             if (data.HasFlag(PossiblePlugins.UrlCollection))
             {
-                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<UrlCollectionPluginBaseTests.Unimplemented>));
-
                 Helpers.AssertAllMembersThrowOnAccess<AccessedException<UrlCollectionPluginBaseTests.Unimplemented>, UrlCollectionPluginBaseTests.Unimplemented>(
                     finalImpl,
                     customFilter: NoInnerOrSources,
                     typesToExclude: typeof(IAsyncDisposable)
                 );
             }
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(
-                finalImpl,
-                customFilter: NoInnerOrSources,
-                expectedExceptions: expectedExceptionsWhenDisposing.ToArray()
-            );
-        }
-
-        [TestMethod, Timeout(5000)]
-        [AllEnumFlagCombinations(typeof(PossiblePlugins))]
-        public async Task DisposeAsync_AllCombinations(PossiblePlugins data)
-        {
-            var builder = new SdkModelPlugin(SdkTestPluginMetadata.Metadata).RecentlyPlayed;
-            var defaultImplementation = new NotBlockingDisposeAsync();
-            builder.Add(x => new NoOverride(x)
-            {
-                InnerDownloadable = data.HasFlag(PossiblePlugins.Downloadable) ? new DownloadablePluginBaseTests.NotBlockingDisposeAsync() : x,
-                InnerPlayable = data.HasFlag(PossiblePlugins.Playable) ? new PlayablePluginBaseTests.NotBlockingDisposeAsync() : x,
-                InnerArtistCollection = data.HasFlag(PossiblePlugins.ArtistCollection) ? new ArtistCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
-                InnerAlbumCollection = data.HasFlag(PossiblePlugins.AlbumCollection) ? new AlbumCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
-                InnerTrackCollection = data.HasFlag(PossiblePlugins.TrackCollection) ? new TrackCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
-                InnerPlaylistCollection = data.HasFlag(PossiblePlugins.PlaylistCollection) ? new PlaylistCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
-                InnerImageCollection = data.HasFlag(PossiblePlugins.ImageCollection) ? new ImageCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
-                InnerUrlCollection = data.HasFlag(PossiblePlugins.UrlCollection) ? new UrlCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
-            });
-
-            var finalImpl = builder.Execute(defaultImplementation);
-
-            Assert.AreNotSame(finalImpl, defaultImplementation);
-            Assert.IsInstanceOfType(finalImpl, typeof(NoOverride));
-
-            await finalImpl.DisposeAsync();
         }
 
         internal class FullyCustom : RecentlyPlayedPluginBase
@@ -304,7 +251,6 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
 
             internal static AccessedException<FullyCustom> AccessedException { get; } = new();
 
-            public override ValueTask DisposeAsync() => throw AccessedException;
             public override Task<bool> IsAddImageAvailableAsync(int index, CancellationToken cancellationToken = default) => throw AccessedException;
             public override Task<bool> IsRemoveImageAvailableAsync(int index, CancellationToken cancellationToken = default) => throw AccessedException;
             public override Task RemoveImageAsync(int index, CancellationToken cancellationToken = default) => throw AccessedException;
@@ -438,23 +384,11 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
             }
         }
 
-        internal class NotBlockingDisposeAsync : RecentlyPlayedPluginBase
-        {
-            public NotBlockingDisposeAsync()
-                : base(new ModelPluginMetadata("", nameof(NotBlockingDisposeAsync), "", new Version()), new Unimplemented())
-            {
-            }
-
-            /// <inheritdoc />
-            public override ValueTask DisposeAsync() => default;
-        }
-
         internal class Unimplemented : IRecentlyPlayed
         {
             internal static AccessedException<Unimplemented> AccessedException { get; } = new();
 
             public event EventHandler? SourcesChanged { add => throw AccessedException; remove => throw AccessedException; }
-            public ValueTask DisposeAsync() => throw AccessedException;
             public Task<bool> IsAddImageAvailableAsync(int index, CancellationToken cancellationToken = default) => throw AccessedException;
             public Task<bool> IsRemoveImageAvailableAsync(int index, CancellationToken cancellationToken = default) => throw AccessedException;
             public Task RemoveImageAsync(int index, CancellationToken cancellationToken = default) => throw AccessedException;

--- a/src/Sdk/StrixMusic.Sdk.Tests/Plugins/Models/RecentlyPlayedPluginBaseTests.cs
+++ b/src/Sdk/StrixMusic.Sdk.Tests/Plugins/Models/RecentlyPlayedPluginBaseTests.cs
@@ -130,8 +130,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
                 Helpers.AssertAllMembersThrowOnAccess<AccessedException<DownloadablePluginBaseTests.Unimplemented>,
                     DownloadablePluginBaseTests.Unimplemented>(
                     finalImpl,
-                    customFilter: NoInnerOrSources,
-                    typesToExclude: typeof(IAsyncDisposable)
+                    customFilter: NoInnerOrSources
                 );
             }
 
@@ -143,7 +142,6 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
                     customFilter: NoInnerOrSources,
                     typesToExclude: new[]
                     {
-                        typeof(IAsyncDisposable),
                         typeof(DownloadablePluginBaseTests.Unimplemented),
                         typeof(ImageCollectionPluginBaseTests.Unimplemented),
                         typeof(UrlCollectionPluginBaseTests.Unimplemented)
@@ -159,7 +157,6 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
                     customFilter: NoInnerOrSources,
                     typesToExclude: new[]
                     {
-                        typeof(IAsyncDisposable),
                         typeof(DownloadablePluginBaseTests.Unimplemented),
                         typeof(ImageCollectionPluginBaseTests.Unimplemented),
                         typeof(UrlCollectionPluginBaseTests.Unimplemented),
@@ -177,7 +174,6 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
                     customFilter: NoInnerOrSources,
                     typesToExclude: new[]
                     {
-                        typeof(IAsyncDisposable),
                         typeof(DownloadablePluginBaseTests.Unimplemented),
                         typeof(ImageCollectionPluginBaseTests.Unimplemented),
                         typeof(UrlCollectionPluginBaseTests.Unimplemented),
@@ -195,7 +191,6 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
                     customFilter: NoInnerOrSources,
                     typesToExclude: new[]
                     {
-                        typeof(IAsyncDisposable),
                         typeof(DownloadablePluginBaseTests.Unimplemented),
                         typeof(ImageCollectionPluginBaseTests.Unimplemented),
                         typeof(UrlCollectionPluginBaseTests.Unimplemented),
@@ -212,7 +207,6 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
                     customFilter: NoInnerOrSources,
                     typesToExclude: new[]
                     {
-                        typeof(IAsyncDisposable),
                         typeof(DownloadablePluginBaseTests.Unimplemented),
                         typeof(ImageCollectionPluginBaseTests.Unimplemented),
                         typeof(UrlCollectionPluginBaseTests.Unimplemented),
@@ -227,8 +221,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
                 Helpers.AssertAllMembersThrowOnAccess<AccessedException<ImageCollectionPluginBaseTests.Unimplemented>,
                     ImageCollectionPluginBaseTests.Unimplemented>(
                     finalImpl,
-                    customFilter: NoInnerOrSources,
-                    typesToExclude: typeof(IAsyncDisposable)
+                    customFilter: NoInnerOrSources
                 );
             }
 
@@ -236,8 +229,7 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
             {
                 Helpers.AssertAllMembersThrowOnAccess<AccessedException<UrlCollectionPluginBaseTests.Unimplemented>, UrlCollectionPluginBaseTests.Unimplemented>(
                     finalImpl,
-                    customFilter: NoInnerOrSources,
-                    typesToExclude: typeof(IAsyncDisposable)
+                    customFilter: NoInnerOrSources
                 );
             }
         }

--- a/src/Sdk/StrixMusic.Sdk.Tests/Plugins/Models/SearchHistoryPluginBaseTests.cs
+++ b/src/Sdk/StrixMusic.Sdk.Tests/Plugins/Models/SearchHistoryPluginBaseTests.cs
@@ -125,34 +125,23 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
             Assert.AreNotSame(finalImpl, defaultImplementation);
             Assert.IsInstanceOfType(finalImpl, typeof(NoOverride));
 
-            var expectedExceptionsWhenDisposing = new List<Type>
-            {
-                typeof(AccessedException<Unimplemented>),
-            };
-
             if (data.HasFlag(PossiblePlugins.Downloadable))
             {
-                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<DownloadablePluginBaseTests.Unimplemented>));
-
                 Helpers.AssertAllMembersThrowOnAccess<AccessedException<DownloadablePluginBaseTests.Unimplemented>,
                     DownloadablePluginBaseTests.Unimplemented>(
                     finalImpl,
-                    customFilter: NoInnerOrSources,
-                    typesToExclude: typeof(IAsyncDisposable)
+                    customFilter: NoInnerOrSources
                 );
             }
 
             if (data.HasFlag(PossiblePlugins.Playable))
             {
-                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<PlayablePluginBaseTests.Unimplemented>));
-
                 Helpers.AssertAllMembersThrowOnAccess<AccessedException<PlayablePluginBaseTests.Unimplemented>,
                     PlayablePluginBaseTests.Unimplemented>(
                     finalImpl,
                     customFilter: NoInnerOrSources,
                     typesToExclude: new[]
                     {
-                        typeof(IAsyncDisposable),
                         typeof(DownloadablePluginBaseTests.Unimplemented),
                         typeof(ImageCollectionPluginBaseTests.Unimplemented),
                         typeof(UrlCollectionPluginBaseTests.Unimplemented)
@@ -162,15 +151,12 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
 
             if (data.HasFlag(PossiblePlugins.ArtistCollection))
             {
-                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<ArtistCollectionPluginBaseTests.Unimplemented>));
-
                 Helpers.AssertAllMembersThrowOnAccess<AccessedException<ArtistCollectionPluginBaseTests.Unimplemented>,
                     ArtistCollectionPluginBaseTests.Unimplemented>(
                     finalImpl,
                     customFilter: NoInnerOrSources,
                     typesToExclude: new[]
                     {
-                        typeof(IAsyncDisposable),
                         typeof(DownloadablePluginBaseTests.Unimplemented),
                         typeof(ImageCollectionPluginBaseTests.Unimplemented),
                         typeof(UrlCollectionPluginBaseTests.Unimplemented),
@@ -182,15 +168,12 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
 
             if (data.HasFlag(PossiblePlugins.AlbumCollection))
             {
-                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<AlbumCollectionPluginBaseTests.Unimplemented>));
-
                 Helpers.AssertAllMembersThrowOnAccess<AccessedException<AlbumCollectionPluginBaseTests.Unimplemented>,
                     AlbumCollectionPluginBaseTests.Unimplemented>(
                     finalImpl,
                     customFilter: NoInnerOrSources,
                     typesToExclude: new[]
                     {
-                        typeof(IAsyncDisposable),
                         typeof(DownloadablePluginBaseTests.Unimplemented),
                         typeof(ImageCollectionPluginBaseTests.Unimplemented),
                         typeof(UrlCollectionPluginBaseTests.Unimplemented),
@@ -202,15 +185,12 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
 
             if (data.HasFlag(PossiblePlugins.PlaylistCollection))
             {
-                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<PlaylistCollectionPluginBaseTests.Unimplemented>));
-
                 Helpers.AssertAllMembersThrowOnAccess<AccessedException<PlaylistCollectionPluginBaseTests.Unimplemented>,
                     PlaylistCollectionPluginBaseTests.Unimplemented>(
                     finalImpl,
                     customFilter: NoInnerOrSources,
                     typesToExclude: new[]
                     {
-                        typeof(IAsyncDisposable),
                         typeof(DownloadablePluginBaseTests.Unimplemented),
                         typeof(ImageCollectionPluginBaseTests.Unimplemented),
                         typeof(UrlCollectionPluginBaseTests.Unimplemented),
@@ -222,14 +202,11 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
 
             if (data.HasFlag(PossiblePlugins.TrackCollection))
             {
-                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<TrackCollectionPluginBaseTests.Unimplemented>));
-
                 Helpers.AssertAllMembersThrowOnAccess<AccessedException<TrackCollectionPluginBaseTests.Unimplemented>, TrackCollectionPluginBaseTests.Unimplemented>(
                     finalImpl,
                     customFilter: NoInnerOrSources,
                     typesToExclude: new[]
                     {
-                        typeof(IAsyncDisposable),
                         typeof(DownloadablePluginBaseTests.Unimplemented),
                         typeof(ImageCollectionPluginBaseTests.Unimplemented),
                         typeof(UrlCollectionPluginBaseTests.Unimplemented),
@@ -241,58 +218,20 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
 
             if (data.HasFlag(PossiblePlugins.ImageCollection))
             {
-                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<ImageCollectionPluginBaseTests.Unimplemented>));
-
                 Helpers.AssertAllMembersThrowOnAccess<AccessedException<ImageCollectionPluginBaseTests.Unimplemented>,
                     ImageCollectionPluginBaseTests.Unimplemented>(
                     finalImpl,
-                    customFilter: NoInnerOrSources,
-                    typesToExclude: typeof(IAsyncDisposable)
+                    customFilter: NoInnerOrSources
                 );
             }
 
             if (data.HasFlag(PossiblePlugins.UrlCollection))
             {
-                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<UrlCollectionPluginBaseTests.Unimplemented>));
-
                 Helpers.AssertAllMembersThrowOnAccess<AccessedException<UrlCollectionPluginBaseTests.Unimplemented>, UrlCollectionPluginBaseTests.Unimplemented>(
                     finalImpl,
-                    customFilter: NoInnerOrSources,
-                    typesToExclude: typeof(IAsyncDisposable)
+                    customFilter: NoInnerOrSources
                 );
             }
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(
-                finalImpl,
-                customFilter: NoInnerOrSources,
-                expectedExceptions: expectedExceptionsWhenDisposing.ToArray()
-            );
-        }
-
-        [TestMethod, Timeout(5000)]
-        [AllEnumFlagCombinations(typeof(PossiblePlugins))]
-        public async Task DisposeAsync_AllCombinations(PossiblePlugins data)
-        {
-            var builder = new SdkModelPlugin(SdkTestPluginMetadata.Metadata).SearchHistory;
-            var defaultImplementation = new NotBlockingDisposeAsync();
-            builder.Add(x => new NoOverride(x)
-            {
-                InnerDownloadable = data.HasFlag(PossiblePlugins.Downloadable) ? new DownloadablePluginBaseTests.NotBlockingDisposeAsync() : x,
-                InnerPlayable = data.HasFlag(PossiblePlugins.Playable) ? new PlayablePluginBaseTests.NotBlockingDisposeAsync() : x,
-                InnerArtistCollection = data.HasFlag(PossiblePlugins.ArtistCollection) ? new ArtistCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
-                InnerAlbumCollection = data.HasFlag(PossiblePlugins.AlbumCollection) ? new AlbumCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
-                InnerTrackCollection = data.HasFlag(PossiblePlugins.TrackCollection) ? new TrackCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
-                InnerPlaylistCollection = data.HasFlag(PossiblePlugins.PlaylistCollection) ? new PlaylistCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
-                InnerImageCollection = data.HasFlag(PossiblePlugins.ImageCollection) ? new ImageCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
-                InnerUrlCollection = data.HasFlag(PossiblePlugins.UrlCollection) ? new UrlCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
-            });
-
-            var finalImpl = builder.Execute(defaultImplementation);
-
-            Assert.AreNotSame(finalImpl, defaultImplementation);
-            Assert.IsInstanceOfType(finalImpl, typeof(NoOverride));
-
-            await finalImpl.DisposeAsync();
         }
 
         internal class FullyCustom : SearchHistoryPluginBase
@@ -304,7 +243,6 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
 
             internal static AccessedException<FullyCustom> AccessedException { get; } = new();
 
-            public override ValueTask DisposeAsync() => throw AccessedException;
             public override Task<bool> IsAddImageAvailableAsync(int index, CancellationToken cancellationToken = default) => throw AccessedException;
             public override Task<bool> IsRemoveImageAvailableAsync(int index, CancellationToken cancellationToken = default) => throw AccessedException;
             public override Task RemoveImageAsync(int index, CancellationToken cancellationToken = default) => throw AccessedException;
@@ -438,23 +376,11 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
             }
         }
 
-        internal class NotBlockingDisposeAsync : SearchHistoryPluginBase
-        {
-            public NotBlockingDisposeAsync()
-                : base(new ModelPluginMetadata("", nameof(NotBlockingDisposeAsync), "", new Version()), new Unimplemented())
-            {
-            }
-
-            /// <inheritdoc />
-            public override ValueTask DisposeAsync() => default;
-        }
-
         internal class Unimplemented : ISearchHistory
         {
             internal static AccessedException<Unimplemented> AccessedException { get; } = new();
 
             public event EventHandler? SourcesChanged { add => throw AccessedException; remove => throw AccessedException; }
-            public ValueTask DisposeAsync() => throw AccessedException;
             public Task<bool> IsAddImageAvailableAsync(int index, CancellationToken cancellationToken = default) => throw AccessedException;
             public Task<bool> IsRemoveImageAvailableAsync(int index, CancellationToken cancellationToken = default) => throw AccessedException;
             public Task RemoveImageAsync(int index, CancellationToken cancellationToken = default) => throw AccessedException;

--- a/src/Sdk/StrixMusic.Sdk.Tests/Plugins/Models/SearchResultsPluginBaseTests.cs
+++ b/src/Sdk/StrixMusic.Sdk.Tests/Plugins/Models/SearchResultsPluginBaseTests.cs
@@ -125,34 +125,23 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
             Assert.AreNotSame(finalImpl, defaultImplementation);
             Assert.IsInstanceOfType(finalImpl, typeof(NoOverride));
 
-            var expectedExceptionsWhenDisposing = new List<Type>
-            {
-                typeof(AccessedException<Unimplemented>),
-            };
-
             if (data.HasFlag(PossiblePlugins.Downloadable))
             {
-                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<DownloadablePluginBaseTests.Unimplemented>));
-
                 Helpers.AssertAllMembersThrowOnAccess<AccessedException<DownloadablePluginBaseTests.Unimplemented>,
                     DownloadablePluginBaseTests.Unimplemented>(
                     finalImpl,
-                    customFilter: NoInnerOrSources,
-                    typesToExclude: typeof(IAsyncDisposable)
+                    customFilter: NoInnerOrSources
                 );
             }
 
             if (data.HasFlag(PossiblePlugins.Playable))
             {
-                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<PlayablePluginBaseTests.Unimplemented>));
-
                 Helpers.AssertAllMembersThrowOnAccess<AccessedException<PlayablePluginBaseTests.Unimplemented>,
                     PlayablePluginBaseTests.Unimplemented>(
                     finalImpl,
                     customFilter: NoInnerOrSources,
                     typesToExclude: new[]
                     {
-                        typeof(IAsyncDisposable),
                         typeof(DownloadablePluginBaseTests.Unimplemented),
                         typeof(ImageCollectionPluginBaseTests.Unimplemented),
                         typeof(UrlCollectionPluginBaseTests.Unimplemented)
@@ -162,15 +151,12 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
 
             if (data.HasFlag(PossiblePlugins.ArtistCollection))
             {
-                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<ArtistCollectionPluginBaseTests.Unimplemented>));
-
                 Helpers.AssertAllMembersThrowOnAccess<AccessedException<ArtistCollectionPluginBaseTests.Unimplemented>,
                     ArtistCollectionPluginBaseTests.Unimplemented>(
                     finalImpl,
                     customFilter: NoInnerOrSources,
                     typesToExclude: new[]
                     {
-                        typeof(IAsyncDisposable),
                         typeof(DownloadablePluginBaseTests.Unimplemented),
                         typeof(ImageCollectionPluginBaseTests.Unimplemented),
                         typeof(UrlCollectionPluginBaseTests.Unimplemented),
@@ -182,15 +168,12 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
 
             if (data.HasFlag(PossiblePlugins.AlbumCollection))
             {
-                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<AlbumCollectionPluginBaseTests.Unimplemented>));
-
                 Helpers.AssertAllMembersThrowOnAccess<AccessedException<AlbumCollectionPluginBaseTests.Unimplemented>,
                     AlbumCollectionPluginBaseTests.Unimplemented>(
                     finalImpl,
                     customFilter: NoInnerOrSources,
                     typesToExclude: new[]
                     {
-                        typeof(IAsyncDisposable),
                         typeof(DownloadablePluginBaseTests.Unimplemented),
                         typeof(ImageCollectionPluginBaseTests.Unimplemented),
                         typeof(UrlCollectionPluginBaseTests.Unimplemented),
@@ -202,15 +185,12 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
 
             if (data.HasFlag(PossiblePlugins.PlaylistCollection))
             {
-                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<PlaylistCollectionPluginBaseTests.Unimplemented>));
-
                 Helpers.AssertAllMembersThrowOnAccess<AccessedException<PlaylistCollectionPluginBaseTests.Unimplemented>,
                     PlaylistCollectionPluginBaseTests.Unimplemented>(
                     finalImpl,
                     customFilter: NoInnerOrSources,
                     typesToExclude: new[]
                     {
-                        typeof(IAsyncDisposable),
                         typeof(DownloadablePluginBaseTests.Unimplemented),
                         typeof(ImageCollectionPluginBaseTests.Unimplemented),
                         typeof(UrlCollectionPluginBaseTests.Unimplemented),
@@ -222,14 +202,11 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
 
             if (data.HasFlag(PossiblePlugins.TrackCollection))
             {
-                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<TrackCollectionPluginBaseTests.Unimplemented>));
-
                 Helpers.AssertAllMembersThrowOnAccess<AccessedException<TrackCollectionPluginBaseTests.Unimplemented>, TrackCollectionPluginBaseTests.Unimplemented>(
                     finalImpl,
                     customFilter: NoInnerOrSources,
                     typesToExclude: new[]
                     {
-                        typeof(IAsyncDisposable),
                         typeof(DownloadablePluginBaseTests.Unimplemented),
                         typeof(ImageCollectionPluginBaseTests.Unimplemented),
                         typeof(UrlCollectionPluginBaseTests.Unimplemented),
@@ -241,58 +218,20 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
 
             if (data.HasFlag(PossiblePlugins.ImageCollection))
             {
-                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<ImageCollectionPluginBaseTests.Unimplemented>));
-
                 Helpers.AssertAllMembersThrowOnAccess<AccessedException<ImageCollectionPluginBaseTests.Unimplemented>,
                     ImageCollectionPluginBaseTests.Unimplemented>(
                     finalImpl,
-                    customFilter: NoInnerOrSources,
-                    typesToExclude: typeof(IAsyncDisposable)
+                    customFilter: NoInnerOrSources
                 );
             }
 
             if (data.HasFlag(PossiblePlugins.UrlCollection))
             {
-                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<UrlCollectionPluginBaseTests.Unimplemented>));
-
                 Helpers.AssertAllMembersThrowOnAccess<AccessedException<UrlCollectionPluginBaseTests.Unimplemented>, UrlCollectionPluginBaseTests.Unimplemented>(
                     finalImpl,
-                    customFilter: NoInnerOrSources,
-                    typesToExclude: typeof(IAsyncDisposable)
+                    customFilter: NoInnerOrSources
                 );
             }
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(
-                finalImpl,
-                customFilter: NoInnerOrSources,
-                expectedExceptions: expectedExceptionsWhenDisposing.ToArray()
-            );
-        }
-
-        [TestMethod, Timeout(5000)]
-        [AllEnumFlagCombinations(typeof(PossiblePlugins))]
-        public async Task DisposeAsync_AllCombinations(PossiblePlugins data)
-        {
-            var builder = new SdkModelPlugin(SdkTestPluginMetadata.Metadata).SearchResults;
-            var defaultImplementation = new NotBlockingDisposeAsync();
-            builder.Add(x => new NoOverride(x)
-            {
-                InnerDownloadable = data.HasFlag(PossiblePlugins.Downloadable) ? new DownloadablePluginBaseTests.NotBlockingDisposeAsync() : x,
-                InnerPlayable = data.HasFlag(PossiblePlugins.Playable) ? new PlayablePluginBaseTests.NotBlockingDisposeAsync() : x,
-                InnerArtistCollection = data.HasFlag(PossiblePlugins.ArtistCollection) ? new ArtistCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
-                InnerAlbumCollection = data.HasFlag(PossiblePlugins.AlbumCollection) ? new AlbumCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
-                InnerTrackCollection = data.HasFlag(PossiblePlugins.TrackCollection) ? new TrackCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
-                InnerPlaylistCollection = data.HasFlag(PossiblePlugins.PlaylistCollection) ? new PlaylistCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
-                InnerImageCollection = data.HasFlag(PossiblePlugins.ImageCollection) ? new ImageCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
-                InnerUrlCollection = data.HasFlag(PossiblePlugins.UrlCollection) ? new UrlCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
-            });
-
-            var finalImpl = builder.Execute(defaultImplementation);
-
-            Assert.AreNotSame(finalImpl, defaultImplementation);
-            Assert.IsInstanceOfType(finalImpl, typeof(NoOverride));
-
-            await finalImpl.DisposeAsync();
         }
 
         internal class FullyCustom : SearchResultsPluginBase
@@ -304,7 +243,6 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
 
             internal static AccessedException<FullyCustom> AccessedException { get; } = new();
 
-            public override ValueTask DisposeAsync() => throw AccessedException;
             public override Task<bool> IsAddImageAvailableAsync(int index, CancellationToken cancellationToken = default) => throw AccessedException;
             public override Task<bool> IsRemoveImageAvailableAsync(int index, CancellationToken cancellationToken = default) => throw AccessedException;
             public override Task RemoveImageAsync(int index, CancellationToken cancellationToken = default) => throw AccessedException;
@@ -438,23 +376,11 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
             }
         }
 
-        internal class NotBlockingDisposeAsync : SearchResultsPluginBase
-        {
-            public NotBlockingDisposeAsync()
-                : base(new ModelPluginMetadata("", nameof(NotBlockingDisposeAsync), "", new Version()), new Unimplemented())
-            {
-            }
-
-            /// <inheritdoc />
-            public override ValueTask DisposeAsync() => default;
-        }
-
         internal class Unimplemented : ISearchResults
         {
             internal static AccessedException<Unimplemented> AccessedException { get; } = new();
 
             public event EventHandler? SourcesChanged { add => throw AccessedException; remove => throw AccessedException; }
-            public ValueTask DisposeAsync() => throw AccessedException;
             public Task<bool> IsAddImageAvailableAsync(int index, CancellationToken cancellationToken = default) => throw AccessedException;
             public Task<bool> IsRemoveImageAvailableAsync(int index, CancellationToken cancellationToken = default) => throw AccessedException;
             public Task RemoveImageAsync(int index, CancellationToken cancellationToken = default) => throw AccessedException;

--- a/src/Sdk/StrixMusic.Sdk.Tests/Plugins/Models/TrackCollectionPluginBaseTests.cs
+++ b/src/Sdk/StrixMusic.Sdk.Tests/Plugins/Models/TrackCollectionPluginBaseTests.cs
@@ -115,34 +115,23 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
             Assert.AreNotSame(finalImpl, defaultImplementation);
             Assert.IsInstanceOfType(finalImpl, typeof(NoOverride));
 
-            var expectedExceptionsWhenDisposing = new List<Type>
-            {
-                typeof(AccessedException<Unimplemented>),
-            };
-
             if (data.HasFlag(PossiblePlugins.Downloadable))
             {
-                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<DownloadablePluginBaseTests.Unimplemented>));
-
                 Helpers.AssertAllMembersThrowOnAccess<AccessedException<DownloadablePluginBaseTests.Unimplemented>,
                     DownloadablePluginBaseTests.Unimplemented>(
                     finalImpl,
-                    customFilter: NoInnerOrSources,
-                    typesToExclude: typeof(IAsyncDisposable)
+                    customFilter: NoInnerOrSources
                 );
             }
 
             if (data.HasFlag(PossiblePlugins.Playable))
             {
-                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<PlayablePluginBaseTests.Unimplemented>));
-
                 Helpers.AssertAllMembersThrowOnAccess<AccessedException<PlayablePluginBaseTests.Unimplemented>,
                     PlayablePluginBaseTests.Unimplemented>(
                     finalImpl,
                     customFilter: NoInnerOrSources,
                     typesToExclude: new[]
                     {
-                        typeof(IAsyncDisposable),
                         typeof(DownloadablePluginBaseTests.Unimplemented),
                         typeof(ImageCollectionPluginBaseTests.Unimplemented),
                         typeof(UrlCollectionPluginBaseTests.Unimplemented)
@@ -152,54 +141,20 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
 
             if (data.HasFlag(PossiblePlugins.ImageCollection))
             {
-                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<ImageCollectionPluginBaseTests.Unimplemented>));
-
                 Helpers.AssertAllMembersThrowOnAccess<AccessedException<ImageCollectionPluginBaseTests.Unimplemented>,
                     ImageCollectionPluginBaseTests.Unimplemented>(
                     finalImpl,
-                    customFilter: NoInnerOrSources,
-                    typesToExclude: typeof(IAsyncDisposable)
+                    customFilter: NoInnerOrSources
                 );
             }
 
             if (data.HasFlag(PossiblePlugins.UrlCollection))
             {
-                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<UrlCollectionPluginBaseTests.Unimplemented>));
-
                 Helpers.AssertAllMembersThrowOnAccess<AccessedException<UrlCollectionPluginBaseTests.Unimplemented>, UrlCollectionPluginBaseTests.Unimplemented>(
                     finalImpl,
-                    customFilter: NoInnerOrSources,
-                    typesToExclude: typeof(IAsyncDisposable)
+                    customFilter: NoInnerOrSources
                 );
             }
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(
-                finalImpl,
-                customFilter: NoInnerOrSources,
-                expectedExceptions: expectedExceptionsWhenDisposing.ToArray()
-            );
-        }
-
-        [TestMethod, Timeout(5000)]
-        [AllEnumFlagCombinations(typeof(PossiblePlugins))]
-        public async Task DisposeAsync_AllCombinations(PossiblePlugins data)
-        {
-            var builder = new SdkModelPlugin(SdkTestPluginMetadata.Metadata).TrackCollection;
-            var defaultImplementation = new NotBlockingDisposeAsync();
-            builder.Add(x => new NoOverride(x)
-            {
-                InnerDownloadable = data.HasFlag(PossiblePlugins.Downloadable) ? new DownloadablePluginBaseTests.NotBlockingDisposeAsync() : x,
-                InnerPlayable = data.HasFlag(PossiblePlugins.Playable) ? new PlayablePluginBaseTests.NotBlockingDisposeAsync() : x,
-                InnerImageCollection = data.HasFlag(PossiblePlugins.ImageCollection) ? new ImageCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
-                InnerUrlCollection = data.HasFlag(PossiblePlugins.UrlCollection) ? new UrlCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
-            });
-
-            var finalImpl = builder.Execute(defaultImplementation);
-
-            Assert.AreNotSame(finalImpl, defaultImplementation);
-            Assert.IsInstanceOfType(finalImpl, typeof(NoOverride));
-
-            await finalImpl.DisposeAsync();
         }
 
         internal class FullyCustom : TrackCollectionPluginBase
@@ -250,7 +205,6 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
             public override Task ChangeDescriptionAsync(string? description, CancellationToken cancellationToken = default) => throw AccessedException;
             public override Task ChangeDurationAsync(TimeSpan duration, CancellationToken cancellationToken = default) => throw AccessedException;
             public override Task ChangeNameAsync(string name, CancellationToken cancellationToken = default) => throw AccessedException;
-            public override ValueTask DisposeAsync() => throw AccessedException;
             public override bool Equals(ICoreImageCollection? other) => throw AccessedException;
             public override bool Equals(ICoreUrlCollection? other) => throw AccessedException;
             public override bool Equals(ICoreTrackCollection? other) => throw AccessedException;
@@ -278,17 +232,6 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
                 : base(new ModelPluginMetadata("", nameof(NoOverride), "", new Version()), inner)
             {
             }
-        }
-
-        internal class NotBlockingDisposeAsync : TrackCollectionPluginBase
-        {
-            public NotBlockingDisposeAsync()
-                : base(new ModelPluginMetadata("", nameof(NotBlockingDisposeAsync), "", new Version()), new Unimplemented())
-            {
-            }
-
-            /// <inheritdoc />
-            public override ValueTask DisposeAsync() => default;
         }
 
         internal class Unimplemented : ITrackCollection
@@ -338,7 +281,6 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
             public Task ChangeDescriptionAsync(string? description, CancellationToken cancellationToken = default) => throw AccessedException;
             public Task ChangeDurationAsync(TimeSpan duration, CancellationToken cancellationToken = default) => throw AccessedException;
             public Task ChangeNameAsync(string name, CancellationToken cancellationToken = default) => throw AccessedException;
-            public ValueTask DisposeAsync() => throw AccessedException;
             public bool Equals(ICoreImageCollection? other) => throw AccessedException;
             public bool Equals(ICoreUrlCollection? other) => throw AccessedException;
             public bool Equals(ICoreTrackCollection? other) => throw AccessedException;

--- a/src/Sdk/StrixMusic.Sdk.Tests/Plugins/Models/TrackPluginBaseTests.cs
+++ b/src/Sdk/StrixMusic.Sdk.Tests/Plugins/Models/TrackPluginBaseTests.cs
@@ -128,34 +128,23 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
             Assert.AreNotSame(finalImpl, defaultImplementation);
             Assert.IsInstanceOfType(finalImpl, typeof(NoOverride));
 
-            var expectedExceptionsWhenDisposing = new List<Type>
-            {
-                typeof(AccessedException<Unimplemented>),
-            };
-
             if (data.HasFlag(PossiblePlugins.Downloadable))
             {
-                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<DownloadablePluginBaseTests.Unimplemented>));
-
                 Helpers.AssertAllMembersThrowOnAccess<AccessedException<DownloadablePluginBaseTests.Unimplemented>,
                     DownloadablePluginBaseTests.Unimplemented>(
                     finalImpl,
-                    customFilter: NoInnerOrSources,
-                    typesToExclude: typeof(IAsyncDisposable)
+                    customFilter: NoInnerOrSources
                 );
             }
 
             if (data.HasFlag(PossiblePlugins.Playable))
             {
-                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<PlayablePluginBaseTests.Unimplemented>));
-
                 Helpers.AssertAllMembersThrowOnAccess<AccessedException<PlayablePluginBaseTests.Unimplemented>,
                     PlayablePluginBaseTests.Unimplemented>(
                     finalImpl,
                     customFilter: NoInnerOrSources,
                     typesToExclude: new[]
                     {
-                        typeof(IAsyncDisposable),
                         typeof(DownloadablePluginBaseTests.Unimplemented),
                         typeof(ImageCollectionPluginBaseTests.Unimplemented),
                         typeof(UrlCollectionPluginBaseTests.Unimplemented)
@@ -165,15 +154,12 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
 
             if (data.HasFlag(PossiblePlugins.ArtistCollection))
             {
-                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<ArtistCollectionPluginBaseTests.Unimplemented>));
-
                 Helpers.AssertAllMembersThrowOnAccess<AccessedException<ArtistCollectionPluginBaseTests.Unimplemented>,
                     ArtistCollectionPluginBaseTests.Unimplemented>(
                     finalImpl,
                     customFilter: NoInnerOrSources,
                     typesToExclude: new[]
                     {
-                        typeof(IAsyncDisposable),
                         typeof(DownloadablePluginBaseTests.Unimplemented),
                         typeof(ImageCollectionPluginBaseTests.Unimplemented),
                         typeof(UrlCollectionPluginBaseTests.Unimplemented),
@@ -185,67 +171,29 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
 
             if (data.HasFlag(PossiblePlugins.GenreCollection))
             {
-                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<GenreCollectionPluginBaseTests.Unimplemented>));
-
                 Helpers.AssertAllMembersThrowOnAccess<AccessedException<GenreCollectionPluginBaseTests.Unimplemented>,
                     GenreCollectionPluginBaseTests.Unimplemented>(
                     finalImpl,
-                    customFilter: NoInnerOrSources,
-                    typesToExclude: typeof(IAsyncDisposable)
+                    customFilter: NoInnerOrSources
                 );
             }
 
             if (data.HasFlag(PossiblePlugins.ImageCollection))
             {
-                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<ImageCollectionPluginBaseTests.Unimplemented>));
-
                 Helpers.AssertAllMembersThrowOnAccess<AccessedException<ImageCollectionPluginBaseTests.Unimplemented>,
                     ImageCollectionPluginBaseTests.Unimplemented>(
                     finalImpl,
-                    customFilter: NoInnerOrSources,
-                    typesToExclude: typeof(IAsyncDisposable)
+                    customFilter: NoInnerOrSources
                 );
             }
 
             if (data.HasFlag(PossiblePlugins.UrlCollection))
             {
-                expectedExceptionsWhenDisposing.Add(typeof(AccessedException<UrlCollectionPluginBaseTests.Unimplemented>));
-
                 Helpers.AssertAllMembersThrowOnAccess<AccessedException<UrlCollectionPluginBaseTests.Unimplemented>, UrlCollectionPluginBaseTests.Unimplemented>(
                     finalImpl,
-                    customFilter: NoInnerOrSources,
-                    typesToExclude: typeof(IAsyncDisposable)
+                    customFilter: NoInnerOrSources
                 );
             }
-
-            Helpers.AssertAllThrowsOnMemberAccess<IAsyncDisposable>(
-                finalImpl,
-                customFilter: NoInnerOrSources,
-                expectedExceptions: expectedExceptionsWhenDisposing.ToArray()
-            );
-        }
-
-        [TestMethod, Timeout(5000)]
-        [AllEnumFlagCombinations(typeof(PossiblePlugins))]
-        public async Task DisposeAsync_AllCombinations(PossiblePlugins data)
-        {
-            var builder = new SdkModelPlugin(SdkTestPluginMetadata.Metadata).Track;
-            var defaultImplementation = new NotBlockingDisposeAsync();
-            builder.Add(x => new NoOverride(x)
-            {
-                InnerDownloadable = data.HasFlag(PossiblePlugins.Downloadable) ? new DownloadablePluginBaseTests.NotBlockingDisposeAsync() : x,
-                InnerPlayable = data.HasFlag(PossiblePlugins.Playable) ? new PlayablePluginBaseTests.NotBlockingDisposeAsync() : x,
-                InnerArtistCollection = data.HasFlag(PossiblePlugins.ArtistCollection) ? new ArtistCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
-                InnerImageCollection = data.HasFlag(PossiblePlugins.ImageCollection) ? new ImageCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
-                InnerUrlCollection = data.HasFlag(PossiblePlugins.UrlCollection) ? new UrlCollectionPluginBaseTests.NotBlockingDisposeAsync() : x,
-            });
-
-            var finalImpl = builder.Execute(defaultImplementation);
-
-            Assert.AreNotSame(finalImpl, defaultImplementation);
-            Assert.IsInstanceOfType(finalImpl, typeof(NoOverride));
-
-            await finalImpl.DisposeAsync();
         }
 
         internal class FullyCustom : TrackPluginBase
@@ -257,7 +205,6 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
 
             internal static AccessedException<FullyCustom> AccessedException { get; } = new();
 
-            public override ValueTask DisposeAsync() => throw AccessedException;
             public override Task<bool> IsAddImageAvailableAsync(int index, CancellationToken cancellationToken = default) => throw AccessedException;
             public override Task<bool> IsRemoveImageAvailableAsync(int index, CancellationToken cancellationToken = default) => throw AccessedException;
             public override Task RemoveImageAsync(int index, CancellationToken cancellationToken = default) => throw AccessedException;
@@ -360,23 +307,11 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
             }
         }
 
-        internal class NotBlockingDisposeAsync : TrackPluginBase
-        {
-            public NotBlockingDisposeAsync()
-                : base(new ModelPluginMetadata("", nameof(NotBlockingDisposeAsync), "", new Version()), new Unimplemented())
-            {
-            }
-
-            /// <inheritdoc />
-            public override ValueTask DisposeAsync() => default;
-        }
-
         internal class Unimplemented : ITrack
         {
             internal static AccessedException<Unimplemented> AccessedException { get; } = new();
             
             public event EventHandler? SourcesChanged { add => throw AccessedException; remove => throw AccessedException; }
-            public ValueTask DisposeAsync() => throw AccessedException;
             public Task<bool> IsAddImageAvailableAsync(int index, CancellationToken cancellationToken = default) => throw AccessedException;
             public Task<bool> IsRemoveImageAvailableAsync(int index, CancellationToken cancellationToken = default) => throw AccessedException;
             public Task RemoveImageAsync(int index, CancellationToken cancellationToken = default) => throw AccessedException;

--- a/src/Sdk/StrixMusic.Sdk.Tests/Plugins/Models/UrlCollectionPluginBaseTests.cs
+++ b/src/Sdk/StrixMusic.Sdk.Tests/Plugins/Models/UrlCollectionPluginBaseTests.cs
@@ -95,8 +95,6 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
 
             public override Task AddUrlAsync(IUrl url, int index, CancellationToken cancellationToken = default) => throw AccessedException;
 
-            public override ValueTask DisposeAsync() => throw AccessedException;
-
             public override bool Equals(ICoreUrlCollection? other) => throw AccessedException;
 
             public override IAsyncEnumerable<IUrl> GetUrlsAsync(int limit, int offset, CancellationToken cancellationToken = default) => throw AccessedException;
@@ -116,17 +114,6 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
             }
         }
 
-        internal class NotBlockingDisposeAsync : UrlCollectionPluginBase
-        {
-            public NotBlockingDisposeAsync()
-                : base(new ModelPluginMetadata("", nameof(NotBlockingDisposeAsync), "", new Version()), new Unimplemented())
-            {
-            }
-
-            /// <inheritdoc />
-            public override ValueTask DisposeAsync() => default;
-        }
-
         public class Unimplemented : IUrlCollection
         {
             internal static AccessedException<Unimplemented> AccessedException { get; } = new();
@@ -140,8 +127,6 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
             public event EventHandler<int>? UrlsCountChanged { add => throw AccessedException; remove => throw AccessedException; }
 
             public Task AddUrlAsync(IUrl url, int index, CancellationToken cancellationToken = default) => throw AccessedException;
-
-            public ValueTask DisposeAsync() => throw AccessedException;
 
             public bool Equals(ICoreUrlCollection? other) => throw AccessedException;
 

--- a/src/Sdk/StrixMusic.Sdk.Tests/Plugins/Models/UrlPluginBaseTests.cs
+++ b/src/Sdk/StrixMusic.Sdk.Tests/Plugins/Models/UrlPluginBaseTests.cs
@@ -86,7 +86,6 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
 
             internal static AccessedException<FullyCustom> AccessedException { get; } = new();
 
-            public override ValueTask DisposeAsync() => throw AccessedException;
             public override string Label => throw AccessedException;
             public override Uri Url => throw AccessedException;
             public override UrlType Type => throw AccessedException;
@@ -106,7 +105,6 @@ namespace StrixMusic.Sdk.Tests.Plugins.Models
             internal static AccessedException<Unimplemented> AccessedException { get; } = new();
             
             public event EventHandler? SourcesChanged { add => throw AccessedException; remove => throw AccessedException; }
-            public ValueTask DisposeAsync() => throw AccessedException;
             public string Label => throw AccessedException;
             public Uri Url => throw AccessedException;
             public UrlType Type => throw AccessedException;

--- a/src/Sdk/StrixMusic.Sdk/AdapterModels/DeviceAdapter.cs
+++ b/src/Sdk/StrixMusic.Sdk/AdapterModels/DeviceAdapter.cs
@@ -236,8 +236,5 @@ namespace StrixMusic.Sdk.AdapterModels
 
         /// <inheritdoc />
         public PlaybackItem? NowPlaying { get; private set; }
-
-        /// <inheritdoc />
-        public ValueTask DisposeAsync() => _source.DisposeAsync();
     }
 }

--- a/src/Sdk/StrixMusic.Sdk/AdapterModels/MergedAlbum.cs
+++ b/src/Sdk/StrixMusic.Sdk/AdapterModels/MergedAlbum.cs
@@ -581,18 +581,5 @@ namespace StrixMusic.Sdk.AdapterModels
 
         /// <inheritdoc />
         public bool Equals(ICoreUrlCollection other) => Equals(other as ICoreAlbum);
-
-        /// <inheritdoc />
-        public async ValueTask DisposeAsync()
-        {
-            DetachEvents(_preferredSource);
-
-            await _artistCollectionMap.DisposeAsync();
-            await _imageCollectionMap.DisposeAsync();
-            await _genreCollectionMap.DisposeAsync();
-            await _urlCollectionMap.DisposeAsync();
-
-            await Sources.InParallel(x => x.DisposeAsync().AsTask());
-        }
     }
 }

--- a/src/Sdk/StrixMusic.Sdk/AdapterModels/MergedAlbumCollection.cs
+++ b/src/Sdk/StrixMusic.Sdk/AdapterModels/MergedAlbumCollection.cs
@@ -390,17 +390,5 @@ namespace StrixMusic.Sdk.AdapterModels
 
         /// <inheritdoc />
         public bool Equals(ICoreUrlCollection other) => Equals(other as ICoreAlbumCollection);
-
-        /// <inheritdoc />
-        public async ValueTask DisposeAsync()
-        {
-            DetachEvents(_preferredSource);
-
-            await _albumMap.DisposeAsync();
-            await _imageMap.DisposeAsync();
-            await _urlMap.DisposeAsync();
-
-            await Sources.InParallel(x => x.DisposeAsync().AsTask());
-        }
     }
 }

--- a/src/Sdk/StrixMusic.Sdk/AdapterModels/MergedArtist.cs
+++ b/src/Sdk/StrixMusic.Sdk/AdapterModels/MergedArtist.cs
@@ -568,19 +568,5 @@ namespace StrixMusic.Sdk.AdapterModels
         {
             return _preferredSource.GetHashCode();
         }
-
-        /// <inheritdoc />
-        public async ValueTask DisposeAsync()
-        {
-            DetachEvents(_preferredSource);
-
-            await _albumCollectionItemMap.DisposeAsync();
-            await _trackCollectionMap.DisposeAsync();
-            await _imageCollectionMap.DisposeAsync();
-            await _genreCollectionMap.DisposeAsync();
-            await _urlCollectionMap.DisposeAsync();
-
-            await Sources.InParallel(x => x.DisposeAsync().AsTask());
-        }
     }
 }

--- a/src/Sdk/StrixMusic.Sdk/AdapterModels/MergedArtistCollection.cs
+++ b/src/Sdk/StrixMusic.Sdk/AdapterModels/MergedArtistCollection.cs
@@ -395,17 +395,5 @@ namespace StrixMusic.Sdk.AdapterModels
 
         /// <inheritdoc />
         public bool Equals(ICoreUrlCollection other) => Equals(other as ICoreArtistCollection);
-
-        /// <inheritdoc />
-        public async ValueTask DisposeAsync()
-        {
-            DetachEvents(_preferredSource);
-
-            await _artistMap.DisposeAsync();
-            await _imageMap.DisposeAsync();
-            await _urlMap.DisposeAsync();
-
-            await _sources.InParallel(x => x.DisposeAsync().AsTask());
-        }
     }
 }

--- a/src/Sdk/StrixMusic.Sdk/AdapterModels/MergedCollectionMap.cs
+++ b/src/Sdk/StrixMusic.Sdk/AdapterModels/MergedCollectionMap.cs
@@ -27,7 +27,7 @@ namespace StrixMusic.Sdk.AdapterModels
     /// <typeparam name="TCollectionItem">The type of the item returned from the merged collection.</typeparam>
     /// <typeparam name="TCoreCollectionItem">The type of the items returned from the original source collections.</typeparam>
     internal sealed class MergedCollectionMap<TCollection, TCoreCollection, TCollectionItem, TCoreCollectionItem>
-        : IMerged<TCoreCollection>, IMergedMutable<TCoreCollection>, IAsyncInit, IAsyncDisposable
+        : IMerged<TCoreCollection>, IMergedMutable<TCoreCollection>, IAsyncInit
         where TCollection : class, ICollectionBase, IMerged<TCoreCollection>
         where TCoreCollection : class, ICoreCollection
         where TCollectionItem : class, ICollectionItemBase, IMerged<TCoreCollectionItem>
@@ -37,8 +37,6 @@ namespace StrixMusic.Sdk.AdapterModels
         private static bool _isInitialized;
         private static TaskCompletionSource<bool>? _initCompletionSource;
 
-        private readonly SemaphoreSlim _disposeSemaphore = new(1, 1);
-
         private readonly TCollection _collection;
         private readonly MergedCollectionConfig _config;
 
@@ -47,8 +45,6 @@ namespace StrixMusic.Sdk.AdapterModels
         /// </summary>
         private readonly List<MappedData> _sortedMap = new();
         private readonly List<MergedMappedData> _mergedMappedData = new();
-
-        private bool _isDisposed;
 
         /// <inheritdoc />
         public IReadOnlyList<TCoreCollection> Sources => _collection.Sources;
@@ -977,27 +973,6 @@ namespace StrixMusic.Sdk.AdapterModels
             public IMergedMutable<TCoreCollectionItem> CollectionItem { get; }
 
             public List<MappedData> MergedMapData { get; }
-        }
-
-        /// <inheritdoc />
-        public async ValueTask DisposeAsync()
-        {
-            if (_isDisposed)
-                return;
-
-            using (await OwlCore.Flow.EasySemaphore(_disposeSemaphore))
-            {
-                if (_isDisposed)
-                    return;
-
-                DetachEvents();
-                _mergedMappedData.Clear();
-                _sortedMap.Clear();
-
-                _isDisposed = true;
-
-                return;
-            }
         }
     }
 }

--- a/src/Sdk/StrixMusic.Sdk/AdapterModels/MergedGenre.cs
+++ b/src/Sdk/StrixMusic.Sdk/AdapterModels/MergedGenre.cs
@@ -66,11 +66,5 @@ namespace StrixMusic.Sdk.AdapterModels
         {
             return other?.Name == Name;
         }
-
-        /// <inheritdoc />
-        public async ValueTask DisposeAsync()
-        {
-            await _sources.InParallel(x => x.DisposeAsync().AsTask());
-        }
     }
 }

--- a/src/Sdk/StrixMusic.Sdk/AdapterModels/MergedImage.cs
+++ b/src/Sdk/StrixMusic.Sdk/AdapterModels/MergedImage.cs
@@ -79,11 +79,5 @@ namespace StrixMusic.Sdk.AdapterModels
             // For merging, this check can be done as we retrieve the images from the collection.
             return ReferenceEquals(this, other);
         }
-
-        /// <inheritdoc />
-        public async ValueTask DisposeAsync()
-        {
-            await _sources.InParallel(x => x.DisposeAsync().AsTask());
-        }
     }
 }

--- a/src/Sdk/StrixMusic.Sdk/AdapterModels/MergedPlayableCollectionGroupBase.cs
+++ b/src/Sdk/StrixMusic.Sdk/AdapterModels/MergedPlayableCollectionGroupBase.cs
@@ -22,7 +22,7 @@ namespace StrixMusic.Sdk.AdapterModels
     /// A base that merges multiple <see cref="IPlayableCollectionGroupBase"/>s.
     /// </summary>
     public abstract class MergedPlayableCollectionGroupBase<TCoreBase> : IPlayableCollectionGroup, IMergedMutable<TCoreBase>
-        where TCoreBase : class, ICorePlayableCollectionGroup, IAsyncDisposable
+        where TCoreBase : class, ICorePlayableCollectionGroup
     {
         private readonly MergedCollectionMap<IAlbumCollection, ICoreAlbumCollection, IAlbumCollectionItem, ICoreAlbumCollectionItem> _albumCollectionMap;
         private readonly MergedCollectionMap<IArtistCollection, ICoreArtistCollection, IArtistCollectionItem, ICoreArtistCollectionItem> _artistCollectionMap;
@@ -831,34 +831,6 @@ namespace StrixMusic.Sdk.AdapterModels
         public virtual bool Equals(TCoreBase? other)
         {
             return other != null && other.Name.Equals(Name, StringComparison.InvariantCulture);
-        }
-
-        /// <inheritdoc />
-        public async ValueTask DisposeAsync()
-        {
-            if (_isDisposed)
-                return;
-
-            using (await OwlCore.Flow.EasySemaphore(_disposeSemaphore))
-            {
-                if (_isDisposed)
-                    return;
-
-                DetachCollectionChangedEvents();
-                DetachPropertyChangedEvents(PreferredSource);
-
-                await _albumCollectionMap.DisposeAsync();
-                await _artistCollectionMap.DisposeAsync();
-                await _playableCollectionGroupMap.DisposeAsync();
-                await _playlistCollectionMap.DisposeAsync();
-                await _trackCollectionMap.DisposeAsync();
-                await _imageCollectionMap.DisposeAsync();
-                await _urlCollectionMap.DisposeAsync();
-
-                await Sources.InParallel(x => x.DisposeAsync().AsTask());
-
-                _isDisposed = true;
-            }
         }
     }
 }

--- a/src/Sdk/StrixMusic.Sdk/AdapterModels/MergedPlayableCollectionGroupBase.cs
+++ b/src/Sdk/StrixMusic.Sdk/AdapterModels/MergedPlayableCollectionGroupBase.cs
@@ -31,9 +31,6 @@ namespace StrixMusic.Sdk.AdapterModels
         private readonly MergedCollectionMap<IPlayableCollectionGroup, ICorePlayableCollectionGroup, IPlayableCollectionGroup, ICorePlayableCollectionGroup> _playableCollectionGroupMap;
         private readonly MergedCollectionMap<IImageCollection, ICoreImageCollection, IImage, ICoreImage> _imageCollectionMap;
         private readonly MergedCollectionMap<IUrlCollection, ICoreUrlCollection, IUrl, ICoreUrl> _urlCollectionMap;
-        private readonly SemaphoreSlim _disposeSemaphore = new(1, 1);
-
-        private bool _isDisposed;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="MergedPlayableCollectionGroupBase{T}"/> class.

--- a/src/Sdk/StrixMusic.Sdk/AdapterModels/MergedPlaylist.cs
+++ b/src/Sdk/StrixMusic.Sdk/AdapterModels/MergedPlaylist.cs
@@ -427,16 +427,5 @@ namespace StrixMusic.Sdk.AdapterModels
         {
             return _preferredSource.GetHashCode();
         }
-
-        /// <inheritdoc />
-        public async ValueTask DisposeAsync()
-        {
-            DetachEvents(_preferredSource);
-
-            await _sources.InParallel(x => x.DisposeAsync().AsTask());
-
-            await _imageCollectionMap.DisposeAsync();
-            await _trackCollectionMap.DisposeAsync();
-        }
     }
 }

--- a/src/Sdk/StrixMusic.Sdk/AdapterModels/MergedPlaylistCollection.cs
+++ b/src/Sdk/StrixMusic.Sdk/AdapterModels/MergedPlaylistCollection.cs
@@ -394,17 +394,5 @@ namespace StrixMusic.Sdk.AdapterModels
 
         /// <inheritdoc />
         public bool Equals(ICoreUrlCollection other) => Equals(other as ICorePlaylistCollection);
-
-        /// <inheritdoc />
-        public async ValueTask DisposeAsync()
-        {
-            DetachEvents(_preferredSource);
-
-            await _sources.InParallel(x => x.DisposeAsync().AsTask());
-
-            await _playlistMap.DisposeAsync();
-            await _imageMap.DisposeAsync();
-            await _urlMap.DisposeAsync();
-        }
     }
 }

--- a/src/Sdk/StrixMusic.Sdk/AdapterModels/MergedSearch.cs
+++ b/src/Sdk/StrixMusic.Sdk/AdapterModels/MergedSearch.cs
@@ -129,11 +129,5 @@ namespace StrixMusic.Sdk.AdapterModels
         /// <param name="other">An object to compare with this object.</param>
         /// <returns>true. We always merge together search sources.</returns>
         public bool Equals(ICoreSearch other) => true;
-
-        /// <inheritdoc />
-        public async ValueTask DisposeAsync()
-        {
-            await _sources.InParallel(x => x.DisposeAsync().AsTask());
-        }
     }
 }

--- a/src/Sdk/StrixMusic.Sdk/AdapterModels/MergedTrack.cs
+++ b/src/Sdk/StrixMusic.Sdk/AdapterModels/MergedTrack.cs
@@ -579,18 +579,5 @@ namespace StrixMusic.Sdk.AdapterModels
                    !(other.Album is null) &&
                    album.Equals(other.Album);
         }
-
-        /// <inheritdoc />
-        public async ValueTask DisposeAsync()
-        {
-            DetachEvents(_preferredSource);
-
-            await _sources.InParallel(x => x.DisposeAsync().AsTask());
-
-            await _imageCollectionMap.DisposeAsync();
-            await _artistMap.DisposeAsync();
-            await _genreCollectionMap.DisposeAsync();
-            await _urlCollectionMap.DisposeAsync();
-        }
     }
 }

--- a/src/Sdk/StrixMusic.Sdk/AdapterModels/MergedTrackCollection.cs
+++ b/src/Sdk/StrixMusic.Sdk/AdapterModels/MergedTrackCollection.cs
@@ -364,17 +364,5 @@ namespace StrixMusic.Sdk.AdapterModels
 
         /// <inheritdoc />
         public bool Equals(ICoreUrlCollection other) => Equals(other as ICoreTrackCollection);
-
-        /// <inheritdoc />
-        public async ValueTask DisposeAsync()
-        {
-            DetachEvents(_preferredSource);
-
-            await _sources.InParallel(x => x.DisposeAsync().AsTask());
-
-            await _trackMap.DisposeAsync();
-            await _urlMap.DisposeAsync();
-            await _imageMap.DisposeAsync();
-        }
     }
 }

--- a/src/Sdk/StrixMusic.Sdk/AdapterModels/MergedUrl.cs
+++ b/src/Sdk/StrixMusic.Sdk/AdapterModels/MergedUrl.cs
@@ -72,11 +72,5 @@ namespace StrixMusic.Sdk.AdapterModels
                    other?.Type == Type &&
                    other?.Label == Label;
         }
-
-        /// <inheritdoc />
-        public async ValueTask DisposeAsync()
-        {
-            await _sources.InParallel(x => x.DisposeAsync().AsTask());
-        }
     }
 }

--- a/src/Sdk/StrixMusic.Sdk/AdapterModels/UserAdapter.cs
+++ b/src/Sdk/StrixMusic.Sdk/AdapterModels/UserAdapter.cs
@@ -247,12 +247,5 @@ namespace StrixMusic.Sdk.AdapterModels
         /// <returns>false. User profiles are never merged.</returns>
         public bool Equals(ICoreUrlCollection other) =>
             false;
-
-        /// <inheritdoc />
-        public ValueTask DisposeAsync()
-        {
-            DetachEvents();
-            return _user.DisposeAsync();
-        }
     }
 }

--- a/src/Sdk/StrixMusic.Sdk/AdapterModels/UserProfileAdapter.cs
+++ b/src/Sdk/StrixMusic.Sdk/AdapterModels/UserProfileAdapter.cs
@@ -288,12 +288,5 @@ namespace StrixMusic.Sdk.AdapterModels
         /// <param name="other">An object to compare with this object.</param>
         /// <returns>false. User profiles are never merged.</returns>
         public bool Equals(ICoreUrlCollection other) => false;
-
-        /// <inheritdoc />
-        public ValueTask DisposeAsync()
-        {
-            DetachEvents();
-            return _userProfile.DisposeAsync();
-        }
     }
 }

--- a/src/Sdk/StrixMusic.Sdk/AppModels/IDownloadable.cs
+++ b/src/Sdk/StrixMusic.Sdk/AppModels/IDownloadable.cs
@@ -11,7 +11,7 @@ namespace StrixMusic.Sdk.AppModels
     /// <summary>
     /// Indicates an item that can be downloaded for offline usage.
     /// </summary>
-    public interface IDownloadable : IAsyncDisposable
+    public interface IDownloadable
     {
         /// <summary>
         /// Information about downloading this item.

--- a/src/Sdk/StrixMusic.Sdk/AppModels/InitialPlaylistData.cs
+++ b/src/Sdk/StrixMusic.Sdk/AppModels/InitialPlaylistData.cs
@@ -313,8 +313,5 @@ namespace StrixMusic.Sdk.AppModels
 
         /// <inheritdoc />
         public bool Equals(ICorePlaylist other) => false;
-
-        /// <inheritdoc />
-        public ValueTask DisposeAsync() => default;
     }
 }

--- a/src/Sdk/StrixMusic.Sdk/BaseModels/IAlbumBase.cs
+++ b/src/Sdk/StrixMusic.Sdk/BaseModels/IAlbumBase.cs
@@ -11,7 +11,7 @@ namespace StrixMusic.Sdk.BaseModels
     /// <summary>
     /// A published album containing one or more tracks, discs, artist, etc.
     /// </summary>
-    public interface IAlbumBase : IPlayableCollectionItem, IAlbumCollectionItemBase, IArtistCollectionBase, ITrackCollectionBase, IImageCollectionBase, IGenreCollectionBase, IAsyncDisposable
+    public interface IAlbumBase : IPlayableCollectionItem, IAlbumCollectionItemBase, IArtistCollectionBase, ITrackCollectionBase, IImageCollectionBase, IGenreCollectionBase
     {
         /// <summary>
         /// The date the album was released.

--- a/src/Sdk/StrixMusic.Sdk/BaseModels/IAlbumCollectionBase.cs
+++ b/src/Sdk/StrixMusic.Sdk/BaseModels/IAlbumCollectionBase.cs
@@ -11,7 +11,7 @@ namespace StrixMusic.Sdk.BaseModels
     /// <summary>
     /// A collection of <see cref="IAlbumCollectionItemBase"/>s and the properties and methods for using and manipulating them.
     /// </summary>
-    public interface IAlbumCollectionBase : IPlayableCollectionBase, IAlbumCollectionItemBase, IAsyncDisposable
+    public interface IAlbumCollectionBase : IPlayableCollectionBase, IAlbumCollectionItemBase
     {
         /// <summary>
         /// The total number of available Albums.

--- a/src/Sdk/StrixMusic.Sdk/BaseModels/IAlbumCollectionItemBase.cs
+++ b/src/Sdk/StrixMusic.Sdk/BaseModels/IAlbumCollectionItemBase.cs
@@ -9,7 +9,7 @@ namespace StrixMusic.Sdk.BaseModels
     /// <summary>
     /// An item that belongs in an <see cref="IAlbumCollectionBase"/> or <see cref="IAlbumBase"/>.
     /// </summary>
-    public interface IAlbumCollectionItemBase : ICollectionItemBase, IPlayableCollectionItem, IAsyncDisposable
+    public interface IAlbumCollectionItemBase : ICollectionItemBase, IPlayableCollectionItem
     {
     }
 }

--- a/src/Sdk/StrixMusic.Sdk/BaseModels/IArtistBase.cs
+++ b/src/Sdk/StrixMusic.Sdk/BaseModels/IArtistBase.cs
@@ -10,7 +10,7 @@ namespace StrixMusic.Sdk.BaseModels
     /// <summary>
     /// A musician or creator that has published one or more <see cref="ITrack"/>s and <see cref="IAlbum"/>s.
     /// </summary>
-    public interface IArtistBase : IPlayableCollectionItem, IArtistCollectionItemBase, IAlbumCollectionBase, ITrackCollectionBase, IGenreCollectionBase, IAsyncDisposable
+    public interface IArtistBase : IPlayableCollectionItem, IArtistCollectionItemBase, IAlbumCollectionBase, ITrackCollectionBase, IGenreCollectionBase
     {
     }
 }

--- a/src/Sdk/StrixMusic.Sdk/BaseModels/IArtistCollectionBase.cs
+++ b/src/Sdk/StrixMusic.Sdk/BaseModels/IArtistCollectionBase.cs
@@ -12,7 +12,7 @@ namespace StrixMusic.Sdk.BaseModels
     /// <summary>
     /// A collection of <see cref="IArtistCollectionItemBase"/>s and the properties and methods for using and manipulating them.
     /// </summary>
-    public interface IArtistCollectionBase : IPlayableCollectionBase, IArtistCollectionItemBase, IAsyncDisposable
+    public interface IArtistCollectionBase : IPlayableCollectionBase, IArtistCollectionItemBase
     {
         /// <summary>
         /// The total number of available Artists.

--- a/src/Sdk/StrixMusic.Sdk/BaseModels/IArtistCollectionItemBase.cs
+++ b/src/Sdk/StrixMusic.Sdk/BaseModels/IArtistCollectionItemBase.cs
@@ -9,7 +9,7 @@ namespace StrixMusic.Sdk.BaseModels
     /// <summary>
     /// An item that belongs in an <see cref="IArtistCollectionBase"/>.
     /// </summary>
-    public interface IArtistCollectionItemBase : IPlayableCollectionItem, IAsyncDisposable
+    public interface IArtistCollectionItemBase : IPlayableCollectionItem
     {
     }
 }

--- a/src/Sdk/StrixMusic.Sdk/BaseModels/ICollectionBase.cs
+++ b/src/Sdk/StrixMusic.Sdk/BaseModels/ICollectionBase.cs
@@ -9,7 +9,7 @@ namespace StrixMusic.Sdk.BaseModels
     /// <summary>
     /// A base class for collections.
     /// </summary>
-    public interface ICollectionBase : IAsyncDisposable
+    public interface ICollectionBase
     {
     }
 }

--- a/src/Sdk/StrixMusic.Sdk/BaseModels/ICollectionItemBase.cs
+++ b/src/Sdk/StrixMusic.Sdk/BaseModels/ICollectionItemBase.cs
@@ -9,7 +9,7 @@ namespace StrixMusic.Sdk.BaseModels
     /// <summary>
     /// An item that is returned from any collection.
     /// </summary>
-    public interface ICollectionItemBase : IAsyncDisposable
+    public interface ICollectionItemBase
     {
     }
 }

--- a/src/Sdk/StrixMusic.Sdk/BaseModels/IDeviceBase.cs
+++ b/src/Sdk/StrixMusic.Sdk/BaseModels/IDeviceBase.cs
@@ -13,7 +13,7 @@ namespace StrixMusic.Sdk.BaseModels
     /// <summary>
     /// A device that controls playback of an audio player.
     /// </summary>
-    public interface IDeviceBase : IAudioPlayerBase, IAsyncDisposable
+    public interface IDeviceBase : IAudioPlayerBase
     {
         /// <summary>
         /// A unique identifier for the player.

--- a/src/Sdk/StrixMusic.Sdk/BaseModels/IDiscoverablesBase.cs
+++ b/src/Sdk/StrixMusic.Sdk/BaseModels/IDiscoverablesBase.cs
@@ -9,7 +9,7 @@ namespace StrixMusic.Sdk.BaseModels
     /// <summary>
     /// Used to browse and discover new music.
     /// </summary>
-    public interface IDiscoverablesBase : IPlayableCollectionGroupBase, IAsyncDisposable
+    public interface IDiscoverablesBase : IPlayableCollectionGroupBase
     {
     }
 }

--- a/src/Sdk/StrixMusic.Sdk/BaseModels/IGenreCollectionBase.cs
+++ b/src/Sdk/StrixMusic.Sdk/BaseModels/IGenreCollectionBase.cs
@@ -11,7 +11,7 @@ namespace StrixMusic.Sdk.BaseModels
     /// <summary>
     /// A common interface for all collections that return genres.
     /// </summary>
-    public interface IGenreCollectionBase : ICollectionBase, IAsyncDisposable
+    public interface IGenreCollectionBase : ICollectionBase
     {
         /// <summary>
         /// The total number of genres in this collection.

--- a/src/Sdk/StrixMusic.Sdk/BaseModels/IImageCollectionBase.cs
+++ b/src/Sdk/StrixMusic.Sdk/BaseModels/IImageCollectionBase.cs
@@ -15,7 +15,7 @@ namespace StrixMusic.Sdk.BaseModels
     /// </summary>
     /// <seealso cref="IImageCollection"/>
     /// <seealso cref="ICoreImageCollection"/>
-    public interface IImageCollectionBase : ICollectionBase, IAsyncDisposable
+    public interface IImageCollectionBase : ICollectionBase
     {
         /// <summary>
         /// Checks if adding a <see cref="IImageBase"/> to the collection at at the given <paramref name="index"/> is supported.

--- a/src/Sdk/StrixMusic.Sdk/BaseModels/IInitialDataBase.cs
+++ b/src/Sdk/StrixMusic.Sdk/BaseModels/IInitialDataBase.cs
@@ -9,7 +9,7 @@ namespace StrixMusic.Sdk.BaseModels
     /// <summary>
     /// Used as a common interface for data that is created in the UI.
     /// </summary>
-    public interface IInitialDataBase : ICollectionItemBase, IAsyncDisposable
+    public interface IInitialDataBase : ICollectionItemBase
     {
     }
 }

--- a/src/Sdk/StrixMusic.Sdk/BaseModels/ILibraryBase.cs
+++ b/src/Sdk/StrixMusic.Sdk/BaseModels/ILibraryBase.cs
@@ -9,7 +9,7 @@ namespace StrixMusic.Sdk.BaseModels
     /// <summary>
     /// A group of collections that represent a music library.
     /// </summary>
-    public interface ILibraryBase : IPlayableCollectionGroupBase, IAsyncDisposable
+    public interface ILibraryBase : IPlayableCollectionGroupBase
     {
     }
 }

--- a/src/Sdk/StrixMusic.Sdk/BaseModels/IPlayableBase.cs
+++ b/src/Sdk/StrixMusic.Sdk/BaseModels/IPlayableBase.cs
@@ -12,7 +12,7 @@ namespace StrixMusic.Sdk.BaseModels
     /// <summary>
     /// Represents an item that can be played.
     /// </summary>
-    public interface IPlayableBase : IImageCollectionBase, IUrlCollectionBase, IAsyncDisposable
+    public interface IPlayableBase : IImageCollectionBase, IUrlCollectionBase
     {
         /// <summary>
         /// The ID of the playable item.

--- a/src/Sdk/StrixMusic.Sdk/BaseModels/IPlayableCollectionBase.cs
+++ b/src/Sdk/StrixMusic.Sdk/BaseModels/IPlayableCollectionBase.cs
@@ -9,7 +9,7 @@ namespace StrixMusic.Sdk.BaseModels
     /// <summary>
     /// A base class for playable collections.
     /// </summary>
-    public interface IPlayableCollectionBase : ICollectionBase, IPlayableCollectionItem, IAsyncDisposable
+    public interface IPlayableCollectionBase : ICollectionBase, IPlayableCollectionItem
     {
     }
 }

--- a/src/Sdk/StrixMusic.Sdk/BaseModels/IPlayableCollectionGroupBase.cs
+++ b/src/Sdk/StrixMusic.Sdk/BaseModels/IPlayableCollectionGroupBase.cs
@@ -9,7 +9,7 @@ namespace StrixMusic.Sdk.BaseModels
     /// <summary>
     /// Multiple playable collections that are grouped together under a single context.
     /// </summary>
-    public interface IPlayableCollectionGroupBase : IPlaylistCollectionBase, ITrackCollectionBase, IAlbumCollectionBase, IArtistCollectionBase, ICollectionItemBase, IPlayableCollectionGroupChildrenBase, IAsyncDisposable
+    public interface IPlayableCollectionGroupBase : IPlaylistCollectionBase, ITrackCollectionBase, IAlbumCollectionBase, IArtistCollectionBase, ICollectionItemBase, IPlayableCollectionGroupChildrenBase
     {
     }
 }

--- a/src/Sdk/StrixMusic.Sdk/BaseModels/IPlayableCollectionGroupChildrenBase.cs
+++ b/src/Sdk/StrixMusic.Sdk/BaseModels/IPlayableCollectionGroupChildrenBase.cs
@@ -11,7 +11,7 @@ namespace StrixMusic.Sdk.BaseModels
     /// <summary>
     /// A collection of <see cref="IPlayableCollectionGroupBase"/>s and the properties and methods for using and manipulating them.
     /// </summary>
-    public interface IPlayableCollectionGroupChildrenBase : IPlayableCollectionBase, IAsyncDisposable
+    public interface IPlayableCollectionGroupChildrenBase : IPlayableCollectionBase
     {
         /// <summary>
         /// Attempts to play the playable collection. Resumes if paused.

--- a/src/Sdk/StrixMusic.Sdk/BaseModels/IPlayableCollectionItem.cs
+++ b/src/Sdk/StrixMusic.Sdk/BaseModels/IPlayableCollectionItem.cs
@@ -9,7 +9,7 @@ namespace StrixMusic.Sdk.BaseModels
     /// <summary>
     /// An <see cref="IPlayableBase"/> that belongs to a playable collection.
     /// </summary>
-    public interface IPlayableCollectionItem : IPlayableBase, ICollectionItemBase, IAsyncDisposable
+    public interface IPlayableCollectionItem : IPlayableBase, ICollectionItemBase
     {
         /// <summary>
         /// The date this item was added to a collection. If unknown, value is null.

--- a/src/Sdk/StrixMusic.Sdk/BaseModels/IPlaylistBase.cs
+++ b/src/Sdk/StrixMusic.Sdk/BaseModels/IPlaylistBase.cs
@@ -9,7 +9,7 @@ namespace StrixMusic.Sdk.BaseModels
     /// <summary>
     /// A collection of arbitrary songs that the user can edit, rearrange and play back.
     /// </summary>
-    public interface IPlaylistBase : IPlayableCollectionItem, ITrackCollectionBase, IPlaylistCollectionItemBase, IAsyncDisposable
+    public interface IPlaylistBase : IPlayableCollectionItem, ITrackCollectionBase, IPlaylistCollectionItemBase
     {
     }
 }

--- a/src/Sdk/StrixMusic.Sdk/BaseModels/IPlaylistCollectionBase.cs
+++ b/src/Sdk/StrixMusic.Sdk/BaseModels/IPlaylistCollectionBase.cs
@@ -11,7 +11,7 @@ namespace StrixMusic.Sdk.BaseModels
     /// <summary>
     /// A collection of <see cref="IPlaylistCollectionItemBase"/>s and the properties and methods for using and manipulating them.
     /// </summary>
-    public interface IPlaylistCollectionBase : IPlayableCollectionItem, IPlaylistCollectionItemBase, IAsyncDisposable
+    public interface IPlaylistCollectionBase : IPlayableCollectionItem, IPlaylistCollectionItemBase
     {
         /// <summary>
         /// The total number of available Playlists.

--- a/src/Sdk/StrixMusic.Sdk/BaseModels/IPlaylistCollectionItemBase.cs
+++ b/src/Sdk/StrixMusic.Sdk/BaseModels/IPlaylistCollectionItemBase.cs
@@ -9,7 +9,7 @@ namespace StrixMusic.Sdk.BaseModels
     /// <summary>
     /// An item that belongs in an <see cref="IPlaylistCollectionBase"/>.
     /// </summary>
-    public interface IPlaylistCollectionItemBase : IPlayableCollectionItem, IAsyncDisposable
+    public interface IPlaylistCollectionItemBase : IPlayableCollectionItem
     {
     }
 }

--- a/src/Sdk/StrixMusic.Sdk/BaseModels/IRecentlyPlayedBase.cs
+++ b/src/Sdk/StrixMusic.Sdk/BaseModels/IRecentlyPlayedBase.cs
@@ -9,7 +9,7 @@ namespace StrixMusic.Sdk.BaseModels
     /// <summary>
     /// Contains recently played albums, artists, tracks, playlists, etc.
     /// </summary>
-    public interface IRecentlyPlayedBase : IPlayableCollectionGroupBase, IAsyncDisposable
+    public interface IRecentlyPlayedBase : IPlayableCollectionGroupBase
     {
     }
 }

--- a/src/Sdk/StrixMusic.Sdk/BaseModels/ISearchBase.cs
+++ b/src/Sdk/StrixMusic.Sdk/BaseModels/ISearchBase.cs
@@ -11,7 +11,7 @@ namespace StrixMusic.Sdk.BaseModels
     /// <summary>
     /// Delegates search operations
     /// </summary>
-    public interface ISearchBase : IAsyncDisposable
+    public interface ISearchBase
     {
         /// <summary>
         /// Given a query, return suggested completed queries.

--- a/src/Sdk/StrixMusic.Sdk/BaseModels/ISearchHistoryBase.cs
+++ b/src/Sdk/StrixMusic.Sdk/BaseModels/ISearchHistoryBase.cs
@@ -9,7 +9,7 @@ namespace StrixMusic.Sdk.BaseModels
     /// <summary>
     /// Contains a history of playable items which were selected from search results.
     /// </summary>
-    public interface ISearchHistoryBase : IPlayableCollectionGroupBase, IAsyncDisposable
+    public interface ISearchHistoryBase : IPlayableCollectionGroupBase
     {
     }
 }

--- a/src/Sdk/StrixMusic.Sdk/BaseModels/ISearchResultsBase.cs
+++ b/src/Sdk/StrixMusic.Sdk/BaseModels/ISearchResultsBase.cs
@@ -9,7 +9,7 @@ namespace StrixMusic.Sdk.BaseModels
     /// <summary>
     /// Relevant items requested with a query from a core.
     /// </summary>
-    public interface ISearchResultsBase : IPlayableCollectionGroupBase, IAsyncDisposable
+    public interface ISearchResultsBase : IPlayableCollectionGroupBase
     {
     }
 }

--- a/src/Sdk/StrixMusic.Sdk/BaseModels/ITrackBase.cs
+++ b/src/Sdk/StrixMusic.Sdk/BaseModels/ITrackBase.cs
@@ -13,7 +13,7 @@ namespace StrixMusic.Sdk.BaseModels
     /// <summary>
     /// Represents an audio stream with metadata that belongs to an <see cref="ITrackCollectionBase"/>.
     /// </summary>
-    public interface ITrackBase : IPlayableCollectionItem, IArtistCollectionBase, IGenreCollectionBase, IAsyncDisposable
+    public interface ITrackBase : IPlayableCollectionItem, IArtistCollectionBase, IGenreCollectionBase
     {
         /// <inheritdoc cref="TrackType"/>
         TrackType Type { get; }

--- a/src/Sdk/StrixMusic.Sdk/BaseModels/ITrackCollectionBase.cs
+++ b/src/Sdk/StrixMusic.Sdk/BaseModels/ITrackCollectionBase.cs
@@ -11,7 +11,7 @@ namespace StrixMusic.Sdk.BaseModels
     /// <summary>
     /// A collection of tracks and the properties and methods for using and manipulating them.
     /// </summary>
-    public interface ITrackCollectionBase : IPlayableCollectionBase, IAsyncDisposable
+    public interface ITrackCollectionBase : IPlayableCollectionBase
     {
         /// <summary>
         /// The total number of available Tracks.

--- a/src/Sdk/StrixMusic.Sdk/BaseModels/IUrlCollectionCollectionBase.cs
+++ b/src/Sdk/StrixMusic.Sdk/BaseModels/IUrlCollectionCollectionBase.cs
@@ -11,7 +11,7 @@ namespace StrixMusic.Sdk.BaseModels
     /// <summary>
     /// A common interface for all collections that return urls.
     /// </summary>
-    public interface IUrlCollectionBase : ICollectionBase, IAsyncDisposable
+    public interface IUrlCollectionBase : ICollectionBase
     {
         /// <summary>
         /// The total number of urls in this collection.

--- a/src/Sdk/StrixMusic.Sdk/BaseModels/IUserBase.cs
+++ b/src/Sdk/StrixMusic.Sdk/BaseModels/IUserBase.cs
@@ -9,7 +9,7 @@ namespace StrixMusic.Sdk.BaseModels
     /// <summary>
     /// Contains information about a user.
     /// </summary>
-    public interface IUserBase : IUserProfileBase, IAsyncDisposable
+    public interface IUserBase : IUserProfileBase
     {
     }
 }

--- a/src/Sdk/StrixMusic.Sdk/BaseModels/IUserProfileBase.cs
+++ b/src/Sdk/StrixMusic.Sdk/BaseModels/IUserProfileBase.cs
@@ -12,7 +12,7 @@ namespace StrixMusic.Sdk.BaseModels
     /// <summary>
     /// Describes a generic user profile.
     /// </summary>
-    public interface IUserProfileBase : IImageCollectionBase, IAsyncDisposable
+    public interface IUserProfileBase : IImageCollectionBase
     {
         /// <summary>
         /// Identifier for the user

--- a/src/Sdk/StrixMusic.Sdk/CoreModels/InitialCorePlaylistData.cs
+++ b/src/Sdk/StrixMusic.Sdk/CoreModels/InitialCorePlaylistData.cs
@@ -362,11 +362,5 @@ namespace StrixMusic.Sdk.CoreModels
         {
             throw new NotSupportedException();
         }
-
-        /// <inheritdoc />
-        public ValueTask DisposeAsync()
-        {
-            return default;
-        }
     }
 }

--- a/src/Sdk/StrixMusic.Sdk/MediaPlayback/LocalDevice/StrixDevice.cs
+++ b/src/Sdk/StrixMusic.Sdk/MediaPlayback/LocalDevice/StrixDevice.cs
@@ -222,12 +222,5 @@ namespace StrixMusic.Sdk.MediaPlayback.LocalDevice
 
         /// <inheritdoc />
         public Task ToggleRepeatAsync(CancellationToken cancellationToken = default) => _playbackHandler.ToggleRepeatAsync(cancellationToken);
-
-        /// <inheritdoc />
-        public ValueTask DisposeAsync()
-        {
-            DetachEvents();
-            return default;
-        }
     }
 }

--- a/src/Sdk/StrixMusic.Sdk/PluginModels/AlbumCollectionPluginWrapper.cs
+++ b/src/Sdk/StrixMusic.Sdk/PluginModels/AlbumCollectionPluginWrapper.cs
@@ -339,13 +339,6 @@ public class AlbumCollectionPluginWrapper : IAlbumCollection, IPluginWrapper
     /// <inheritdoc/>
     public bool Equals(ICoreAlbumCollection other) => _albumCollection.Equals(other);
 
-    /// <inheritdoc/>
-    public ValueTask DisposeAsync()
-    {
-        DetachEvents(_albumCollection);
-        return _albumCollection.DisposeAsync();
-    }
-
     private IAlbumCollectionItem Transform(IAlbumCollectionItem item) => item switch
     {
         IAlbum album => new AlbumPluginWrapper(album, _plugins),

--- a/src/Sdk/StrixMusic.Sdk/PluginModels/AlbumPluginWrapper.cs
+++ b/src/Sdk/StrixMusic.Sdk/PluginModels/AlbumPluginWrapper.cs
@@ -474,13 +474,6 @@ public class AlbumPluginWrapper : IAlbum, IPluginWrapper
     /// <inheritdoc/>
     public Task AddGenreAsync(IGenre genre, int index, CancellationToken cancellationToken = default) => _album.AddGenreAsync(genre, index, cancellationToken);
 
-    /// <inheritdoc/>
-    public ValueTask DisposeAsync()
-    {
-        DetachEvents(_album);
-        return _album.DisposeAsync();
-    }
-
     private IArtistCollectionItem Transform(IArtistCollectionItem item) => item switch
     {
         IArtist artist => new ArtistPluginWrapper(artist, _plugins),

--- a/src/Sdk/StrixMusic.Sdk/PluginModels/ArtistCollectionPluginWrapper.cs
+++ b/src/Sdk/StrixMusic.Sdk/PluginModels/ArtistCollectionPluginWrapper.cs
@@ -336,13 +336,6 @@ public class ArtistCollectionPluginWrapper : IArtistCollection, IPluginWrapper
     /// <inheritdoc/>
     public bool Equals(ICoreArtistCollection other) => _artistCollection.Equals(other);
 
-    /// <inheritdoc/>
-    public ValueTask DisposeAsync()
-    {
-        DetachEvents(_artistCollection);
-        return _artistCollection.DisposeAsync();
-    }
-
     private IArtistCollectionItem Transform(IArtistCollectionItem item) => item switch
     {
         IArtist artist => new ArtistPluginWrapper(artist, _plugins),

--- a/src/Sdk/StrixMusic.Sdk/PluginModels/ArtistPluginWrapper.cs
+++ b/src/Sdk/StrixMusic.Sdk/PluginModels/ArtistPluginWrapper.cs
@@ -441,13 +441,6 @@ public class ArtistPluginWrapper : IArtist, IPluginWrapper
     /// <inheritdoc/>
     public bool Equals(ICoreArtistCollectionItem other) => _artist.Equals(other);
 
-    /// <inheritdoc/>
-    public ValueTask DisposeAsync()
-    {
-        DetachEvents(_artist);
-        return _artist.DisposeAsync();
-    }
-
     private IAlbumCollectionItem Transform(IAlbumCollectionItem item) => item switch
     {
         IAlbum album => new AlbumPluginWrapper(album, _plugins),

--- a/src/Sdk/StrixMusic.Sdk/PluginModels/GenrePluginWrapper.cs
+++ b/src/Sdk/StrixMusic.Sdk/PluginModels/GenrePluginWrapper.cs
@@ -61,11 +61,4 @@ public class GenrePluginWrapper : IGenre, IPluginWrapper
 
     /// <inheritdoc/>
     public string Name => _genre.Name;
-
-    /// <inheritdoc/>
-    public ValueTask DisposeAsync()
-    {
-        DetachEvents(_genre);
-        return _genre.DisposeAsync();
-    }
 }

--- a/src/Sdk/StrixMusic.Sdk/PluginModels/ImagePluginWrapper.cs
+++ b/src/Sdk/StrixMusic.Sdk/PluginModels/ImagePluginWrapper.cs
@@ -72,11 +72,4 @@ public class ImagePluginWrapper : IImage, IPluginWrapper
 
     /// <inheritdoc/>
     public IReadOnlyList<ICoreImage> Sources => _image.Sources;
-
-    /// <inheritdoc/>
-    public ValueTask DisposeAsync()
-    {
-        DetachEvents(_image);
-        return _image.DisposeAsync();
-    }
 }

--- a/src/Sdk/StrixMusic.Sdk/PluginModels/PlayableCollectionGroupPluginWrapperBase.cs
+++ b/src/Sdk/StrixMusic.Sdk/PluginModels/PlayableCollectionGroupPluginWrapperBase.cs
@@ -622,13 +622,6 @@ public abstract class PlayableCollectionGroupPluginWrapperBase : IPlayableCollec
     /// <inheritdoc/>
     public bool Equals(ICorePlayableCollectionGroup other) => _playableCollectionGroup.Equals(other);
 
-    /// <inheritdoc/>
-    public ValueTask DisposeAsync()
-    {
-        DetachEvents(_playableCollectionGroup);
-        return _playableCollectionGroup.DisposeAsync();
-    }
-
     private IArtistCollectionItem Transform(IArtistCollectionItem item) => item switch
     {
         IArtist artist => new ArtistPluginWrapper(artist, _plugins),

--- a/src/Sdk/StrixMusic.Sdk/PluginModels/PlaylistCollectionPluginWrapper.cs
+++ b/src/Sdk/StrixMusic.Sdk/PluginModels/PlaylistCollectionPluginWrapper.cs
@@ -336,13 +336,6 @@ public class PlaylistCollectionPluginWrapper : IPlaylistCollection, IPluginWrapp
     /// <inheritdoc/>
     public bool Equals(ICorePlaylistCollection other) => _playlistCollection.Equals(other);
 
-    /// <inheritdoc/>
-    public ValueTask DisposeAsync()
-    {
-        DetachEvents(_playlistCollection);
-        return _playlistCollection.DisposeAsync();
-    }
-
     private IPlaylistCollectionItem Transform(IPlaylistCollectionItem item) => item switch
     {
         IPlaylist playlist => new PlaylistPluginWrapper(playlist, _plugins),

--- a/src/Sdk/StrixMusic.Sdk/PluginModels/PlaylistPluginWrapper.cs
+++ b/src/Sdk/StrixMusic.Sdk/PluginModels/PlaylistPluginWrapper.cs
@@ -344,13 +344,6 @@ public class PlaylistPluginWrapper : IPlaylist, IPluginWrapper
     /// <inheritdoc/>
     public bool Equals(ICorePlaylist other) => _playlist.Equals(other);
 
-    /// <inheritdoc/>
-    public ValueTask DisposeAsync()
-    {
-        DetachEvents(_playlist);
-        return _playlist.DisposeAsync();
-    }
-
     private ITrack Transform(ITrack item) => new TrackPluginWrapper(item, _plugins);
     
     /// <inheritdoc/>

--- a/src/Sdk/StrixMusic.Sdk/PluginModels/SearchPluginWrapper.cs
+++ b/src/Sdk/StrixMusic.Sdk/PluginModels/SearchPluginWrapper.cs
@@ -75,11 +75,4 @@ public class SearchPluginWrapper : ISearch, IPluginWrapper
 
     /// <inheritdoc/>
     public ISearchHistory? SearchHistory { get; }
-
-    /// <inheritdoc/>
-    public ValueTask DisposeAsync()
-    {
-        DetachEvents(_search);
-        return _search.DisposeAsync();
-    }
 }

--- a/src/Sdk/StrixMusic.Sdk/PluginModels/TrackCollectionPluginWrapper.cs
+++ b/src/Sdk/StrixMusic.Sdk/PluginModels/TrackCollectionPluginWrapper.cs
@@ -329,12 +329,5 @@ public class TrackCollectionPluginWrapper : ITrackCollection, IPluginWrapper
     /// <inheritdoc/>
     public bool Equals(ICoreTrackCollection other) => _trackCollection.Equals(other);
 
-    /// <inheritdoc/>
-    public ValueTask DisposeAsync()
-    {
-        DetachEvents(_trackCollection);
-        return _trackCollection.DisposeAsync();
-    }
-
     private ITrack Transform(ITrack track) => new TrackPluginWrapper(track, _plugins);
 }

--- a/src/Sdk/StrixMusic.Sdk/PluginModels/TrackPluginWrapper.cs
+++ b/src/Sdk/StrixMusic.Sdk/PluginModels/TrackPluginWrapper.cs
@@ -142,12 +142,7 @@ public class TrackPluginWrapper : ITrack, IPluginWrapper
         if (e is not null)
             Album = new AlbumPluginWrapper(e, _plugins);
         else
-        {
-            if (Album is not null)
-                (Album as AlbumPluginWrapper)?.DisposeAsync();
-            
             Album = null;
-        }
     }
 
     private void OnDownloadInfoChanged(object sender, DownloadInfo e) => DownloadInfoChanged?.Invoke(sender, e);
@@ -492,13 +487,6 @@ public class TrackPluginWrapper : ITrack, IPluginWrapper
 
     /// <inheritdoc/>
     public Task ChangeAlbumAsync(IAlbum? album, CancellationToken cancellationToken = default) => _track.ChangeAlbumAsync(album, cancellationToken);
-
-    /// <inheritdoc/>
-    public ValueTask DisposeAsync()
-    {
-        DetachEvents(_track);
-        return _track.DisposeAsync();
-    }
 
     private IArtistCollectionItem Transform(IArtistCollectionItem item) => item switch
     {

--- a/src/Sdk/StrixMusic.Sdk/PluginModels/UrlPluginWrapper.cs
+++ b/src/Sdk/StrixMusic.Sdk/PluginModels/UrlPluginWrapper.cs
@@ -51,13 +51,6 @@ public class UrlPluginWrapper : IUrl, IPluginWrapper
     public SdkModelPlugin ActivePlugins { get; } = new(PluginModelWrapperInfo.Metadata);
 
     /// <inheritdoc/>
-    public ValueTask DisposeAsync()
-    {
-        DetachEvents(_url);
-        return _url.DisposeAsync();
-    }
-
-    /// <inheritdoc/>
     public bool Equals(ICoreUrl other) => _url.Equals(other);
 
     /// <inheritdoc/>

--- a/src/Sdk/StrixMusic.Sdk/Plugins/Model/AlbumCollectionPluginBase.cs
+++ b/src/Sdk/StrixMusic.Sdk/Plugins/Model/AlbumCollectionPluginBase.cs
@@ -328,20 +328,5 @@ namespace StrixMusic.Sdk.Plugins.Model
 
         /// <inheritdoc/>
         public virtual Task StartDownloadOperationAsync(DownloadOperation operation, CancellationToken cancellationToken = default) => InnerDownloadable.StartDownloadOperationAsync(operation, cancellationToken);
-
-        /// <inheritdoc/>
-        public virtual ValueTask DisposeAsync()
-        {
-            var uniqueInstances = new HashSet<IAsyncDisposable>()
-            {
-                Inner,
-                InnerDownloadable,
-                InnerPlayable,
-                InnerImageCollection,
-                InnerUrlCollection,
-            };
-
-            return new ValueTask(uniqueInstances.InParallel(async x => await x.DisposeAsync()));
-        }
     }
 }

--- a/src/Sdk/StrixMusic.Sdk/Plugins/Model/AlbumPluginBase.cs
+++ b/src/Sdk/StrixMusic.Sdk/Plugins/Model/AlbumPluginBase.cs
@@ -366,24 +366,6 @@ namespace StrixMusic.Sdk.Plugins.Model
         public virtual Task ChangeNameAsync(string name, CancellationToken cancellationToken = default) => InnerPlayable.ChangeNameAsync(name, cancellationToken);
 
         /// <inheritdoc/>
-        public virtual ValueTask DisposeAsync()
-        {
-            var uniqueInstances = new HashSet<IAsyncDisposable>()
-            {
-                Inner,
-                InnerTrackCollection,
-                InnerArtistCollection,
-                InnerDownloadable,
-                InnerPlayable,
-                InnerImageCollection,
-                InnerUrlCollection,
-                InnerGenreCollection,
-            };
-
-            return new ValueTask(uniqueInstances.InParallel(async x => await x.DisposeAsync()));
-        }
-
-        /// <inheritdoc/>
         public virtual bool Equals(ICoreGenreCollection other) => InnerGenreCollection.Equals(other);
 
         /// <inheritdoc/>

--- a/src/Sdk/StrixMusic.Sdk/Plugins/Model/ArtistCollectionPluginBase.cs
+++ b/src/Sdk/StrixMusic.Sdk/Plugins/Model/ArtistCollectionPluginBase.cs
@@ -328,20 +328,5 @@ namespace StrixMusic.Sdk.Plugins.Model
 
         /// <inheritdoc/>
         public virtual Task StartDownloadOperationAsync(DownloadOperation operation, CancellationToken cancellationToken = default) => InnerDownloadable.StartDownloadOperationAsync(operation, cancellationToken);
-
-        /// <inheritdoc/>
-        public virtual ValueTask DisposeAsync()
-        {
-            var uniqueInstances = new HashSet<IAsyncDisposable>()
-            {
-                Inner,
-                InnerDownloadable,
-                InnerPlayable,
-                InnerImageCollection,
-                InnerUrlCollection,
-            };
-
-            return new ValueTask(uniqueInstances.InParallel(async x => await x.DisposeAsync()));
-        }
     }
 }

--- a/src/Sdk/StrixMusic.Sdk/Plugins/Model/ArtistPluginBase.cs
+++ b/src/Sdk/StrixMusic.Sdk/Plugins/Model/ArtistPluginBase.cs
@@ -468,23 +468,5 @@ namespace StrixMusic.Sdk.Plugins.Model
 
         /// <inheritdoc/>
         public virtual IPlayableCollectionGroup? RelatedItems => Inner.RelatedItems;
-
-        /// <inheritdoc/>
-        public virtual ValueTask DisposeAsync()
-        {
-            var uniqueInstances = new HashSet<IAsyncDisposable>()
-            {
-                Inner,
-                InnerTrackCollection,
-                InnerAlbumCollection,
-                InnerDownloadable,
-                InnerPlayable,
-                InnerImageCollection,
-                InnerUrlCollection,
-                InnerGenreCollection,
-            };
-
-            return new ValueTask(uniqueInstances.InParallel(async x => await x.DisposeAsync()));
-        }
     }
 }

--- a/src/Sdk/StrixMusic.Sdk/Plugins/Model/DownloadablePluginBase.cs
+++ b/src/Sdk/StrixMusic.Sdk/Plugins/Model/DownloadablePluginBase.cs
@@ -44,9 +44,6 @@ namespace StrixMusic.Sdk.Plugins.Model
         }
 
         /// <inheritdoc/>
-        public virtual ValueTask DisposeAsync() => Inner.DisposeAsync();
-
-        /// <inheritdoc/>
         public virtual Task StartDownloadOperationAsync(DownloadOperation operation, CancellationToken cancellationToken = default) => Inner.StartDownloadOperationAsync(operation, cancellationToken);
     }
 }

--- a/src/Sdk/StrixMusic.Sdk/Plugins/Model/GenreCollectionPluginBase.cs
+++ b/src/Sdk/StrixMusic.Sdk/Plugins/Model/GenreCollectionPluginBase.cs
@@ -67,9 +67,6 @@ namespace StrixMusic.Sdk.Plugins.Model
         public virtual Task AddGenreAsync(IGenre gene, int index, CancellationToken cancellationToken = default) => Inner.AddGenreAsync(gene, index, cancellationToken);
 
         /// <inheritdoc/>
-        public virtual ValueTask DisposeAsync() => Inner.DisposeAsync();
-
-        /// <inheritdoc/>
         public virtual bool Equals(ICoreGenreCollection other) => Inner.Equals(other);
 
         /// <inheritdoc/>

--- a/src/Sdk/StrixMusic.Sdk/Plugins/Model/ImageCollectionPluginBase.cs
+++ b/src/Sdk/StrixMusic.Sdk/Plugins/Model/ImageCollectionPluginBase.cs
@@ -67,9 +67,6 @@ namespace StrixMusic.Sdk.Plugins.Model
         public virtual Task AddImageAsync(IImage image, int index, CancellationToken cancellationToken = default) => Inner.AddImageAsync(image, index, cancellationToken);
 
         /// <inheritdoc/>
-        public virtual ValueTask DisposeAsync() => Inner.DisposeAsync();
-
-        /// <inheritdoc/>
         public virtual bool Equals(ICoreImageCollection other) => Inner.Equals(other);
 
         /// <inheritdoc/>

--- a/src/Sdk/StrixMusic.Sdk/Plugins/Model/ImagePluginBase.cs
+++ b/src/Sdk/StrixMusic.Sdk/Plugins/Model/ImagePluginBase.cs
@@ -58,9 +58,6 @@ namespace StrixMusic.Sdk.Plugins.Model
         public IReadOnlyList<ICoreImage> Sources => Inner.Sources;
 
         /// <inheritdoc/>
-        public virtual ValueTask DisposeAsync() => Inner.DisposeAsync();
-
-        /// <inheritdoc/>
         public virtual bool Equals(ICoreImage other) => Inner.Equals(other);
     }
 }

--- a/src/Sdk/StrixMusic.Sdk/Plugins/Model/PlayableCollectionGroupPluginBase.cs
+++ b/src/Sdk/StrixMusic.Sdk/Plugins/Model/PlayableCollectionGroupPluginBase.cs
@@ -619,24 +619,5 @@ namespace StrixMusic.Sdk.Plugins.Model
 
         /// <inheritdoc />
         public virtual bool Equals(ICorePlayableCollectionGroup other) => Inner.Equals(other);
-
-        /// <inheritdoc/>
-        public virtual ValueTask DisposeAsync()
-        {
-            var uniqueInstances = new HashSet<IAsyncDisposable>()
-            {
-                Inner,
-                InnerPlayable,
-                InnerArtistCollection,
-                InnerAlbumCollection,
-                InnerPlaylistCollection,
-                InnerTrackCollection,
-                InnerDownloadable,
-                InnerImageCollection,
-                InnerUrlCollection,
-            };
-            
-            return new ValueTask(uniqueInstances.InParallel(async x => await x.DisposeAsync()));
-        }
     }
 }

--- a/src/Sdk/StrixMusic.Sdk/Plugins/Model/PlayablePluginBase.cs
+++ b/src/Sdk/StrixMusic.Sdk/Plugins/Model/PlayablePluginBase.cs
@@ -245,19 +245,5 @@ namespace StrixMusic.Sdk.Plugins.Model
 
         /// <inheritdoc/>
         public virtual bool Equals(ICoreUrlCollection other) => InnerUrlCollection.Equals(other);
-
-        /// <inheritdoc/>
-        public virtual ValueTask DisposeAsync()
-        {
-            var uniqueInstances = new HashSet<IAsyncDisposable>()
-            {
-                Inner,
-                InnerDownloadable,
-                InnerImageCollection,
-                InnerUrlCollection,
-            };
-
-            return new ValueTask(uniqueInstances.InParallel(async x => await x.DisposeAsync()));
-        }
     }
 }

--- a/src/Sdk/StrixMusic.Sdk/Plugins/Model/PlaylistCollectionPluginBase.cs
+++ b/src/Sdk/StrixMusic.Sdk/Plugins/Model/PlaylistCollectionPluginBase.cs
@@ -328,20 +328,5 @@ namespace StrixMusic.Sdk.Plugins.Model
 
         /// <inheritdoc/>
         public virtual Task StartDownloadOperationAsync(DownloadOperation operation, CancellationToken cancellationToken = default) => InnerDownloadable.StartDownloadOperationAsync(operation, cancellationToken);
-
-        /// <inheritdoc/>
-        public virtual ValueTask DisposeAsync()
-        {
-            var uniqueInstances = new HashSet<IAsyncDisposable>()
-            {
-                Inner,
-                InnerDownloadable,
-                InnerPlayable,
-                InnerImageCollection,
-                InnerUrlCollection,
-            };
-
-            return new ValueTask(uniqueInstances.InParallel(async x => await x.DisposeAsync()));
-        }
     }
 }

--- a/src/Sdk/StrixMusic.Sdk/Plugins/Model/PlaylistPluginBase.cs
+++ b/src/Sdk/StrixMusic.Sdk/Plugins/Model/PlaylistPluginBase.cs
@@ -347,21 +347,5 @@ namespace StrixMusic.Sdk.Plugins.Model
 
         /// <inheritdoc/>
         public virtual IPlayableCollectionGroup? RelatedItems => Inner.RelatedItems;
-
-        /// <inheritdoc/>
-        public virtual ValueTask DisposeAsync()
-        {
-            var uniqueInstances = new HashSet<IAsyncDisposable>()
-            {
-                Inner,
-                InnerTrackCollection,
-                InnerDownloadable,
-                InnerPlayable,
-                InnerImageCollection,
-                InnerUrlCollection,
-            };
-
-            return new ValueTask(uniqueInstances.InParallel(async x => await x.DisposeAsync()));
-        }
     }
 }

--- a/src/Sdk/StrixMusic.Sdk/Plugins/Model/TrackCollectionPluginBase.cs
+++ b/src/Sdk/StrixMusic.Sdk/Plugins/Model/TrackCollectionPluginBase.cs
@@ -320,20 +320,5 @@ namespace StrixMusic.Sdk.Plugins.Model
 
         /// <inheritdoc/>
         public virtual Task StartDownloadOperationAsync(DownloadOperation operation, CancellationToken cancellationToken = default) => InnerDownloadable.StartDownloadOperationAsync(operation, cancellationToken);
-
-        /// <inheritdoc/>
-        public virtual ValueTask DisposeAsync()
-        {
-            var uniqueInstances = new HashSet<IAsyncDisposable>()
-            {
-                Inner,
-                InnerDownloadable,
-                InnerPlayable,
-                InnerImageCollection,
-                InnerUrlCollection,
-            };
-
-            return new ValueTask(uniqueInstances.InParallel(async x => await x.DisposeAsync()));
-        }
     }
 }

--- a/src/Sdk/StrixMusic.Sdk/Plugins/Model/TrackPluginBase.cs
+++ b/src/Sdk/StrixMusic.Sdk/Plugins/Model/TrackPluginBase.cs
@@ -476,22 +476,5 @@ namespace StrixMusic.Sdk.Plugins.Model
 
         /// <inheritdoc />
         public virtual Task ChangeAlbumAsync(IAlbum? album, CancellationToken cancellationToken = default) => Inner.ChangeAlbumAsync(album, cancellationToken);
-
-        /// <inheritdoc/>
-        public virtual ValueTask DisposeAsync()
-        {
-            var uniqueInstances = new HashSet<IAsyncDisposable>()
-            {
-                Inner,
-                InnerArtistCollection,
-                InnerDownloadable,
-                InnerPlayable,
-                InnerImageCollection,
-                InnerUrlCollection,
-                InnerGenreCollection,
-            };
-
-            return new ValueTask(uniqueInstances.InParallel(async x => await x.DisposeAsync()));
-        }
     }
 }

--- a/src/Sdk/StrixMusic.Sdk/Plugins/Model/UrlCollectionPluginBase.cs
+++ b/src/Sdk/StrixMusic.Sdk/Plugins/Model/UrlCollectionPluginBase.cs
@@ -67,9 +67,6 @@ namespace StrixMusic.Sdk.Plugins.Model
         public virtual Task AddUrlAsync(IUrl url, int index, CancellationToken cancellationToken = default) => Inner.AddUrlAsync(url, index, cancellationToken);
 
         /// <inheritdoc/>
-        public virtual ValueTask DisposeAsync() => Inner.DisposeAsync();
-
-        /// <inheritdoc/>
         public virtual bool Equals(ICoreUrlCollection other) => Inner.Equals(other);
 
         /// <inheritdoc/>

--- a/src/Sdk/StrixMusic.Sdk/Plugins/Model/UrlPluginBase.cs
+++ b/src/Sdk/StrixMusic.Sdk/Plugins/Model/UrlPluginBase.cs
@@ -35,9 +35,6 @@ namespace StrixMusic.Sdk.Plugins.Model
         public IUrl Inner { get; }
 
         /// <inheritdoc/>
-        public virtual ValueTask DisposeAsync() => Inner.DisposeAsync();
-
-        /// <inheritdoc/>
         public virtual string Label => Inner.Label;
 
         /// <inheritdoc/>

--- a/src/Sdk/StrixMusic.Sdk/ViewModels/AlbumCollectionViewModel.cs
+++ b/src/Sdk/StrixMusic.Sdk/ViewModels/AlbumCollectionViewModel.cs
@@ -613,12 +613,5 @@ namespace StrixMusic.Sdk.ViewModels
 
             return Task.WhenAll(InitAlbumCollectionAsync(cancellationToken), InitImageCollectionAsync(cancellationToken));
         }
-
-        /// <inheritdoc />
-        public ValueTask DisposeAsync()
-        {
-            DetachEvents();
-            return _collection.DisposeAsync();
-        }
     }
 }

--- a/src/Sdk/StrixMusic.Sdk/ViewModels/AlbumViewModel.cs
+++ b/src/Sdk/StrixMusic.Sdk/ViewModels/AlbumViewModel.cs
@@ -923,12 +923,5 @@ namespace StrixMusic.Sdk.ViewModels
             Guard.IsNotNull(name, nameof(name));
             return _album.ChangeNameAsync(name, cancellationToken);
         }
-
-        /// <inheritdoc />
-        public ValueTask DisposeAsync()
-        {
-            DetachEvents();
-            return _album.DisposeAsync();
-        }
     }
 }

--- a/src/Sdk/StrixMusic.Sdk/ViewModels/ArtistCollectionViewModel.cs
+++ b/src/Sdk/StrixMusic.Sdk/ViewModels/ArtistCollectionViewModel.cs
@@ -616,12 +616,5 @@ namespace StrixMusic.Sdk.ViewModels
             Guard.IsNotNull(name, nameof(name));
             return _collection.ChangeNameAsync(name, cancellationToken);
         }
-
-        /// <inheritdoc />
-        public ValueTask DisposeAsync()
-        {
-            DetachEvents();
-            return _collection.DisposeAsync();
-        }
     }
 }

--- a/src/Sdk/StrixMusic.Sdk/ViewModels/ArtistViewModel.cs
+++ b/src/Sdk/StrixMusic.Sdk/ViewModels/ArtistViewModel.cs
@@ -896,12 +896,5 @@ namespace StrixMusic.Sdk.ViewModels
             Guard.IsNotNull(name, nameof(name));
             return _artist.ChangeNameAsync(name, cancellationToken);
         }
-
-        /// <inheritdoc />
-        public ValueTask DisposeAsync()
-        {
-            DetachEvents();
-            return _artist.DisposeAsync();
-        }
     }
 }

--- a/src/Sdk/StrixMusic.Sdk/ViewModels/CoreViewModel.cs
+++ b/src/Sdk/StrixMusic.Sdk/ViewModels/CoreViewModel.cs
@@ -210,7 +210,6 @@ namespace StrixMusic.Sdk.ViewModels
         public async ValueTask DisposeAsync()
         {
             DetachEvents();
-
             await _core.DisposeAsync();
         }
 

--- a/src/Sdk/StrixMusic.Sdk/ViewModels/DeviceViewModel.cs
+++ b/src/Sdk/StrixMusic.Sdk/ViewModels/DeviceViewModel.cs
@@ -342,12 +342,5 @@ namespace StrixMusic.Sdk.ViewModels
         /// Attempts to change volume.
         /// </summary>
         public IAsyncRelayCommand<double> ChangeVolumeAsyncCommand { get; }
-
-        /// <inheritdoc />
-        public ValueTask DisposeAsync()
-        {
-            DetachEvents();
-            return _model.DisposeAsync();
-        }
     }
 }

--- a/src/Sdk/StrixMusic.Sdk/ViewModels/PlayableCollectionGroupViewModel.cs
+++ b/src/Sdk/StrixMusic.Sdk/ViewModels/PlayableCollectionGroupViewModel.cs
@@ -1291,12 +1291,5 @@ namespace StrixMusic.Sdk.ViewModels
 
         /// <inheritdoc />
         public bool IsInitialized { get; protected set; }
-
-        /// <inheritdoc />
-        public ValueTask DisposeAsync()
-        {
-            DetachPropertyEvents();
-            return _collectionGroup.DisposeAsync();
-        }
     }
 }

--- a/src/Sdk/StrixMusic.Sdk/ViewModels/PlaylistCollectionViewModel.cs
+++ b/src/Sdk/StrixMusic.Sdk/ViewModels/PlaylistCollectionViewModel.cs
@@ -608,12 +608,5 @@ namespace StrixMusic.Sdk.ViewModels
             Guard.IsNotNull(name, nameof(name));
             return _collection.ChangeNameAsync(name, cancellationToken);
         }
-
-        /// <inheritdoc />
-        public ValueTask DisposeAsync()
-        {
-            DetachEvents();
-            return _collection.DisposeAsync();
-        }
     }
 }

--- a/src/Sdk/StrixMusic.Sdk/ViewModels/PlaylistViewModel.cs
+++ b/src/Sdk/StrixMusic.Sdk/ViewModels/PlaylistViewModel.cs
@@ -615,12 +615,5 @@ namespace StrixMusic.Sdk.ViewModels
             Guard.IsNotNull(name, nameof(name));
             return _playlist.ChangeNameAsync(name, cancellationToken);
         }
-
-        /// <inheritdoc />
-        public ValueTask DisposeAsync()
-        {
-            DetachEvents();
-            return _playlist.DisposeAsync();
-        }
     }
 }

--- a/src/Sdk/StrixMusic.Sdk/ViewModels/SearchViewModel.cs
+++ b/src/Sdk/StrixMusic.Sdk/ViewModels/SearchViewModel.cs
@@ -60,8 +60,5 @@ namespace StrixMusic.Sdk.ViewModels
         /// The view model for search history.
         /// </summary>
         public SearchHistoryViewModel? SearchHistory { get; }
-
-        /// <inheritdoc />
-        public ValueTask DisposeAsync() => _search.DisposeAsync();
     }
 }

--- a/src/Sdk/StrixMusic.Sdk/ViewModels/TrackCollectionViewModel.cs
+++ b/src/Sdk/StrixMusic.Sdk/ViewModels/TrackCollectionViewModel.cs
@@ -590,12 +590,5 @@ namespace StrixMusic.Sdk.ViewModels
             Guard.IsNotNull(name, nameof(name));
             return _collection.ChangeNameAsync(name, cancellationToken);
         }
-
-        /// <inheritdoc />
-        public ValueTask DisposeAsync()
-        {
-            DetachEvents();
-            return _collection.DisposeAsync();
-        }
     }
 }

--- a/src/Sdk/StrixMusic.Sdk/ViewModels/TrackViewModel.cs
+++ b/src/Sdk/StrixMusic.Sdk/ViewModels/TrackViewModel.cs
@@ -822,13 +822,6 @@ namespace StrixMusic.Sdk.ViewModels
         }
 
         /// <inheritdoc />
-        public ValueTask DisposeAsync()
-        {
-            DetachEvents();
-            return _model.DisposeAsync();
-        }
-
-        /// <inheritdoc />
         public async Task InitAsync(CancellationToken cancellationToken = default)
         {
             if (!IsInitialized)

--- a/src/Sdk/StrixMusic.Sdk/ViewModels/UserProfileViewModel.cs
+++ b/src/Sdk/StrixMusic.Sdk/ViewModels/UserProfileViewModel.cs
@@ -268,8 +268,5 @@ namespace StrixMusic.Sdk.ViewModels
 
         /// <inheritdoc />
         public bool Equals(ICoreUrlCollection other) => _userProfile.Equals(other);
-
-        /// <inheritdoc />
-        public ValueTask DisposeAsync() => _userProfile.DisposeAsync();
     }
 }


### PR DESCRIPTION
<!--
To categorize this PR in the generated changelog, include one of the following in the PR title: 
[breaking], [fix], [improvement], [new], [refactor], [cleanup]
-->

## Overview
<!-- Replace with the issue number. This will auto-close the issue once the PR is merged. If no issue exists, open one first. -->
Closes #223

<!-- Add a brief overview here of the change. -->

<!-- Include screenshots or a short video demonstrating the change, if possible -->

## Checklist
<!-- Note: Changes to the Sdk MUST be accompanied by unit tests, even if there were none before. -->
This PR meets the following requirements:
- [x] Tested and contains **NO** breaking changes or known regressions.
- [x] Tested with the upstream branch merged in.
- [x] Tests have been added for bug fixes / features (or this option is not applicable)
- [x] All new code has been documented (or this option is not applicable)
- [x] Headers have been added to all new source files (or this option is not applicable)

<!-- 
Is this a breaking change?
Please describe the impact and migration path for existing applications below.
-->


# Migration path

## Core implementors
Each core model is required to have a `SourceCore` property, meant to be the core which ultimately spawned the model you're currently in.

All core models must have this. `ICore` contains methods for InitAsnyc and DisposeAsync - this should be enough to set up / tear down any unmanaged resources needed by your core, such as opening and closing a websocket. 

If that is set up, you can place your service on your `ICore` and use the SourceCore property to interact with your service.

Since your service is stored on your core, you can share the instance across models, and it'll keep functioning even when a model is garbage collected and fully disposed.

The GC will clean up any model that isn't being referenced. 

For cleanup, just stick to `ICore.DisposeAsync`.

## Plugin authors

If you were overriding these to help dispose resources, then remove that and make your plugin IAsyncDisposable instead. 

If you were overriding these to manipulate the lifetime of a model, then don't. The GC in .NET is smart enough to take care of it for you, as long as everyone cleans up their references to the model.

## SDK consumers
Remove any calls you have to `DisposeAsync` on these models. Instead, just make sure you clean up your references to the model if you aren't actively using it.

If the data structure is disposed, events and even method calls may stop working as the cores and sdk release resources. Call `DisposeAsync` on your `IStrixDataRoot` when you're done using it.

