### PR TITLE
[fix] Fixed groove foreground color as well as check state for splitview. 

### DIFF
--- a/src/Shells/StrixMusic.Shells.Groove/GrooveMusic.xaml
+++ b/src/Shells/StrixMusic.Shells.Groove/GrooveMusic.xaml
@@ -12,45 +12,54 @@
 	xmlns:selectors="using:StrixMusic.Shells.Groove.TemplateSelectors"
 	mc:Ignorable="d">
 
-	<sdkctrls:Shell.Resources>
-		<ResourceDictionary>
-			<ResourceDictionary.MergedDictionaries>
-				<ResourceDictionary Source="ms-appx:///StrixMusic.Shells.Groove/Resources.xaml" />
-			</ResourceDictionary.MergedDictionaries>
+    <sdkctrls:Shell.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="ms-appx:///StrixMusic.Shells.Groove/Resources.xaml" />
+            </ResourceDictionary.MergedDictionaries>
 
-			<DataTemplate x:Key="GroovePlaylistsPageDataTemplate" x:DataType="sdkvms:IPlaylistCollectionViewModel">
-				<pages:GroovePlaylistsPage PlaylistCollection="{Binding DataContext, Mode=OneTime}" />
-			</DataTemplate>
+            <DataTemplate x:Key="GroovePlaylistsPageDataTemplate" x:DataType="sdkvms:IPlaylistCollectionViewModel">
+                <pages:GroovePlaylistsPage PlaylistCollection="{Binding DataContext, Mode=OneTime}" />
+            </DataTemplate>
 
-			<selectors:MainContentTemplateSelector x:Key="MainContentTemplateSelector" PlaylistsPageTemplate="{StaticResource GroovePlaylistsPageDataTemplate}">
-				<selectors:MainContentTemplateSelector.AlbumPageTemplate>
-					<DataTemplate x:DataType="sdkvms:AlbumViewModel">
-						<pages:GrooveAlbumPage Album="{Binding}" />
-					</DataTemplate>
-				</selectors:MainContentTemplateSelector.AlbumPageTemplate>
-				<selectors:MainContentTemplateSelector.ArtistPageTemplate>
-					<DataTemplate x:DataType="sdkvms:ArtistViewModel">
-						<pages:GrooveArtistPage Artist="{Binding}" />
-					</DataTemplate>
-				</selectors:MainContentTemplateSelector.ArtistPageTemplate>
-				<selectors:MainContentTemplateSelector.HomePageTemplate>
-					<DataTemplate x:DataType="sdkvms:LibraryViewModel">
-						<pages:GrooveHomePage Library="{Binding}" />
-					</DataTemplate>
-				</selectors:MainContentTemplateSelector.HomePageTemplate>
-				<selectors:MainContentTemplateSelector.PlaylistPageTemplate>
-					<DataTemplate x:DataType="sdkvms:PlaylistViewModel">
-						<pages:GroovePlaylistPage Playlist="{Binding}" />
-					</DataTemplate>
-				</selectors:MainContentTemplateSelector.PlaylistPageTemplate>
-			</selectors:MainContentTemplateSelector>
-		</ResourceDictionary>
-	</sdkctrls:Shell.Resources>
+            <selectors:MainContentTemplateSelector x:Key="MainContentTemplateSelector" PlaylistsPageTemplate="{StaticResource GroovePlaylistsPageDataTemplate}">
+                <selectors:MainContentTemplateSelector.AlbumPageTemplate>
+                    <DataTemplate x:DataType="sdkvms:AlbumViewModel">
+                        <pages:GrooveAlbumPage Album="{Binding}" />
+                    </DataTemplate>
+                </selectors:MainContentTemplateSelector.AlbumPageTemplate>
+                <selectors:MainContentTemplateSelector.ArtistPageTemplate>
+                    <DataTemplate x:DataType="sdkvms:ArtistViewModel">
+                        <pages:GrooveArtistPage Artist="{Binding}" />
+                    </DataTemplate>
+                </selectors:MainContentTemplateSelector.ArtistPageTemplate>
+                <selectors:MainContentTemplateSelector.HomePageTemplate>
+                    <DataTemplate x:DataType="sdkvms:LibraryViewModel">
+                        <pages:GrooveHomePage Library="{Binding}" />
+                    </DataTemplate>
+                </selectors:MainContentTemplateSelector.HomePageTemplate>
+                <selectors:MainContentTemplateSelector.PlaylistPageTemplate>
+                    <DataTemplate x:DataType="sdkvms:PlaylistViewModel">
+                        <pages:GroovePlaylistPage Playlist="{Binding}" />
+                    </DataTemplate>
+                </selectors:MainContentTemplateSelector.PlaylistPageTemplate>
+            </selectors:MainContentTemplateSelector>
 
-	<Grid>
-		<Border x:Name="CustomTitleBarBorder" Height="32" />
+            <ResourceDictionary.ThemeDictionaries>
+                <ResourceDictionary x:Key="Light">
+                   <SolidColorBrush x:Key="ToggleButtonCheckedForeground" Color="Black"/>
+                </ResourceDictionary>
+                 <ResourceDictionary x:Key="Dark">
+                    <SolidColorBrush x:Key="ToggleButtonForegroundChecked" Color="White"/>
+                </ResourceDictionary>
+            </ResourceDictionary.ThemeDictionaries>
+        </ResourceDictionary>
+    </sdkctrls:Shell.Resources>
 
-		<SplitView
+    <Grid>
+        <Border x:Name="CustomTitleBarBorder" Height="32" />
+
+        <SplitView
 			x:Name="MainSplitView"
 			DisplayMode="CompactInline"
 			OpenPaneLength="320"
@@ -58,39 +67,39 @@
 			PaneClosed="OnPaneStateChanged"
 			PaneClosing="OnPaneStateChanged"
 			PaneOpening="OnPaneStateChanged">
-			<SplitView.Content>
-				<Grid>
-					<Grid.RowDefinitions>
-						<RowDefinition Height="auto" />
-						<RowDefinition />
-					</Grid.RowDefinitions>
+            <SplitView.Content>
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="auto" />
+                        <RowDefinition />
+                    </Grid.RowDefinitions>
 
-					<Grid
+                    <Grid
 						x:Name="SmallHeader"
 						Height="84"
 						Background="{ThemeResource PaneHostBackgroundBrush}"
 						Visibility="Collapsed">
-						<Grid.RowDefinitions>
-							<RowDefinition Height="36" />
-							<RowDefinition />
-						</Grid.RowDefinitions>
-						<Grid.ColumnDefinitions>
-							<ColumnDefinition Width="48" />
-							<ColumnDefinition Width="auto" />
-							<ColumnDefinition Width="*" />
-						</Grid.ColumnDefinitions>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="36" />
+                            <RowDefinition />
+                        </Grid.RowDefinitions>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="48" />
+                            <ColumnDefinition Width="auto" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
 
-						<!--  Hamburger Button  -->
-						<Button
+                        <!--  Hamburger Button  -->
+                        <Button
 							Grid.Row="1"
 							Width="48"
 							Command="{x:Bind HamburgerPressedCommand}"
 							Style="{StaticResource GrooveButton}">
-							<FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE700;" />
-						</Button>
+                            <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE700;" />
+                        </Button>
 
-						<!--  Small Header text  -->
-						<TextBlock
+                        <!--  Small Header text  -->
+                        <TextBlock
 							x:Name="SmallHeaderText"
 							Grid.Row="1"
 							Grid.Column="1"
@@ -100,69 +109,69 @@
 							FontWeight="SemiBold"
 							Text="{x:Bind Title, Mode=OneWay}" />
 
-						<!--  Search button  -->
-						<Button
+                        <!--  Search button  -->
+                        <Button
 							Grid.Row="1"
 							Grid.Column="2"
 							Width="48"
 							HorizontalAlignment="Right"
 							Style="{StaticResource GrooveButton}">
-							<FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE11A;" />
-						</Button>
-					</Grid>
+                            <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE11A;" />
+                        </Button>
+                    </Grid>
 
-					<!--  Large Header  -->
-					<Grid x:Name="LargeHeaderWrapper" Visibility="{x:Bind ShowLargeHeader, Mode=OneWay}">
-						<TextBlock
+                    <!--  Large Header  -->
+                    <Grid x:Name="LargeHeaderWrapper" Visibility="{x:Bind ShowLargeHeader, Mode=OneWay}">
+                        <TextBlock
 							x:Name="LargeHeaderText"
 							Margin="20,44,20,0"
 							FontSize="34"
 							FontWeight="Light"
 							Text="{x:Bind Title, Mode=OneWay}" />
-					</Grid>
+                    </Grid>
 
-					<ContentControl
+                    <ContentControl
 						x:Name="MainContent"
 						Grid.Row="1"
 						HorizontalContentAlignment="Stretch"
 						ContentTemplateSelector="{StaticResource MainContentTemplateSelector}" />
-				</Grid>
-			</SplitView.Content>
-			<SplitView.Pane>
-				<Grid Padding="0,0,0,104">
-					<Grid.RowDefinitions>
-						<RowDefinition Height="36" />
-						<RowDefinition Height="auto" />
-						<RowDefinition />
-					</Grid.RowDefinitions>
+                </Grid>
+            </SplitView.Content>
+            <SplitView.Pane>
+                <Grid Padding="0,0,0,104">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="36" />
+                        <RowDefinition Height="auto" />
+                        <RowDefinition />
+                    </Grid.RowDefinitions>
 
-					<TextBlock
+                    <TextBlock
 						x:Uid="/Resources/AppNameTB"
 						Margin="48,0,0,0"
 						VerticalAlignment="Center"
 						FontSize="12"
 						FontWeight="SemiLight" />
 
-					<StackPanel Grid.Row="1">
-						<!--  Hamburger Button  -->
-						<Button
+                    <StackPanel Grid.Row="1">
+                        <!--  Hamburger Button  -->
+                        <Button
 							Width="48"
 							Height="48"
 							Background="Transparent"
 							BorderThickness="0"
 							Command="{x:Bind HamburgerPressedCommand}">
-							<FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE700;" />
-						</Button>
+                            <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE700;" />
+                        </Button>
 
-						<!--  Search Box  -->
-						<Button
+                        <!--  Search Box  -->
+                        <Button
 							x:Name="SearchButton"
 							Width="48"
 							HorizontalAlignment="Left"
 							Style="{StaticResource GrooveButton}">
-							<FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE11A;" />
-						</Button>
-						<AutoSuggestBox
+                            <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE11A;" />
+                        </Button>
+                        <AutoSuggestBox
 							x:Name="SearchBox"
 							x:Uid="/Common/SearchTBox"
 							Margin="8"
@@ -171,192 +180,192 @@
 							QueryIcon="Find"
 							Style="{StaticResource GrooveSearchAutoSuggestBox}" />
 
-						<!--  Main Nav Buttons  -->
-						<ToggleButton
+                        <!--  Main Nav Buttons  -->
+                        <ToggleButton
 							x:Name="MyMusicButton"
 							Click="NavigationButtonClicked"
 							Style="{StaticResource GrooveNavigationButton}"
 							Tag="MyMusic">
-							<Grid>
-								<Grid.ColumnDefinitions>
-									<ColumnDefinition Width="48" />
-									<ColumnDefinition />
-								</Grid.ColumnDefinitions>
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="48" />
+                                    <ColumnDefinition />
+                                </Grid.ColumnDefinitions>
 
-								<FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xEC4F;" />
+                                <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xEC4F;" />
 
-								<TextBlock
+                                <TextBlock
 									x:Uid="/Music/MyMusicTB"
 									Grid.Column="1"
 									Text="My Music" />
-							</Grid>
-						</ToggleButton>
-						<ToggleButton
+                            </Grid>
+                        </ToggleButton>
+                        <ToggleButton
 							x:Name="RecentButton"
 							Click="NavigationButtonClicked"
 							Style="{StaticResource GrooveNavigationButton}"
 							Tag="Recent">
-							<Grid>
-								<Grid.ColumnDefinitions>
-									<ColumnDefinition Width="48" />
-									<ColumnDefinition />
-								</Grid.ColumnDefinitions>
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="48" />
+                                    <ColumnDefinition />
+                                </Grid.ColumnDefinitions>
 
-								<!--<SymbolIcon Symbol="Clock"/>-->
-								<FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE2AD;" />
+                                <!--<SymbolIcon Symbol="Clock"/>-->
+                                <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE2AD;" />
 
-								<TextBlock
+                                <TextBlock
 									x:Uid="/Music/RecentPlayedTB"
 									Grid.Column="1"
 									Text="Recently Played" />
-							</Grid>
-						</ToggleButton>
-						<ToggleButton
+                            </Grid>
+                        </ToggleButton>
+                        <ToggleButton
 							x:Name="NowPlayingButton"
 							Click="NavigationButtonClicked"
 							Style="{StaticResource GrooveNavigationButton}"
 							Tag="NowPlaying">
-							<Grid>
-								<Grid.ColumnDefinitions>
-									<ColumnDefinition Width="48" />
-									<ColumnDefinition />
-								</Grid.ColumnDefinitions>
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="48" />
+                                    <ColumnDefinition />
+                                </Grid.ColumnDefinitions>
 
-								<FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xF61F;" />
+                                <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xF61F;" />
 
-								<TextBlock
+                                <TextBlock
 									x:Uid="/Music/NowPlayingTB"
 									Grid.Column="1"
 									Text="Now Playing" />
-							</Grid>
-						</ToggleButton>
+                            </Grid>
+                        </ToggleButton>
 
-						<!--  Seperator  -->
-						<Rectangle
+                        <!--  Seperator  -->
+                        <Rectangle
 							x:Name="Seperator"
 							Height="1"
 							Margin="12,0"
 							Fill="{ThemeResource SystemBaseHighColor}"
 							Opacity=".5" />
 
-						<!--  Playlist button  -->
-						<Grid>
-							<Grid.ColumnDefinitions>
-								<ColumnDefinition />
-								<ColumnDefinition Width="auto" />
-							</Grid.ColumnDefinitions>
+                        <!--  Playlist button  -->
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition />
+                                <ColumnDefinition Width="auto" />
+                            </Grid.ColumnDefinitions>
 
-							<ToggleButton
+                            <ToggleButton
 								x:Name="PlaylistsButton"
 								Click="NavigationButtonClicked"
 								Style="{StaticResource GrooveNavigationButton}"
 								Tag="Playlists">
-								<Grid>
-									<Grid.ColumnDefinitions>
-										<ColumnDefinition Width="48" />
-										<ColumnDefinition />
-									</Grid.ColumnDefinitions>
+                                <Grid>
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="48" />
+                                        <ColumnDefinition />
+                                    </Grid.ColumnDefinitions>
 
-									<FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE142;" />
+                                    <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE142;" />
 
-									<TextBlock
+                                    <TextBlock
 										x:Uid="/Music/PlaylistsTB"
 										Grid.Column="1"
 										Text="Playlists" />
-								</Grid>
-							</ToggleButton>
+                                </Grid>
+                            </ToggleButton>
 
-							<Button
+                            <Button
 								Grid.Column="1"
 								Width="48"
 								Style="{StaticResource GrooveButton}">
-								<SymbolIcon Symbol="Add" />
-							</Button>
-						</Grid>
+                                <SymbolIcon Symbol="Add" />
+                            </Button>
+                        </Grid>
 
-						<Button
+                        <Button
 							x:Name="CompactCreatePlaylistButton"
 							Width="48"
 							HorizontalAlignment="Left"
 							Style="{StaticResource GrooveButton}"
 							Visibility="Collapsed">
-							<SymbolIcon Symbol="Add" />
-						</Button>
-					</StackPanel>
+                            <SymbolIcon Symbol="Add" />
+                        </Button>
+                    </StackPanel>
 
-					<collections:GroovePlaylistCollection
+                    <collections:GroovePlaylistCollection
 						x:Name="PlaylistList"
 						Grid.Row="2"
 						Collection="{x:Bind Root.Library, Mode=OneWay}"
 						Style="{StaticResource PanePlaylistCollectionStyle}" />
-				</Grid>
-			</SplitView.Pane>
-		</SplitView>
+                </Grid>
+            </SplitView.Pane>
+        </SplitView>
 
-		<controls:GrooveNowPlayingBar
+        <controls:GrooveNowPlayingBar
 			Height="96"
 			VerticalAlignment="Bottom"
 			Devices="{x:Bind Root.Devices, Mode=OneWay}" />
 
-		<VisualStateManager.VisualStateGroups>
-			<VisualStateGroup x:Name="Sizes">
-				<VisualState x:Name="Large">
-					<VisualState.StateTriggers>
-						<AdaptiveTrigger MinWindowWidth="1200" />
-					</VisualState.StateTriggers>
-					<VisualState.Setters>
-						<Setter Target="MainSplitView.IsPaneOpen" Value="True" />
-					</VisualState.Setters>
-				</VisualState>
-				<VisualState x:Name="Medium">
-					<VisualState.StateTriggers>
-						<AdaptiveTrigger MinWindowWidth="600" />
-					</VisualState.StateTriggers>
-					<VisualState.Setters>
-						<Setter Target="MainSplitView.DisplayMode" Value="CompactOverlay" />
-						<Setter Target="MainSplitView.PaneBackground" Value="{ThemeResource PaneBackgroundBrush}" />
-					</VisualState.Setters>
-				</VisualState>
-				<VisualState x:Name="Small">
-					<VisualState.StateTriggers>
-						<AdaptiveTrigger x:Name="SmallTrigger" MinWindowWidth="0" />
-					</VisualState.StateTriggers>
-					<VisualState.Setters>
-						<Setter Target="MainSplitView.DisplayMode" Value="Overlay" />
-						<Setter Target="MainSplitView.PaneBackground" Value="{ThemeResource PaneBackgroundBrush}" />
-						<Setter Target="LargeHeaderText.Visibility" Value="Collapsed" />
-						<Setter Target="SmallHeader.Visibility" Value="Visible" />
-					</VisualState.Setters>
-				</VisualState>
-			</VisualStateGroup>
-			<VisualStateGroup x:Name="PaneStates">
-				<VisualState x:Name="Full">
-					<!--<VisualState.StateTriggers>
+        <VisualStateManager.VisualStateGroups>
+            <VisualStateGroup x:Name="Sizes">
+                <VisualState x:Name="Large">
+                    <VisualState.StateTriggers>
+                        <AdaptiveTrigger MinWindowWidth="1200" />
+                    </VisualState.StateTriggers>
+                    <VisualState.Setters>
+                        <Setter Target="MainSplitView.IsPaneOpen" Value="True" />
+                    </VisualState.Setters>
+                </VisualState>
+                <VisualState x:Name="Medium">
+                    <VisualState.StateTriggers>
+                        <AdaptiveTrigger MinWindowWidth="600" />
+                    </VisualState.StateTriggers>
+                    <VisualState.Setters>
+                        <Setter Target="MainSplitView.DisplayMode" Value="CompactOverlay" />
+                        <Setter Target="MainSplitView.PaneBackground" Value="{ThemeResource PaneBackgroundBrush}" />
+                    </VisualState.Setters>
+                </VisualState>
+                <VisualState x:Name="Small">
+                    <VisualState.StateTriggers>
+                        <AdaptiveTrigger x:Name="SmallTrigger" MinWindowWidth="0" />
+                    </VisualState.StateTriggers>
+                    <VisualState.Setters>
+                        <Setter Target="MainSplitView.DisplayMode" Value="Overlay" />
+                        <Setter Target="MainSplitView.PaneBackground" Value="{ThemeResource PaneBackgroundBrush}" />
+                        <Setter Target="LargeHeaderText.Visibility" Value="Collapsed" />
+                        <Setter Target="SmallHeader.Visibility" Value="Visible" />
+                    </VisualState.Setters>
+                </VisualState>
+            </VisualStateGroup>
+            <VisualStateGroup x:Name="PaneStates">
+                <VisualState x:Name="Full">
+                    <!--<VisualState.StateTriggers>
                         <StateTrigger IsActive="{x:Bind MainSplitView.IsPaneOpen, Mode=OneWay}"/>
                     </VisualState.StateTriggers>-->
-					<VisualState.Setters>
-						<Setter Target="Seperator.Width" Value="auto" />
-						<Setter Target="Seperator.HorizontalAlignment" Value="Stretch" />
-						<Setter Target="CompactCreatePlaylistButton.Visibility" Value="Collapsed" />
-						<Setter Target="PlaylistList.Visibility" Value="Visible" />
-						<Setter Target="SearchButton.Visibility" Value="Collapsed" />
-						<Setter Target="SearchBox.Visibility" Value="Visible" />
-					</VisualState.Setters>
-				</VisualState>
-				<VisualState x:Name="Compact">
-					<!--<VisualState.StateTriggers>
+                    <VisualState.Setters>
+                        <Setter Target="Seperator.Width" Value="auto" />
+                        <Setter Target="Seperator.HorizontalAlignment" Value="Stretch" />
+                        <Setter Target="CompactCreatePlaylistButton.Visibility" Value="Collapsed" />
+                        <Setter Target="PlaylistList.Visibility" Value="Visible" />
+                        <Setter Target="SearchButton.Visibility" Value="Collapsed" />
+                        <Setter Target="SearchBox.Visibility" Value="Visible" />
+                    </VisualState.Setters>
+                </VisualState>
+                <VisualState x:Name="Compact">
+                    <!--<VisualState.StateTriggers>
                         <StateTrigger IsActive="{x:Bind !MainSplitView.IsPaneOpen, Mode=OneWay}"/>
                     </VisualState.StateTriggers>-->
-					<VisualState.Setters>
-						<Setter Target="Seperator.Width" Value="24" />
-						<Setter Target="Seperator.HorizontalAlignment" Value="Left" />
-						<Setter Target="CompactCreatePlaylistButton.Visibility" Value="Visible" />
-						<Setter Target="PlaylistList.Visibility" Value="Collapsed" />
-						<Setter Target="SearchButton.Visibility" Value="Visible" />
-						<Setter Target="SearchBox.Visibility" Value="Collapsed" />
-					</VisualState.Setters>
-				</VisualState>
-			</VisualStateGroup>
-		</VisualStateManager.VisualStateGroups>
-	</Grid>
+                    <VisualState.Setters>
+                        <Setter Target="Seperator.Width" Value="24" />
+                        <Setter Target="Seperator.HorizontalAlignment" Value="Left" />
+                        <Setter Target="CompactCreatePlaylistButton.Visibility" Value="Visible" />
+                        <Setter Target="PlaylistList.Visibility" Value="Collapsed" />
+                        <Setter Target="SearchButton.Visibility" Value="Visible" />
+                        <Setter Target="SearchBox.Visibility" Value="Collapsed" />
+                    </VisualState.Setters>
+                </VisualState>
+            </VisualStateGroup>
+        </VisualStateManager.VisualStateGroups>
+    </Grid>
 </sdkctrls:Shell>

--- a/src/Shells/StrixMusic.Shells.Groove/GrooveMusic.xaml
+++ b/src/Shells/StrixMusic.Shells.Groove/GrooveMusic.xaml
@@ -1,16 +1,16 @@
 ﻿<sdkctrls:Shell
-	x:Class="StrixMusic.Shells.Groove.GrooveMusic"
-	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-	xmlns:collections="using:StrixMusic.Shells.Groove.Controls.Collections"
-	xmlns:controls="using:StrixMusic.Shells.Groove.Controls"
-	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-	xmlns:pages="using:StrixMusic.Shells.Groove.Controls.Pages"
-	xmlns:sdkctrls="using:StrixMusic.Sdk.WinUI.Controls"
-	xmlns:sdkvms="using:StrixMusic.Sdk.ViewModels"
-	xmlns:selectors="using:StrixMusic.Shells.Groove.TemplateSelectors"
-	mc:Ignorable="d">
+    x:Class="StrixMusic.Shells.Groove.GrooveMusic"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:collections="using:StrixMusic.Shells.Groove.Controls.Collections"
+    xmlns:controls="using:StrixMusic.Shells.Groove.Controls"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:pages="using:StrixMusic.Shells.Groove.Controls.Pages"
+    xmlns:sdkctrls="using:StrixMusic.Sdk.WinUI.Controls"
+    xmlns:sdkvms="using:StrixMusic.Sdk.ViewModels"
+    xmlns:selectors="using:StrixMusic.Shells.Groove.TemplateSelectors"
+    mc:Ignorable="d">
 
     <sdkctrls:Shell.Resources>
         <ResourceDictionary>
@@ -47,10 +47,14 @@
 
             <ResourceDictionary.ThemeDictionaries>
                 <ResourceDictionary x:Key="Light">
-                   <SolidColorBrush x:Key="ToggleButtonCheckedForeground" Color="Black"/>
+                    <SolidColorBrush x:Key="ToggleButtonCheckedForeground" Color="Black" />
+                    <SolidColorBrush x:Key="ToggleButtonForegroundCheckedPointerOver" Color="Black" />
+                    <SolidColorBrush x:Key="ToggleButtonForegroundCheckedPressed" Color="Black" />
                 </ResourceDictionary>
-                 <ResourceDictionary x:Key="Dark">
-                    <SolidColorBrush x:Key="ToggleButtonForegroundChecked" Color="White"/>
+                <ResourceDictionary x:Key="Dark">
+                    <SolidColorBrush x:Key="ToggleButtonForegroundChecked" Color="White" />
+                    <SolidColorBrush x:Key="ToggleButtonForegroundCheckedPointerOver" Color="White" />
+                    <SolidColorBrush x:Key="ToggleButtonForegroundCheckedPressed" Color="White" />
                 </ResourceDictionary>
             </ResourceDictionary.ThemeDictionaries>
         </ResourceDictionary>
@@ -60,13 +64,13 @@
         <Border x:Name="CustomTitleBarBorder" Height="32" />
 
         <SplitView
-			x:Name="MainSplitView"
-			DisplayMode="CompactInline"
-			OpenPaneLength="320"
-			PaneBackground="{ThemeResource PaneHostBackgroundBrush}"
-			PaneClosed="OnPaneStateChanged"
-			PaneClosing="OnPaneStateChanged"
-			PaneOpening="OnPaneStateChanged">
+            x:Name="MainSplitView"
+            DisplayMode="CompactInline"
+            OpenPaneLength="320"
+            PaneBackground="{ThemeResource PaneHostBackgroundBrush}"
+            PaneClosed="OnPaneStateChanged"
+            PaneClosing="OnPaneStateChanged"
+            PaneOpening="OnPaneStateChanged">
             <SplitView.Content>
                 <Grid>
                     <Grid.RowDefinitions>
@@ -75,10 +79,10 @@
                     </Grid.RowDefinitions>
 
                     <Grid
-						x:Name="SmallHeader"
-						Height="84"
-						Background="{ThemeResource PaneHostBackgroundBrush}"
-						Visibility="Collapsed">
+                        x:Name="SmallHeader"
+                        Height="84"
+                        Background="{ThemeResource PaneHostBackgroundBrush}"
+                        Visibility="Collapsed">
                         <Grid.RowDefinitions>
                             <RowDefinition Height="36" />
                             <RowDefinition />
@@ -91,31 +95,31 @@
 
                         <!--  Hamburger Button  -->
                         <Button
-							Grid.Row="1"
-							Width="48"
-							Command="{x:Bind HamburgerPressedCommand}"
-							Style="{StaticResource GrooveButton}">
+                            Grid.Row="1"
+                            Width="48"
+                            Command="{x:Bind HamburgerPressedCommand}"
+                            Style="{StaticResource GrooveButton}">
                             <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE700;" />
                         </Button>
 
                         <!--  Small Header text  -->
                         <TextBlock
-							x:Name="SmallHeaderText"
-							Grid.Row="1"
-							Grid.Column="1"
-							Margin="8,0,0,0"
-							VerticalAlignment="Center"
-							FontSize="18"
-							FontWeight="SemiBold"
-							Text="{x:Bind Title, Mode=OneWay}" />
+                            x:Name="SmallHeaderText"
+                            Grid.Row="1"
+                            Grid.Column="1"
+                            Margin="8,0,0,0"
+                            VerticalAlignment="Center"
+                            FontSize="18"
+                            FontWeight="SemiBold"
+                            Text="{x:Bind Title, Mode=OneWay}" />
 
                         <!--  Search button  -->
                         <Button
-							Grid.Row="1"
-							Grid.Column="2"
-							Width="48"
-							HorizontalAlignment="Right"
-							Style="{StaticResource GrooveButton}">
+                            Grid.Row="1"
+                            Grid.Column="2"
+                            Width="48"
+                            HorizontalAlignment="Right"
+                            Style="{StaticResource GrooveButton}">
                             <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE11A;" />
                         </Button>
                     </Grid>
@@ -123,18 +127,18 @@
                     <!--  Large Header  -->
                     <Grid x:Name="LargeHeaderWrapper" Visibility="{x:Bind ShowLargeHeader, Mode=OneWay}">
                         <TextBlock
-							x:Name="LargeHeaderText"
-							Margin="20,44,20,0"
-							FontSize="34"
-							FontWeight="Light"
-							Text="{x:Bind Title, Mode=OneWay}" />
+                            x:Name="LargeHeaderText"
+                            Margin="20,44,20,0"
+                            FontSize="34"
+                            FontWeight="Light"
+                            Text="{x:Bind Title, Mode=OneWay}" />
                     </Grid>
 
                     <ContentControl
-						x:Name="MainContent"
-						Grid.Row="1"
-						HorizontalContentAlignment="Stretch"
-						ContentTemplateSelector="{StaticResource MainContentTemplateSelector}" />
+                        x:Name="MainContent"
+                        Grid.Row="1"
+                        HorizontalContentAlignment="Stretch"
+                        ContentTemplateSelector="{StaticResource MainContentTemplateSelector}" />
                 </Grid>
             </SplitView.Content>
             <SplitView.Pane>
@@ -146,46 +150,46 @@
                     </Grid.RowDefinitions>
 
                     <TextBlock
-						x:Uid="/Resources/AppNameTB"
-						Margin="48,0,0,0"
-						VerticalAlignment="Center"
-						FontSize="12"
-						FontWeight="SemiLight" />
+                        x:Uid="/Resources/AppNameTB"
+                        Margin="48,0,0,0"
+                        VerticalAlignment="Center"
+                        FontSize="12"
+                        FontWeight="SemiLight" />
 
                     <StackPanel Grid.Row="1">
                         <!--  Hamburger Button  -->
                         <Button
-							Width="48"
-							Height="48"
-							Background="Transparent"
-							BorderThickness="0"
-							Command="{x:Bind HamburgerPressedCommand}">
+                            Width="48"
+                            Height="48"
+                            Background="Transparent"
+                            BorderThickness="0"
+                            Command="{x:Bind HamburgerPressedCommand}">
                             <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE700;" />
                         </Button>
 
                         <!--  Search Box  -->
                         <Button
-							x:Name="SearchButton"
-							Width="48"
-							HorizontalAlignment="Left"
-							Style="{StaticResource GrooveButton}">
+                            x:Name="SearchButton"
+                            Width="48"
+                            HorizontalAlignment="Left"
+                            Style="{StaticResource GrooveButton}">
                             <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE11A;" />
                         </Button>
                         <AutoSuggestBox
-							x:Name="SearchBox"
-							x:Uid="/Common/SearchTBox"
-							Margin="8"
-							BorderThickness="0"
-							PlaceholderText="Search..."
-							QueryIcon="Find"
-							Style="{StaticResource GrooveSearchAutoSuggestBox}" />
+                            x:Name="SearchBox"
+                            x:Uid="/Common/SearchTBox"
+                            Margin="8"
+                            BorderThickness="0"
+                            PlaceholderText="Search..."
+                            QueryIcon="Find"
+                            Style="{StaticResource GrooveSearchAutoSuggestBox}" />
 
                         <!--  Main Nav Buttons  -->
                         <ToggleButton
-							x:Name="MyMusicButton"
-							Click="NavigationButtonClicked"
-							Style="{StaticResource GrooveNavigationButton}"
-							Tag="MyMusic">
+                            x:Name="MyMusicButton"
+                            Click="NavigationButtonClicked"
+                            Style="{StaticResource GrooveNavigationButton}"
+                            Tag="MyMusic">
                             <Grid>
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="48" />
@@ -195,16 +199,16 @@
                                 <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xEC4F;" />
 
                                 <TextBlock
-									x:Uid="/Music/MyMusicTB"
-									Grid.Column="1"
-									Text="My Music" />
+                                    x:Uid="/Music/MyMusicTB"
+                                    Grid.Column="1"
+                                    Text="My Music" />
                             </Grid>
                         </ToggleButton>
                         <ToggleButton
-							x:Name="RecentButton"
-							Click="NavigationButtonClicked"
-							Style="{StaticResource GrooveNavigationButton}"
-							Tag="Recent">
+                            x:Name="RecentButton"
+                            Click="NavigationButtonClicked"
+                            Style="{StaticResource GrooveNavigationButton}"
+                            Tag="Recent">
                             <Grid>
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="48" />
@@ -215,16 +219,16 @@
                                 <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE2AD;" />
 
                                 <TextBlock
-									x:Uid="/Music/RecentPlayedTB"
-									Grid.Column="1"
-									Text="Recently Played" />
+                                    x:Uid="/Music/RecentPlayedTB"
+                                    Grid.Column="1"
+                                    Text="Recently Played" />
                             </Grid>
                         </ToggleButton>
                         <ToggleButton
-							x:Name="NowPlayingButton"
-							Click="NavigationButtonClicked"
-							Style="{StaticResource GrooveNavigationButton}"
-							Tag="NowPlaying">
+                            x:Name="NowPlayingButton"
+                            Click="NavigationButtonClicked"
+                            Style="{StaticResource GrooveNavigationButton}"
+                            Tag="NowPlaying">
                             <Grid>
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="48" />
@@ -234,19 +238,19 @@
                                 <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xF61F;" />
 
                                 <TextBlock
-									x:Uid="/Music/NowPlayingTB"
-									Grid.Column="1"
-									Text="Now Playing" />
+                                    x:Uid="/Music/NowPlayingTB"
+                                    Grid.Column="1"
+                                    Text="Now Playing" />
                             </Grid>
                         </ToggleButton>
 
                         <!--  Seperator  -->
                         <Rectangle
-							x:Name="Seperator"
-							Height="1"
-							Margin="12,0"
-							Fill="{ThemeResource SystemBaseHighColor}"
-							Opacity=".5" />
+                            x:Name="Seperator"
+                            Height="1"
+                            Margin="12,0"
+                            Fill="{ThemeResource SystemBaseHighColor}"
+                            Opacity=".5" />
 
                         <!--  Playlist button  -->
                         <Grid>
@@ -256,10 +260,10 @@
                             </Grid.ColumnDefinitions>
 
                             <ToggleButton
-								x:Name="PlaylistsButton"
-								Click="NavigationButtonClicked"
-								Style="{StaticResource GrooveNavigationButton}"
-								Tag="Playlists">
+                                x:Name="PlaylistsButton"
+                                Click="NavigationButtonClicked"
+                                Style="{StaticResource GrooveNavigationButton}"
+                                Tag="Playlists">
                                 <Grid>
                                     <Grid.ColumnDefinitions>
                                         <ColumnDefinition Width="48" />
@@ -269,43 +273,43 @@
                                     <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE142;" />
 
                                     <TextBlock
-										x:Uid="/Music/PlaylistsTB"
-										Grid.Column="1"
-										Text="Playlists" />
+                                        x:Uid="/Music/PlaylistsTB"
+                                        Grid.Column="1"
+                                        Text="Playlists" />
                                 </Grid>
                             </ToggleButton>
 
                             <Button
-								Grid.Column="1"
-								Width="48"
-								Style="{StaticResource GrooveButton}">
+                                Grid.Column="1"
+                                Width="48"
+                                Style="{StaticResource GrooveButton}">
                                 <SymbolIcon Symbol="Add" />
                             </Button>
                         </Grid>
 
                         <Button
-							x:Name="CompactCreatePlaylistButton"
-							Width="48"
-							HorizontalAlignment="Left"
-							Style="{StaticResource GrooveButton}"
-							Visibility="Collapsed">
+                            x:Name="CompactCreatePlaylistButton"
+                            Width="48"
+                            HorizontalAlignment="Left"
+                            Style="{StaticResource GrooveButton}"
+                            Visibility="Collapsed">
                             <SymbolIcon Symbol="Add" />
                         </Button>
                     </StackPanel>
 
                     <collections:GroovePlaylistCollection
-						x:Name="PlaylistList"
-						Grid.Row="2"
-						Collection="{x:Bind Root.Library, Mode=OneWay}"
-						Style="{StaticResource PanePlaylistCollectionStyle}" />
+                        x:Name="PlaylistList"
+                        Grid.Row="2"
+                        Collection="{x:Bind Root.Library, Mode=OneWay}"
+                        Style="{StaticResource PanePlaylistCollectionStyle}" />
                 </Grid>
             </SplitView.Pane>
         </SplitView>
 
         <controls:GrooveNowPlayingBar
-			Height="96"
-			VerticalAlignment="Bottom"
-			Devices="{x:Bind Root.Devices, Mode=OneWay}" />
+            Height="96"
+            VerticalAlignment="Bottom"
+            Devices="{x:Bind Root.Devices, Mode=OneWay}" />
 
         <VisualStateManager.VisualStateGroups>
             <VisualStateGroup x:Name="Sizes">

--- a/src/Shells/StrixMusic.Shells.Groove/GrooveMusic.xaml.cs
+++ b/src/Shells/StrixMusic.Shells.Groove/GrooveMusic.xaml.cs
@@ -172,6 +172,15 @@ namespace StrixMusic.Shells.Groove
                     WeakReferenceMessenger.Default.Send(new PlaylistsViewNavigationRequestMessage((LibraryViewModel)Root.Library));
                     break;
             }
+
+            UpdateCheckedState(button.Tag.ToString());
+        }
+
+        private void UpdateCheckedState(string checkedItem)
+        {
+            MyMusicButton.IsChecked = checkedItem == "MyMusic";
+            RecentButton.IsChecked = checkedItem == "Recent";
+            NowPlayingButton.IsChecked = checkedItem == "NowPlaying";
         }
 
         private void HamburgerToggled()


### PR DESCRIPTION
<!--
To categorize this PR in the generated changelog, include one of the following in the PR title: 
[breaking], [fix], [improvement], [new], [refactor], [cleanup]
-->

## Overview
<!-- Replace with the issue number. This will auto-close the issue once the PR is merged. If no issue exists, open one first. -->
Closes #251 

<!-- Add a brief overview here of the change. -->

- The foreground color of the splitview toggle buttons on checked state was incorrect, used lightweight styling to fix it.
- This also includes a fix where checking on toggle button doesn't uncheck others in splitview. 

<!-- Include screenshots or a short video demonstrating the change, if possible -->

## Checklist
<!-- Note: Changes to the Sdk MUST be accompanied by unit tests, even if there were none before. -->
This PR meets the following requirements:
- [x] Tested and contains **NO** breaking changes or known regressions.
- [x] Tested with the upstream branch merged in.
- [x] Tests have been added for bug fixes / features (or this option is not applicable)
- [x] All new code has been documented (or this option is not applicable)
- [x] Headers have been added to all new source files (or this option is not applicable)

<!-- 
Is this a breaking change?
Please describe the impact and migration path for existing applications below.
-->
## Additional info
<!--
Please add any other information that might be helpful to reviewers.
-->

Not provided
