### PR TITLE
[fix] Fix/crash on album track collection when playing an item on Zune

### DIFF
--- a/src/Shells/StrixMusic.Shells.ZuneDesktop/Controls/Views/Collection/ZuneAlbumCollection.cs
+++ b/src/Shells/StrixMusic.Shells.ZuneDesktop/Controls/Views/Collection/ZuneAlbumCollection.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using CommunityToolkit.Diagnostics;
 using CommunityToolkit.Mvvm.Collections;
@@ -27,6 +28,7 @@ namespace StrixMusic.Shells.ZuneDesktop.Controls.Views.Collection
     public partial class ZuneAlbumCollection : CollectionControl<ZuneAlbumCollectionItem, ZuneAlbumItem>
     {
         private ResourceLoader _loacalizationService;
+        private readonly SemaphoreSlim _collectionModifyMutex = new(1, 1);
 
         private ObservableCollection<ZuneAlbumCollectionItem> _albumItems = new();
 
@@ -205,80 +207,86 @@ namespace StrixMusic.Shells.ZuneDesktop.Controls.Views.Collection
         /// <inheritdoc/>
         protected async Task OnCollectionChangedAsync(IAlbumCollectionViewModel? oldValue, IAlbumCollectionViewModel? newValue)
         {
-            _albumItems.Clear();
-            if (newValue is not null)
+            using (await _collectionModifyMutex.DisposableWaitAsync())
             {
-                if (newValue.InitAlbumCollectionAsyncCommand.IsRunning && newValue.InitAlbumCollectionAsyncCommand.ExecutionTask is not null)
-                    await newValue.InitAlbumCollectionAsyncCommand.ExecutionTask;
-                else if (newValue.InitAlbumCollectionAsyncCommand.CanExecute(null))
-                    await newValue.InitAlbumCollectionAsyncCommand.ExecuteAsync(null);
-
-                if (oldValue is IAlbumCollectionViewModel oldCollection)
+                _albumItems.Clear();
+                if (newValue is not null)
                 {
-                    oldCollection.Albums.CollectionChanged -= Album_CollectionChanged;
-                }
-
-                foreach (var item in newValue.Albums)
-                {
-                    var newItems = new ZuneAlbumCollectionItem
+                    if (oldValue is IAlbumCollectionViewModel oldCollection)
                     {
-                        ParentCollection = newValue,
-                        Album = (AlbumViewModel)item,
-                    };
+                        oldCollection.Albums.CollectionChanged -= Album_CollectionChanged;
+                    }
 
-                    _albumItems.Add(newItems);
+                    if (newValue.InitAlbumCollectionAsyncCommand.IsRunning && newValue.InitAlbumCollectionAsyncCommand.ExecutionTask is not null)
+                        await newValue.InitAlbumCollectionAsyncCommand.ExecutionTask;
+                    else if (newValue.InitAlbumCollectionAsyncCommand.CanExecute(null))
+                        await newValue.InitAlbumCollectionAsyncCommand.ExecuteAsync(null);
+
+                    foreach (var item in newValue.Albums)
+                    {
+                        var newItems = new ZuneAlbumCollectionItem
+                        {
+                            ParentCollection = newValue,
+                            Album = (AlbumViewModel)item,
+                        };
+
+                        _albumItems.Add(newItems);
+                    }
+
+                    newValue.Albums.CollectionChanged += Album_CollectionChanged;
                 }
 
-                newValue.Albums.CollectionChanged += Album_CollectionChanged;
-            }
-
-            if (oldValue is not null)
-            {
-                oldValue.Albums.CollectionChanged -= Album_CollectionChanged;
+                if (oldValue is not null)
+                {
+                    oldValue.Albums.CollectionChanged -= Album_CollectionChanged;
+                }
             }
         }
 
-        private void Album_CollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
+        private async void Album_CollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
         {
-            if (e.Action == System.Collections.Specialized.NotifyCollectionChangedAction.Add)
+            using (await _collectionModifyMutex.DisposableWaitAsync())
             {
-                _albumItems.InsertOrAddRange(e.NewStartingIndex, e.NewItems.Cast<object>().Select(x =>
+                if (e.Action == System.Collections.Specialized.NotifyCollectionChangedAction.Add)
                 {
-                    var newItem = new ZuneAlbumCollectionItem
+                    _albumItems.InsertOrAddRange(e.NewStartingIndex, e.NewItems.Cast<object>().Select(x =>
                     {
-                        Album = (AlbumViewModel)x,
-                        ParentCollection = Collection
-                    };
+                        var newItem = new ZuneAlbumCollectionItem
+                        {
+                            Album = (AlbumViewModel)x,
+                            ParentCollection = Collection
+                        };
 
-                    return newItem;
-                }));
-            }
+                        return newItem;
+                    }));
+                }
 
-            if (e.Action == System.Collections.Specialized.NotifyCollectionChangedAction.Remove)
-            {
-                foreach (var item in e.OldItems)
+                if (e.Action == System.Collections.Specialized.NotifyCollectionChangedAction.Remove)
                 {
-                    var target = AlbumItems.FirstOrDefault(x => x.Album == item);
-                    if (target is not null)
+                    foreach (var item in e.OldItems)
                     {
-                        _albumItems.Remove(target);
+                        var target = AlbumItems.FirstOrDefault(x => x.Album == item);
+                        if (target is not null)
+                        {
+                            _albumItems.Remove(target);
+                        }
                     }
                 }
-            }
 
-            if (e.Action == System.Collections.Specialized.NotifyCollectionChangedAction.Move)
-            {
-                for (var i = 0; i < e.OldItems.Count; i++)
-                    _albumItems.Move(i + e.OldStartingIndex, i + e.NewStartingIndex);
-            }
+                if (e.Action == System.Collections.Specialized.NotifyCollectionChangedAction.Move)
+                {
+                    for (var i = 0; i < e.OldItems.Count; i++)
+                        _albumItems.Move(i + e.OldStartingIndex, i + e.NewStartingIndex);
+                }
 
-            if (e.Action == System.Collections.Specialized.NotifyCollectionChangedAction.Reset)
-            {
-                _albumItems.Clear();
-            }
+                if (e.Action == System.Collections.Specialized.NotifyCollectionChangedAction.Reset)
+                {
+                    _albumItems.Clear();
+                }
 
-            if (e.Action == System.Collections.Specialized.NotifyCollectionChangedAction.Replace)
-                throw new NotImplementedException();
+                if (e.Action == System.Collections.Specialized.NotifyCollectionChangedAction.Replace)
+                    throw new NotImplementedException();
+            }
         }
 
         private void ZuneAlbumCollection_Unloaded(object sender, RoutedEventArgs e)


### PR DESCRIPTION
<!--
To categorize this PR in the generated changelog, include one of the following in the PR title: 
[breaking], [fix], [improvement], [new], [refactor], [cleanup]
-->

## Overview
<!-- Replace with the issue number. This will auto-close the issue once the PR is merged. If no issue exists, open one first. -->
Closes #256 

Apparently this is happening due to race condition when adding collections to custom albumItem/trackitem.
Unsubscribing CollectionChanged fixed it.
<!-- Add a brief overview here of the change. -->

<!-- Include screenshots or a short video demonstrating the change, if possible -->

## Checklist
<!-- Note: Changes to the Sdk MUST be accompanied by unit tests, even if there were none before. -->
This PR meets the following requirements:
- [x] Tested and contains **NO** breaking changes or known regressions.
- [x] Tested with the upstream branch merged in.
- [x] Tests have been added for bug fixes / features (or this option is not applicable)
- [x] All new code has been documented (or this option is not applicable)
- [x] Headers have been added to all new source files (or this option is not applicable)

<!-- 
Is this a breaking change?
Please describe the impact and migration path for existing applications below.
-->

## Additional info
<!--
Please add any other information that might be helpful to reviewers.
-->

Not provided
