### PR TITLE
[fix] Fixed app compile error 'SettingsTemplateSelector.cs could not be found'

### DIFF
--- a/src/Shared/StrixMusic.Shared.projitems
+++ b/src/Shared/StrixMusic.Shared.projitems
@@ -30,7 +30,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)Controls\Settings.xaml.cs">
       <DependentUpon>Settings.xaml</DependentUpon>
     </Compile>
-    <Compile Include="$(MSBuildThisFileDirectory)Controls\SettingsTemplateSelector.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Controls\ShellSettingsEditor.xaml.cs">
       <DependentUpon>ShellSettingsEditor.xaml</DependentUpon>
     </Compile>


### PR DESCRIPTION
<!--
To categorize this PR in the generated changelog, include one of the following in the PR title: 
[breaking], [fix], [improvement], [new], [refactor], [cleanup]
-->

## Overview
<!-- Replace with the issue number. This will auto-close the issue once the PR is merged. If no issue exists, open one first. -->
Closes #246

<!-- Add a brief overview here of the change. -->
Removed the invalid `Compile` element from the shared project.

<!-- Include screenshots or a short video demonstrating the change, if possible -->

## Checklist
<!-- Note: Changes to the Sdk MUST be accompanied by unit tests, even if there were none before. -->
This PR meets the following requirements:
- [*] Tested and contains **NO** breaking changes or known regressions.
- [*] Tested with the upstream branch merged in.
- [*] Tests have been added for bug fixes / features (or this option is not applicable)
- [*] All new code has been documented (or this option is not applicable)
- [*] Headers have been added to all new source files (or this option is not applicable)

<!-- 
Is this a breaking change?
Please describe the impact and migration path for existing applications below.
-->

## Additional info
<!--
Please add any other information that might be helpful to reviewers.
-->

Not provided
