### PR TITLE
[fix] Set up SystemMediaTransportControlsHandler in AppRoot

### DIFF
--- a/src/Shared/AppModels/AppRoot.cs
+++ b/src/Shared/AppModels/AppRoot.cs
@@ -48,6 +48,7 @@ public partial class AppRoot : ObservableObject, IAsyncInit
     private readonly SemaphoreSlim _initMutex = new(1, 1);
     private readonly IModifiableFolder _dataFolder;
     private readonly PlaybackHandlerService _playbackHandler = new();
+    private readonly SystemMediaTransportControlsHandler _smtcHandler;
 
     [ObservableProperty]
     private AppDiagnostics? _diagnostics;
@@ -73,6 +74,7 @@ public partial class AppRoot : ObservableObject, IAsyncInit
     public AppRoot(IModifiableFolder dataFolder)
     {
         _dataFolder = dataFolder;
+        _smtcHandler = new SystemMediaTransportControlsHandler(_playbackHandler);
     }
 
     /// <summary>


### PR DESCRIPTION
<!--
To categorize this PR in the generated changelog, include one of the following in the PR title: 
[breaking], [fix], [improvement], [new], [refactor], [cleanup]
-->

## Overview
<!-- Replace with the issue number. This will auto-close the issue once the PR is merged. If no issue exists, open one first. -->
Closes #254

<!-- Add a brief overview here of the change. -->
This PR simply adds a field to `StrixMusic.AppModels.AppRoot` containing an instance of `SystemMediaTransportControlsHandler`, initialized with the current `PlaybackHandlerService`. This fixes background playback and enables support for the System Media Transport Controls.

<!-- Include screenshots or a short video demonstrating the change, if possible -->

## Checklist
<!-- Note: Changes to the Sdk MUST be accompanied by unit tests, even if there were none before. -->
This PR meets the following requirements:
- [ ] Tested and contains **NO** breaking changes or known regressions.
- [x] Tested with the upstream branch merged in.
- [x] Tests have been added for bug fixes / features (or this option is not applicable)
- [x] All new code has been documented (or this option is not applicable)
- [x] Headers have been added to all new source files (or this option is not applicable)

<!-- 
Is this a breaking change?
Please describe the impact and migration path for existing applications below.
-->

## Additional info
<!--
Please add any other information that might be helpful to reviewers.
-->

Not provided
