### PR TITLE
[fix] Fixed an issue where sandbox shell is not showing any song list when loaded second time.

### DIFF
--- a/src/Sdk/StrixMusic.Sdk.WinUI/DefaultShell.xaml.cs
+++ b/src/Sdk/StrixMusic.Sdk.WinUI/DefaultShell.xaml.cs
@@ -58,7 +58,17 @@ namespace StrixMusic.Shells.Default
             navigationService.RegisterCommonPage(typeof(HomeView));
             navigationService.RegisterCommonPage(typeof(NowPlayingView));
 
+            Unloaded += DefaultShell_Unloaded;
+
             return navigationService;
+        }
+
+        private void DefaultShell_Unloaded(object sender, RoutedEventArgs e)
+        {
+            Unloaded -= DefaultShell_Unloaded;
+
+            _navigationService.NavigationRequested -= NavigationService_NavigationRequested;
+            _navigationService.BackRequested -= Shell_BackRequested;
         }
 
         /// <inheritdoc/>
@@ -76,7 +86,11 @@ namespace StrixMusic.Shells.Default
         {
             if (!e.IsOverlay)
             {
-                _history.Push((Control)MainContent.Content);
+                if ((Control)MainContent.Content != null)
+                {
+                    _history.Push((Control)MainContent.Content);
+                }
+
                 MainContent.Content = e.Page;
             }
             else


### PR DESCRIPTION


<!--
To categorize this PR in the generated changelog, include one of the following in the PR title: 
[breaking], [fix], [improvement], [new], [refactor], [cleanup]
-->

## Overview
<!-- Replace with the issue number. This will auto-close the issue once the PR is merged. If no issue exists, open one first. -->
Closes #193

Added NavigationService events cleanup which was causing a race condition b/w the instances of the DefaultShell to set the overlay content.
The cleanup is done on the DefaulfShell Unload.

<!-- Include screenshots or a short video demonstrating the change, if possible -->

## Checklist
<!-- Note: Changes to the Sdk MUST be accompanied by unit tests, even if there were none before. -->
This PR meets the following requirements:
- [x] Tested and contains **NO** breaking changes or known regressions.
- [x] Tested with the upstream branch merged in.
- [x] Tests have been added for bug fixes / features (or this option is not applicable)
- [x] All new code has been documented (or this option is not applicable)
- [x] Headers have been added to all new source files (or this option is not applicable)

<!-- 
Is this a breaking change?
Please describe the impact and migration path for existing applications below.
-->

## Additional info
<!--
Please add any other information that might be helpful to reviewers.
-->

Not provided
