### PR TITLE
Fixed an issue where core wasn't initialized correctly on app reload.

### DIFF
--- a/src/Shared/AppModels/AppRoot.cs
+++ b/src/Shared/AppModels/AppRoot.cs
@@ -225,8 +225,7 @@ public partial class AppRoot : ObservableObject, IAsyncInit
             await allNewCores.InParallel(x => TryInitCore(x, cancellationToken));
 
             // Prune cores that didn't load successfully
-            allNewCores = allNewCores.Where(x => !x.IsInitialized)
-                .Where(x => _mergedCore?.Sources.Contains(x) == false).ToList();
+            var initializedCores = allNewCores.Where(x => x.IsInitialized).Where(x => MergedCore == null || _mergedCore?.Sources.Contains(x) == false).ToList();
 
             // Even if no new cores need to be created, as settings are changed, _mergedCore can be assigned and sources can be added/removed.
             // If _mergedCore exists, set it up as the data root.

--- a/src/Shared/AppModels/AppRoot.cs
+++ b/src/Shared/AppModels/AppRoot.cs
@@ -225,7 +225,8 @@ public partial class AppRoot : ObservableObject, IAsyncInit
             await allNewCores.InParallel(x => TryInitCore(x, cancellationToken));
 
             // Prune cores that didn't load successfully
-            allNewCores = allNewCores.Where(x => x.IsInitialized).Where(x => MergedCore == null || _mergedCore?.Sources.Contains(x) == false).ToList();
+            var initializedCores = allNewCores = allNewCores.Where(x => x.IsInitialized).ToList();
+            initializedCores = initializedCores.Where(x => MergedCore == null || _mergedCore?.Sources.Contains(x) == false).ToList();
 
             // Even if no new cores need to be created, as settings are changed, _mergedCore can be assigned and sources can be added/removed.
             // If _mergedCore exists, set it up as the data root.

--- a/src/Shared/AppModels/AppRoot.cs
+++ b/src/Shared/AppModels/AppRoot.cs
@@ -225,7 +225,7 @@ public partial class AppRoot : ObservableObject, IAsyncInit
             await allNewCores.InParallel(x => TryInitCore(x, cancellationToken));
 
             // Prune cores that didn't load successfully
-            allNewCores = allNewCores.Where(x => !x.IsInitialized).Where(x => _mergedCore?.Sources.Contains(x) == false).ToList();
+            allNewCores = allNewCores.Where(x => x.IsInitialized).Where(x => MergedCore == null || _mergedCore?.Sources.Contains(x) == false).ToList();
 
             // Even if no new cores need to be created, as settings are changed, _mergedCore can be assigned and sources can be added/removed.
             // If _mergedCore exists, set it up as the data root.

--- a/src/Shared/AppModels/AppRoot.cs
+++ b/src/Shared/AppModels/AppRoot.cs
@@ -225,8 +225,7 @@ public partial class AppRoot : ObservableObject, IAsyncInit
             await allNewCores.InParallel(x => TryInitCore(x, cancellationToken));
 
             // Prune cores that didn't load successfully
-            var initializedCores = allNewCores = allNewCores.Where(x => x.IsInitialized).ToList();
-            initializedCores = initializedCores.Where(x => MergedCore == null || _mergedCore?.Sources.Contains(x) == false).ToList();
+            allNewCores = allNewCores.Where(x => !x.IsInitialized).Where(x => _mergedCore?.Sources.Contains(x) == false).ToList();
 
             // Even if no new cores need to be created, as settings are changed, _mergedCore can be assigned and sources can be added/removed.
             // If _mergedCore exists, set it up as the data root.

--- a/src/Shared/AppModels/AppRoot.cs
+++ b/src/Shared/AppModels/AppRoot.cs
@@ -225,7 +225,8 @@ public partial class AppRoot : ObservableObject, IAsyncInit
             await allNewCores.InParallel(x => TryInitCore(x, cancellationToken));
 
             // Prune cores that didn't load successfully
-            allNewCores = allNewCores.Where(x => !x.IsInitialized).Where(x => _mergedCore?.Sources.Contains(x) == false).ToList();
+            allNewCores = allNewCores.Where(x => !x.IsInitialized)
+                .Where(x => _mergedCore?.Sources.Contains(x) == false).ToList();
 
             // Even if no new cores need to be created, as settings are changed, _mergedCore can be assigned and sources can be added/removed.
             // If _mergedCore exists, set it up as the data root.

--- a/src/Shared/AppModels/AppRoot.cs
+++ b/src/Shared/AppModels/AppRoot.cs
@@ -225,7 +225,7 @@ public partial class AppRoot : ObservableObject, IAsyncInit
             await allNewCores.InParallel(x => TryInitCore(x, cancellationToken));
 
             // Prune cores that didn't load successfully
-            var initializedCores = allNewCores.Where(x => x.IsInitialized).Where(x => MergedCore == null || _mergedCore?.Sources.Contains(x) == false).ToList();
+            allNewCores = allNewCores.Where(x => x.IsInitialized).Where(x => MergedCore == null || _mergedCore?.Sources.Contains(x) == false).ToList();
 
             // Even if no new cores need to be created, as settings are changed, _mergedCore can be assigned and sources can be added/removed.
             // If _mergedCore exists, set it up as the data root.


### PR DESCRIPTION


## Overview
<!-- Replace with the issue number. This will auto-close the issue once the PR is merged. If no issue exists, open one first. -->
Turned out the linq that was used to prune the Uninitialized cores was incorrect, it was pruning initialized ones on app reload. This has been fixed the cores are loading now on app reload.
Closes #289 

<!-- Add a brief overview here of the change. -->

<!-- Include screenshots or a short video demonstrating the change, if possible -->

## Checklist
<!-- Note: Changes to the Sdk MUST be accompanied by unit tests, even if there were none before. -->
This PR meets the following requirements:
- [x] Tested and contains **NO** breaking changes or known regressions.
- [x] Tested with the upstream branch merged in.
- [x] Tests have been added for bug fixes / features (or this option is not applicable)
- [x] All new code has been documented (or this option is not applicable)
- [x] Headers have been added to all new source files (or this option is not applicable)

<!-- 
Is this a breaking change?
Please describe the impact and migration path for existing applications below.
-->
No

## Additional info
<!--
Please add any other information that might be helpful to reviewers.
-->

Not provided
