### PR TITLE
Update packages, update to net9, fix build errors

### DIFF
--- a/build-scripts/Release.ps1
+++ b/build-scripts/Release.ps1
@@ -196,7 +196,7 @@ if ($steps.Contains("uwp")) {
 if ($steps.Contains("organize")) {
   # The resulting folder can be uploaded anywhere (not just ipfs)
   Write-Output "Organizing generated release content"
-  .\OrganizeReleaseContent.ps1 -wasmAppPath "$PSScriptRoot/../src/Platforms/StrixMusic.Wasm/bin/$configuration/net7.0/dist/*" -uwpSideloadBuildPath "$PSScriptRoot/../src/Platforms/StrixMusic.UWP/AppPackages/*" -websitePath $PSScriptRoot/../www/* -docsPath $PSScriptRoot/../docs/wwwroot/* -sdkNupkgFolder $PSScriptRoot/build/sdk/$sdkTag/* -cleanRepoPath $PSScriptRoot/build/source -buildDependenciesPath $PSScriptRoot/build/dependencies/* -outputPath $outputPath
+  .\OrganizeReleaseContent.ps1 -wasmAppPath "$PSScriptRoot/../src/Platforms/StrixMusic.Wasm/bin/$configuration/net9.0/dist/*" -uwpSideloadBuildPath "$PSScriptRoot/../src/Platforms/StrixMusic.UWP/AppPackages/*" -websitePath $PSScriptRoot/../www/* -docsPath $PSScriptRoot/../docs/wwwroot/* -sdkNupkgFolder $PSScriptRoot/build/sdk/$sdkTag/* -cleanRepoPath $PSScriptRoot/build/source -buildDependenciesPath $PSScriptRoot/build/dependencies/* -outputPath $outputPath
 
   if ($pastReleaseCid.Length -gt 0 -or $pastReleaseIpns.Length -gt 0) {
     # Grab previous versioned content such as nuget packages and app installers (requires ipfs)

--- a/docs/cores/create/index.md
+++ b/docs/cores/create/index.md
@@ -54,7 +54,7 @@ Open up the `.csproj` for your new core and add the following lines before the c
 ```xml
 	<PropertyGroup>
 		<Nullable>enable</Nullable>
-		<LangVersion>10.0</LangVersion>
+		<LangVersion>12</LangVersion>
 		<WarningsAsErrors>nullable</WarningsAsErrors>
 	</PropertyGroup>
 ```

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "7.0.100",
+    "version": "9.0.300",
     "rollForward": "latestFeature"
   }
 }

--- a/src/Cores/Storage/src/FileMetadata/FileMetadataManager.cs
+++ b/src/Cores/Storage/src/FileMetadata/FileMetadataManager.cs
@@ -478,7 +478,7 @@ internal sealed class FileMetadataManager : IAsyncInit, IAsyncDisposable
     internal async Task<ConcurrentDictionary<string, Models.FileMetadata>?> TryGetFileMetadataCacheAsync(CancellationToken cancellationToken)
     {
         var cachedFile = await GetMetadataCacheFile(cancellationToken);
-        using var fileCacheStream = await cachedFile.OpenStreamAsync(cancellationToken: cancellationToken);
+        using var fileCacheStream = await cachedFile.OpenReadAsync(cancellationToken: cancellationToken);
 
         if (fileCacheStream.Length == 0)
             return null;

--- a/src/Cores/Storage/src/FileMetadata/Scanners/AudioMetadataScanner.cs
+++ b/src/Cores/Storage/src/FileMetadata/Scanners/AudioMetadataScanner.cs
@@ -330,7 +330,7 @@ internal static class AudioMetadataScanner
         {
             try
             {
-                using var fileStream = await file.OpenStreamAsync();
+                using var fileStream = await file.OpenReadAsync();
 
                 using var memoryStream = new LazyStream(fileStream);
 
@@ -469,7 +469,7 @@ internal static class AudioMetadataScanner
     {
         // Only scan files supported by taglib
         var mimeType = file.Name.GetMimeType();
-        if (!TagLibHelper.TagLibFileFactory.ContainsKey(mimeType))
+        if (mimeType is null || !TagLibHelper.TagLibFileFactory.ContainsKey(mimeType))
             return null;
 
         Logger.LogInformation($"{nameof(GetTagLibMetadata)} entered for file {file.Id}");

--- a/src/Cores/Storage/src/FileMetadata/Scanners/PlaylistMetadataScanner.Parsers.cs
+++ b/src/Cores/Storage/src/FileMetadata/Scanners/PlaylistMetadataScanner.Parsers.cs
@@ -30,7 +30,7 @@ internal partial class PlaylistMetadataScanner
     {
         var ser = new XmlSerializer(typeof(Smil));
 
-        using var stream = await playlistFile.OpenStreamAsync(cancellationToken: cancellationToken);
+        using var stream = await playlistFile.OpenReadAsync(cancellationToken: cancellationToken);
         using var xmlReader = new XmlTextReader(stream);
 
         var smil = ser.Deserialize(xmlReader) as Smil;
@@ -68,7 +68,7 @@ internal partial class PlaylistMetadataScanner
     /// <remarks>Recognizes both M3U (default encoding) and M3U8 (UTF-8 encoding).</remarks>
     private static async Task<PlaylistMetadata?> GetM3UMetadata(IFile playlistFile, IList<IFile> knownFiles, CancellationToken cancellationToken)
     {
-        using var stream = await playlistFile.OpenStreamAsync(cancellationToken: cancellationToken);
+        using var stream = await playlistFile.OpenReadAsync(cancellationToken: cancellationToken);
 
         using var content = Path.GetExtension(playlistFile.Name) == ".m3u8" ? new StreamReader(stream, Encoding.UTF8) : new StreamReader(stream);
 
@@ -114,7 +114,7 @@ internal partial class PlaylistMetadataScanner
     /// <param name="knownFiles">A list of all known files. If a scanned playlist references a file, it must be traversable and must exist this list.</param>
     private static async Task<PlaylistMetadata?> GetXspfMetadata(IFile playlistFile, IList<IFile> knownFiles, CancellationToken cancellationToken)
     {
-        using var stream = await playlistFile.OpenStreamAsync(cancellationToken: cancellationToken);
+        using var stream = await playlistFile.OpenReadAsync(cancellationToken: cancellationToken);
 
         var doc = XDocument.Load(stream);
         var xmlRoot = doc.Root;
@@ -156,7 +156,7 @@ internal partial class PlaylistMetadataScanner
     /// <remarks>Does not support ENTRYREF.</remarks>
     private static async Task<PlaylistMetadata?> GetAsxMetadata(IFile playlistFile, IList<IFile> knownFiles, CancellationToken cancellationToken)
     {
-        using var stream = await playlistFile.OpenStreamAsync(cancellationToken: cancellationToken);
+        using var stream = await playlistFile.OpenReadAsync(cancellationToken: cancellationToken);
 
         var doc = XDocument.Load(stream);
         var asx = doc.Root;
@@ -190,7 +190,7 @@ internal partial class PlaylistMetadataScanner
     /// <param name="knownFiles">A list of all known files. If a scanned playlist references a file, it must be traversable and must exist this list.</param>
     private static async Task<PlaylistMetadata?> GetMpcplMetadata(IFile playlistFile, IList<IFile> knownFiles, CancellationToken cancellationToken)
     {
-        using var stream = await playlistFile.OpenStreamAsync(cancellationToken: cancellationToken);
+        using var stream = await playlistFile.OpenReadAsync(cancellationToken: cancellationToken);
         using var content = new StreamReader(stream);
 
         var playlist = new PlaylistMetadata();
@@ -244,7 +244,7 @@ internal partial class PlaylistMetadataScanner
                 0xE1, 0xA0, 0x9C, 0x91, 0xF8, 0x3C, 0x77, 0x42, 0x85, 0x2C, 0x3B, 0xCC, 0x14, 0x01, 0xD3, 0xF2
             };
 
-            using var stream = await playlistFile.OpenStreamAsync(cancellationToken: cancellationToken);
+            using var stream = await playlistFile.OpenReadAsync(cancellationToken: cancellationToken);
             using var content = new BinaryReader(stream);
 
             var playlist = new PlaylistMetadata()
@@ -394,7 +394,7 @@ internal partial class PlaylistMetadataScanner
     /// <param name="knownFiles">A list of all known files. If a scanned playlist references a file, it must be traversable and must exist this list.</param>
     private static async Task<PlaylistMetadata?> GetPlsMetadata(IFile playlistFile, IList<IFile> knownFiles, CancellationToken cancellationToken)
     {
-        using var stream = await playlistFile.OpenStreamAsync(cancellationToken: cancellationToken);
+        using var stream = await playlistFile.OpenReadAsync(cancellationToken: cancellationToken);
         using var content = new StreamReader(stream);
 
         var playlist = new PlaylistMetadata()
@@ -447,7 +447,7 @@ internal partial class PlaylistMetadataScanner
     private static async Task<PlaylistMetadata?> GetAimpplMetadata(IFile playlistFile, IList<IFile> knownFiles, CancellationToken cancellationToken)
     {
         // Adapted from https://github.com/ApexWeed/aimppl-copy/
-        using var stream = await playlistFile.OpenStreamAsync(cancellationToken: cancellationToken);
+        using var stream = await playlistFile.OpenReadAsync(cancellationToken: cancellationToken);
         using var content = new StreamReader(stream);
 
         var playlist = new PlaylistMetadata()

--- a/src/Cores/Storage/src/StorageCore.cs
+++ b/src/Cores/Storage/src/StorageCore.cs
@@ -225,6 +225,8 @@ public sealed class StorageCore : ICore
             return null;
         }
 
+        Guard.IsNotNull(mimeType);
+
         var stream = await file.OpenStreamAsync(FileAccess.Read, cancellationToken);
 
         if (!stream.CanSeek)

--- a/src/Cores/Storage/src/StrixMusic.Cores.Storage.csproj
+++ b/src/Cores/Storage/src/StrixMusic.Cores.Storage.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>10</LangVersion>
+    <LangVersion>12</LangVersion>
     <Nullable>enable</Nullable>
     <AssemblyVersion>0.1.0</AssemblyVersion>
 
@@ -39,12 +39,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OwlCore" Version="0.4.0" />
+    <PackageReference Include="OwlCore" Version="0.6.1" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.Text.Json" Version="7.0.2" />
+    <PackageReference Include="System.Text.Json" Version="9.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Cores/Storage/test/StrixMusic.Cores.Storage.Tests/StrixMusic.Cores.Storage.Tests.csproj
+++ b/src/Cores/Storage/test/StrixMusic.Cores.Storage.Tests/StrixMusic.Cores.Storage.Tests.csproj
@@ -9,9 +9,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-        <PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />
-        <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
+        <PackageReference Include="MSTest.TestAdapter" Version="3.9.0" />
+        <PackageReference Include="MSTest.TestFramework" Version="3.9.0" />
         <PackageReference Include="coverlet.collector" Version="3.2.0">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
     <PropertyGroup>
         <Nullable>enable</Nullable>
-        <LangVersion>10.0</LangVersion>
+        <LangVersion>12</LangVersion>
         <WarningsAsErrors>nullable</WarningsAsErrors>
     </PropertyGroup>
 </Project>

--- a/src/Libs/OwlCore.WinUI/Collections/IncrementalLoadingCollection.cs
+++ b/src/Libs/OwlCore.WinUI/Collections/IncrementalLoadingCollection.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Threading;
 using System.Threading.Tasks;
+using CommunityToolkit.Diagnostics;
 using OwlCore.Collections.ObjectModel;
 using Windows.Foundation;
 using Windows.UI.Core;
@@ -67,6 +68,7 @@ namespace OwlCore.WinUI.Collections
         /// <returns>An asynchronous operation that results in the <see cref="LoadMoreItemsResult"/>.</returns>
         public IAsyncOperation<LoadMoreItemsResult> LoadMoreItemsAsync(uint count)
         {
+            Guard.IsNotNull(Window.Current);
             CoreDispatcher dispatcher = Window.Current.Dispatcher;
             _onBatchStart?.Invoke(); // This is the UI thread
 

--- a/src/Libs/OwlCore.WinUI/OwlCore.WinUI.csproj
+++ b/src/Libs/OwlCore.WinUI/OwlCore.WinUI.csproj
@@ -1,20 +1,20 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras/3.0.23">
   <PropertyGroup>
-    <TargetFrameworks>uap10.0.19041;net7.0</TargetFrameworks>
+    <TargetFrameworks>uap10.0.19041;net9.0</TargetFrameworks>
     <!-- Ensures the .xr.xml files are generated in a proper layout folder -->
     <GenerateLibraryLayout>true</GenerateLibraryLayout>
     <Nullable>enable</Nullable>
-    <LangVersion>10</LangVersion>
+    <LangVersion>12</LangVersion>
     <WarningsAsErrors>nullable</WarningsAsErrors>
     <UserSecretsId>6fa950de-976e-453b-bfcb-f0abe43fa342</UserSecretsId>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ClusterNet" Version="0.0.3-alpha" />
-    <PackageReference Include="OwlCore" Version="0.4.0" />
+    <PackageReference Include="OwlCore" Version="0.6.1" />
     <PackageReference Include="OwlCore.AbstractUI" Version="0.0.0" />
     <PackageReference Include="SixLabors.ImageSharp" Version="2.1.3" />
-    <PackageReference Include="System.Text.Json" Version="7.0.2" />
-    <PackageReference Include="Uno.UI" Version="4.8.33" />
+    <PackageReference Include="System.Text.Json" Version="9.0.5" />
+    <PackageReference Include="Uno.UI" Version="5.6.99" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'uap10.0.19041'">
     <PackageReference Include="Microsoft.Toolkit.Uwp.UI" Version="7.1.3" />

--- a/src/Libs/OwlCore.WinUI/Threading/UiTaskMethodBuilder.cs
+++ b/src/Libs/OwlCore.WinUI/Threading/UiTaskMethodBuilder.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Runtime.CompilerServices;
+using CommunityToolkit.Diagnostics;
 using Windows.UI.Core;
 using Windows.UI.Xaml;
 
@@ -45,6 +46,7 @@ namespace OwlCore.WinUI.Threading
         /// <returns></returns>
         public static UiTaskMethodBuilder Create()
         {
+            Guard.IsNotNull(Window.Current);
             return new UiTaskMethodBuilder(Window.Current.Dispatcher);
         }
 

--- a/src/Platforms/StrixMusic.UWP/StrixMusic.UWP.csproj
+++ b/src/Platforms/StrixMusic.UWP/StrixMusic.UWP.csproj
@@ -2,32 +2,32 @@
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12</LangVersion>
     <PackageCertificateThumbprint>828E42B157F3BFACA11AE265A50B17A4FC07EDD2</PackageCertificateThumbprint>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.Uwp.Controls.Sizers">
-      <Version>8.0.240109</Version>
+      <Version>8.2.250402</Version>
     </PackageReference>
-    <PackageReference Include="Microsoft.Windows.Compatibility" Version="7.0.1" />
+    <PackageReference Include="Microsoft.Windows.Compatibility" Version="9.0.5" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
     <PackageReference Include="OwlCore.Kubo">
-      <Version>0.12.5</Version>
+      <Version>0.20.2</Version>
     </PackageReference>
     <PackageReference Include="OwlCore.Storage">
-      <Version>0.8.5</Version>
+      <Version>0.12.2</Version>
     </PackageReference>
     <PackageReference Include="CommunityToolkit.Common">
-      <Version>8.2.0</Version>
+      <Version>8.4.0</Version>
     </PackageReference>
     <PackageReference Include="CommunityToolkit.Diagnostics">
-      <Version>8.2.0</Version>
+      <Version>8.4.0</Version>
     </PackageReference>
     <PackageReference Include="CommunityToolkit.Uwp.Controls.SettingsControls">
-      <Version>0.0.18</Version>
+      <Version>8.2.250402</Version>
     </PackageReference>
     <PackageReference Include="CommunityToolkit.Mvvm">
-      <Version>8.2.0</Version>
+      <Version>8.4.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
       <!-- 
@@ -47,22 +47,22 @@
       <Version>2.0.3</Version>
     </PackageReference>
     <PackageReference Include="NLog">
-      <Version>5.1.4</Version>
+      <Version>5.4.0</Version>
     </PackageReference>
     <PackageReference Include="NLog.Extensions.Logging">
-      <Version>5.2.3</Version>
+      <Version>5.4.0</Version>
     </PackageReference>
     <PackageReference Include="OwlCore">
-      <Version>0.4.0</Version>
+      <Version>0.6.1</Version>
     </PackageReference>
     <PackageReference Include="OwlCore.ComponentModel">
-      <Version>0.3.0</Version>
+      <Version>0.9.1</Version>
     </PackageReference>
     <PackageReference Include="OwlCore.Storage.OneDrive">
-      <Version>0.2.0</Version>
+      <Version>0.2.1</Version>
     </PackageReference>
     <PackageReference Include="OwlCore.Storage.Uwp">
-      <Version>0.1.0</Version>
+      <Version>0.2.0</Version>
     </PackageReference>
     <PackageReference Include="StyleCop.Analyzers">
       <Version>1.1.118</Version>
@@ -73,7 +73,7 @@
       <Version>6.0.1</Version>
     </PackageReference>
     <PackageReference Include="System.Text.Json">
-      <Version>7.0.2</Version>
+      <Version>9.0.5</Version>
     </PackageReference>
   </ItemGroup>
   <PropertyGroup>

--- a/src/Platforms/StrixMusic.Wasm/StrixMusic.Wasm.csproj
+++ b/src/Platforms/StrixMusic.Wasm/StrixMusic.Wasm.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <NoWarn>NU1701</NoWarn>
     <WasmPWAManifestFile>manifest.webmanifest</WasmPWAManifestFile>
     <WasmShellMonoRuntimeExecutionMode>Interpreter</WasmShellMonoRuntimeExecutionMode>
@@ -28,6 +28,13 @@
     <Content Include="Assets\SplashScreen.png" />
     <Content Include="manifest.webmanifest" />
     <Content Include="Assets\AppIcon-*.png" />
+    
+    <!--
+    Excluded until conflicting asset errors can be fixed
+    Only needed for SharedArrayBuffer (multithreading) service worker support.
+    See also https://platform.uno/docs/articles/external/uno.wasm.bootstrap/doc/features-additional-files.html
+    -->
+    <Content Remove="wwwroot\index.html" />
   </ItemGroup>
 
   <ItemGroup>
@@ -48,39 +55,39 @@
     <None Include="wwwroot\web.config" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="CommunityToolkit.Labs.Uwp.SizerBase" Version="0.0.4" />
-    <PackageReference Include="OwlCore.Kubo" Version="0.12.5" />
-    <PackageReference Include="OwlCore.Storage" Version="0.8.5" />
-    <PackageReference Include="System.Text.Json" Version="7.0.2" />
-    <PackageReference Include="CommunityToolkit.Common" Version="8.2.0" />
-    <PackageReference Include="CommunityToolkit.Diagnostics" Version="8.2.0" />
-    <PackageReference Include="CommunityToolkit.Labs.Uwp.CanvasView" Version="0.0.2" />
-    <PackageReference Include="CommunityToolkit.Labs.Uwp.SettingsControls" Version="0.0.18" />
-    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.0" />
-    <PackageReference Include="OwlCore" Version="0.4.0" />
-    <PackageReference Include="OwlCore.ComponentModel" Version="0.3.0" />
-    <PackageReference Include="OwlCore.Storage.Uwp" Version="0.1.0" />
-    <PackageReference Include="OwlCore.Storage.OneDrive" Version="0.2.0" />
+    <PackageReference Include="CommunityToolkit.Uwp.Controls.Sizers" Version="8.2.250402" />
+    <PackageReference Include="OwlCore.Kubo" Version="0.20.2" />
+    <PackageReference Include="OwlCore.Storage" Version="0.12.2" />
+    <PackageReference Include="System.Text.Json" Version="9.0.5" />
+    <PackageReference Include="CommunityToolkit.Common" Version="8.4.0" />
+    <PackageReference Include="CommunityToolkit.Diagnostics" Version="8.4.0" />
+    <PackageReference Include="CommunityToolkit.Labs.Uwp.CanvasView" Version="0.1.250319-build.2093" />
+    <PackageReference Include="CommunityToolkit.Uwp.Controls.SettingsControls" Version="8.2.250402" />
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
+    <PackageReference Include="OwlCore" Version="0.6.1" />
+    <PackageReference Include="OwlCore.ComponentModel" Version="0.9.1" />
+    <PackageReference Include="OwlCore.Storage.Uwp" Version="0.2.0" />
+    <PackageReference Include="OwlCore.Storage.OneDrive" Version="0.2.1" />
 
-    <PackageReference Include="NLog" Version="5.1.4" />
-    <PackageReference Include="NLog.Extensions.Logging" Version="5.2.3" />
+    <PackageReference Include="NLog" Version="5.4.0" />
+    <PackageReference Include="NLog.Extensions.Logging" Version="5.4.0" />
     <PackageReference Include="Uno.Microsoft.Toolkit.Uwp.UI" Version="7.1.11" />
     <PackageReference Include="Uno.Microsoft.Toolkit.Uwp.UI.Animations" Version="7.1.11" />
     <PackageReference Include="Uno.Microsoft.Toolkit.Uwp.UI.Controls" Version="7.1.11" />
 
-    <PackageReference Include="Uno.Microsoft.Xaml.Behaviors.Interactivity" Version="2.3.1-uno.2" />
-    <PackageReference Include="Uno.Microsoft.Xaml.Behaviors.Uwp.Managed" Version="2.3.1-uno.2" />
+    <PackageReference Include="Uno.Microsoft.Xaml.Behaviors.Interactivity" Version="3.0.3" />
+    <PackageReference Include="Uno.Microsoft.Xaml.Behaviors.Uwp.Managed" Version="2.4.2" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Windows.Compatibility" Version="7.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
-    <PackageReference Include="Uno.Extensions.Logging.WebAssembly.Console" Version="1.4.0" />
+    <PackageReference Include="Microsoft.Windows.Compatibility" Version="9.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.5" />
+    <PackageReference Include="Uno.Extensions.Logging.WebAssembly.Console" Version="1.7.0" />
     <PackageReference Include="Uno.SourceGeneration" Version="4.2.0" />
-    <PackageReference Include="Uno.UI.WebAssembly" Version="4.8.33" />
-    <PackageReference Include="Uno.UI.RemoteControl" Version="4.8.33" Condition="'$(Configuration)'=='Debug'" />
-    <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.8.33" />
-    <PackageReference Include="Uno.Wasm.Bootstrap" Version="7.0.24" />
-    <PackageReference Include="Uno.Wasm.Bootstrap.DevServer" Version="7.0.24" />
+    <PackageReference Include="Uno.UI.WebAssembly" Version="5.6.99" />
+    <PackageReference Include="Uno.UI.RemoteControl" Version="5.6.99" Condition="'$(Configuration)'=='Debug'" />
+    <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="6.0.611" />
+    <PackageReference Include="Uno.Wasm.Bootstrap" Version="9.0.19" />
+    <PackageReference Include="Uno.Wasm.Bootstrap.DevServer" Version="9.0.19" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Cores\Storage\src\StrixMusic.Cores.Storage.csproj" />

--- a/src/Sdk/StrixMusic.Sdk.Tests/StrixMusic.Sdk.Tests.csproj
+++ b/src/Sdk/StrixMusic.Sdk.Tests/StrixMusic.Sdk.Tests.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <WarningsAsErrors>nullable</WarningsAsErrors>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12</LangVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
@@ -18,15 +18,15 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.9.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.9.0" />
     <PackageReference Include="coverlet.collector" Version="3.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="OwlCore" Version="0.4.0" />
-    <PackageReference Include="System.Text.Json" Version="7.0.2" />
+    <PackageReference Include="OwlCore" Version="0.6.1" />
+    <PackageReference Include="System.Text.Json" Version="9.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Sdk/StrixMusic.Sdk.WinUI/Converters/Units/CountToAlbumsConverter.cs
+++ b/src/Sdk/StrixMusic.Sdk.WinUI/Converters/Units/CountToAlbumsConverter.cs
@@ -19,7 +19,7 @@ namespace StrixMusic.Sdk.WinUI.Converters.Units
         {
             return LocalizationResources.Music is null ?
                 value.ToString() :
-                string.Format(LocalizationResources.Music.GetString("AlbumsCount"), value);
+                string.Format(LocalizationResources.Music.GetString("AlbumsCount") ?? string.Empty, value);
         }
 
         /// <inheritdoc/>

--- a/src/Sdk/StrixMusic.Sdk.WinUI/Converters/Units/CountToArtistsConverter.cs
+++ b/src/Sdk/StrixMusic.Sdk.WinUI/Converters/Units/CountToArtistsConverter.cs
@@ -19,7 +19,7 @@ namespace StrixMusic.Sdk.WinUI.Converters.Units
         {
             return LocalizationResources.Music is null ?
                 value.ToString() :
-                string.Format(LocalizationResources.Music.GetString("ArtistsCount"), value);
+                string.Format(LocalizationResources.Music.GetString("ArtistsCount") ?? string.Empty, value);
         }
 
         /// <inheritdoc/>

--- a/src/Sdk/StrixMusic.Sdk.WinUI/Converters/Units/CountToPlaylistsConverter.cs
+++ b/src/Sdk/StrixMusic.Sdk.WinUI/Converters/Units/CountToPlaylistsConverter.cs
@@ -19,7 +19,7 @@ namespace StrixMusic.Sdk.WinUI.Converters.Units
         {
             return LocalizationResources.Music is null ?
                 value.ToString() :
-                string.Format(LocalizationResources.Music.GetString("PlaylistsCount"), value);
+                string.Format(LocalizationResources.Music.GetString("PlaylistsCount") ?? string.Empty, value);
         }
 
         /// <inheritdoc/>

--- a/src/Sdk/StrixMusic.Sdk.WinUI/Converters/Units/CountToSongsConverter.cs
+++ b/src/Sdk/StrixMusic.Sdk.WinUI/Converters/Units/CountToSongsConverter.cs
@@ -18,7 +18,7 @@ namespace StrixMusic.Sdk.WinUI.Converters.Units
         {
             return LocalizationResources.Music is null ?
                 value.ToString() :
-                string.Format(LocalizationResources.Music.GetString("SongsCount"), value);
+                string.Format(LocalizationResources.Music.GetString("SongsCount") ?? string.Empty, value);
         }
 
         /// <inheritdoc/>

--- a/src/Sdk/StrixMusic.Sdk.WinUI/StrixMusic.Sdk.WinUI.csproj
+++ b/src/Sdk/StrixMusic.Sdk.WinUI/StrixMusic.Sdk.WinUI.csproj
@@ -1,18 +1,18 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras/3.0.23">
   <PropertyGroup>
-    <TargetFrameworks>uap10.0.19041;net7.0</TargetFrameworks>
+    <TargetFrameworks>uap10.0.19041;net9.0</TargetFrameworks>
     <!-- Ensures the .xr.xml files are generated in a proper layout folder -->
     <GenerateLibraryLayout>true</GenerateLibraryLayout>
     <AssemblyName>StrixMusic.Sdk.WinUI</AssemblyName>
     <RootNamespace>StrixMusic.Sdk.WinUI</RootNamespace>
     <Nullable>enable</Nullable>
     <WarningsAsErrors>nullable</WarningsAsErrors>
-    <LangVersion>10</LangVersion>
+    <LangVersion>12</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="OwlCore" Version="0.4.0" />
-    <PackageReference Include="System.Text.Json" Version="7.0.2" />
-    <PackageReference Include="Uno.UI" Version="4.8.33" />
+    <PackageReference Include="OwlCore" Version="0.6.1" />
+    <PackageReference Include="System.Text.Json" Version="9.0.5" />
+    <PackageReference Include="Uno.UI" Version="5.6.99" />
   </ItemGroup>
   <ItemGroup>
     <Page Include="**\*.xaml" Exclude="bin\**\*.xaml;obj\**\*.xaml" />
@@ -156,7 +156,7 @@
     <PackageReference Include="Microsoft.Xaml.Behaviors.Uwp.Managed">
       <Version>2.0.1</Version>
     </PackageReference>
-    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.0" />
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' != 'uap10.0.19041'">
     <PackageReference Include="Uno.UI" Version="4.8.15" />

--- a/src/Sdk/StrixMusic.Sdk/Plugins/Model/AlbumCollectionPluginBase.cs
+++ b/src/Sdk/StrixMusic.Sdk/Plugins/Model/AlbumCollectionPluginBase.cs
@@ -18,7 +18,7 @@ namespace StrixMusic.Sdk.Plugins.Model
     /// An implementation of <see cref="IAlbumCollection"/> which delegates all member access to the <see cref="Inner"/> implementation,
     /// unless the member is overridden in a derived class which changes the behavior.
     /// </summary>
-    public class AlbumCollectionPluginBase : IModelPlugin, IAlbumCollection, IDelegatable<IAlbumCollection>
+    public class AlbumCollectionPluginBase : IModelPlugin, IAlbumCollection, IDelegable<IAlbumCollection>
     {
         /// <summary>
         /// Creates a new instance of <see cref="AlbumCollectionPluginBase"/>.

--- a/src/Sdk/StrixMusic.Sdk/Plugins/Model/AlbumPluginBase.cs
+++ b/src/Sdk/StrixMusic.Sdk/Plugins/Model/AlbumPluginBase.cs
@@ -18,7 +18,7 @@ namespace StrixMusic.Sdk.Plugins.Model
     /// An implementation of <see cref="IAlbum"/> which delegates all member access to the <see cref="Inner"/> implementation,
     /// unless the member is overridden in a derived class which changes the behavior.
     /// </summary>
-    public class AlbumPluginBase : IModelPlugin, IAlbum, IDelegatable<IAlbum>
+    public class AlbumPluginBase : IModelPlugin, IAlbum, IDelegable<IAlbum>
     {
         /// <summary>
         /// Creates a new instance of <see cref="AlbumPluginBase"/>.

--- a/src/Sdk/StrixMusic.Sdk/Plugins/Model/ArtistCollectionPluginBase.cs
+++ b/src/Sdk/StrixMusic.Sdk/Plugins/Model/ArtistCollectionPluginBase.cs
@@ -18,7 +18,7 @@ namespace StrixMusic.Sdk.Plugins.Model
     /// An implementation of <see cref="IArtistCollection"/> which delegates all member access to the <see cref="Inner"/> implementation,
     /// unless the member is overridden in a derived class which changes the behavior.
     /// </summary>
-    public class ArtistCollectionPluginBase : IModelPlugin, IArtistCollection, IDelegatable<IArtistCollection>
+    public class ArtistCollectionPluginBase : IModelPlugin, IArtistCollection, IDelegable<IArtistCollection>
     {
         /// <summary>
         /// Creates a new instance of <see cref="ArtistCollectionPluginBase"/>.

--- a/src/Sdk/StrixMusic.Sdk/Plugins/Model/ArtistPluginBase.cs
+++ b/src/Sdk/StrixMusic.Sdk/Plugins/Model/ArtistPluginBase.cs
@@ -18,7 +18,7 @@ namespace StrixMusic.Sdk.Plugins.Model
     /// An implementation of <see cref="IArtist"/> which delegates all member access to the <see cref="Inner"/> implementation,
     /// unless the member is overridden in a derived class which changes the behavior.
     /// </summary>
-    public class ArtistPluginBase : IModelPlugin, IArtist, IDelegatable<IArtist>
+    public class ArtistPluginBase : IModelPlugin, IArtist, IDelegable<IArtist>
     {
         /// <summary>
         /// Creates a new instance of <see cref="ArtistPluginBase"/>.

--- a/src/Sdk/StrixMusic.Sdk/Plugins/Model/DiscoverablesPluginBase.cs
+++ b/src/Sdk/StrixMusic.Sdk/Plugins/Model/DiscoverablesPluginBase.cs
@@ -14,7 +14,7 @@ namespace StrixMusic.Sdk.Plugins.Model;
 /// An implementation of <see cref="IDiscoverables"/> which delegates all member access to the <see cref="Inner"/> implementation,
 /// unless the member is overridden in a derived class which changes the behavior.
 /// </summary>
-public class DiscoverablesPluginBase : PlayableCollectionGroupPluginBase, IModelPlugin, IDiscoverables, IDelegatable<IDiscoverables>
+public class DiscoverablesPluginBase : PlayableCollectionGroupPluginBase, IModelPlugin, IDiscoverables, IDelegable<IDiscoverables>
 {
     /// <summary>
     /// Creates a new instance of <see cref="PlayableCollectionGroupPluginBase"/>.

--- a/src/Sdk/StrixMusic.Sdk/Plugins/Model/DownloadablePluginBase.cs
+++ b/src/Sdk/StrixMusic.Sdk/Plugins/Model/DownloadablePluginBase.cs
@@ -14,7 +14,7 @@ namespace StrixMusic.Sdk.Plugins.Model
     /// An implementation of <see cref="IDownloadable"/> which delegates all member access to the <see cref="Inner"/> implementation,
     /// unless the member is overridden in a derived class which changes the behavior.
     /// </summary>
-    public class DownloadablePluginBase : IModelPlugin, IDownloadable, IDelegatable<IDownloadable>
+    public class DownloadablePluginBase : IModelPlugin, IDownloadable, IDelegable<IDownloadable>
     {
         /// <summary>
         /// Creates a new instance of <see cref="DownloadablePluginBase"/>.

--- a/src/Sdk/StrixMusic.Sdk/Plugins/Model/GenreCollectionPluginBase.cs
+++ b/src/Sdk/StrixMusic.Sdk/Plugins/Model/GenreCollectionPluginBase.cs
@@ -16,7 +16,7 @@ namespace StrixMusic.Sdk.Plugins.Model
     /// An implementation of <see cref="IGenreCollection"/> which delegates all member access to the <see cref="Inner"/> implementation,
     /// unless the member is overridden in a derived class which changes the behavior.
     /// </summary>
-    public class GenreCollectionPluginBase : IModelPlugin, IGenreCollection, IDelegatable<IGenreCollection>
+    public class GenreCollectionPluginBase : IModelPlugin, IGenreCollection, IDelegable<IGenreCollection>
     {
         /// <summary>
         /// Creates a new instance of <see cref="GenreCollectionPluginBase"/>.

--- a/src/Sdk/StrixMusic.Sdk/Plugins/Model/ImageCollectionPluginBase.cs
+++ b/src/Sdk/StrixMusic.Sdk/Plugins/Model/ImageCollectionPluginBase.cs
@@ -16,7 +16,7 @@ namespace StrixMusic.Sdk.Plugins.Model
     /// An implementation of <see cref="IImageCollection"/> which delegates all member access to the <see cref="Inner"/> implementation,
     /// unless the member is overridden in a derived class which changes the behavior.
     /// </summary>
-    public class ImageCollectionPluginBase : IModelPlugin, IImageCollection, IDelegatable<IImageCollection>
+    public class ImageCollectionPluginBase : IModelPlugin, IImageCollection, IDelegable<IImageCollection>
     {
         /// <summary>
         /// Creates a new instance of <see cref="ImageCollectionPluginBase"/>.

--- a/src/Sdk/StrixMusic.Sdk/Plugins/Model/ImagePluginBase.cs
+++ b/src/Sdk/StrixMusic.Sdk/Plugins/Model/ImagePluginBase.cs
@@ -16,7 +16,7 @@ namespace StrixMusic.Sdk.Plugins.Model
     /// An implementation of <see cref="IImage"/> which delegates all member access to the <see cref="Inner"/> implementation,
     /// unless the member is overridden in a derived class which changes the behavior.
     /// </summary>
-    public class ImagePluginBase : IModelPlugin, IImage, IDelegatable<IImage>
+    public class ImagePluginBase : IModelPlugin, IImage, IDelegable<IImage>
     {
         /// <summary>
         /// Creates a new instance of <see cref="ImagePluginBase"/>.

--- a/src/Sdk/StrixMusic.Sdk/Plugins/Model/LibraryPluginBase.cs
+++ b/src/Sdk/StrixMusic.Sdk/Plugins/Model/LibraryPluginBase.cs
@@ -14,7 +14,7 @@ namespace StrixMusic.Sdk.Plugins.Model;
 /// An implementation of <see cref="ILibrary"/> which delegates all member access to the <see cref="Inner"/> implementation,
 /// unless the member is overridden in a derived class which changes the behavior.
 /// </summary>
-public class LibraryPluginBase : PlayableCollectionGroupPluginBase, IModelPlugin, ILibrary, IDelegatable<ILibrary>
+public class LibraryPluginBase : PlayableCollectionGroupPluginBase, IModelPlugin, ILibrary, IDelegable<ILibrary>
 {
     /// <summary>
     /// Creates a new instance of <see cref="PlayableCollectionGroupPluginBase"/>.

--- a/src/Sdk/StrixMusic.Sdk/Plugins/Model/LyricsPluginBase.cs
+++ b/src/Sdk/StrixMusic.Sdk/Plugins/Model/LyricsPluginBase.cs
@@ -14,7 +14,7 @@ namespace StrixMusic.Sdk.Plugins.Model
     /// An implementation of <see cref="ILyrics"/> which delegates all member access to the <see cref="Inner"/> implementation,
     /// unless the member is overridden in a derived class which changes the behavior.
     /// </summary>
-    public class LyricsPluginBase : IModelPlugin, ILyrics, IDelegatable<ILyrics>
+    public class LyricsPluginBase : IModelPlugin, ILyrics, IDelegable<ILyrics>
     {
         /// <summary>
         /// Creates a new instance of <see cref="LyricsPluginBase"/>.

--- a/src/Sdk/StrixMusic.Sdk/Plugins/Model/PlayableCollectionGroupPluginBase.cs
+++ b/src/Sdk/StrixMusic.Sdk/Plugins/Model/PlayableCollectionGroupPluginBase.cs
@@ -18,7 +18,7 @@ namespace StrixMusic.Sdk.Plugins.Model
     /// An implementation of <see cref="IPlayableCollectionGroup"/> which delegates all member access to the <see cref="Inner"/> implementation,
     /// unless the member is overridden in a derived class which changes the behavior.
     /// </summary>
-    public class PlayableCollectionGroupPluginBase : IModelPlugin, IPlayableCollectionGroup, IDelegatable<IPlayableCollectionGroup>
+    public class PlayableCollectionGroupPluginBase : IModelPlugin, IPlayableCollectionGroup, IDelegable<IPlayableCollectionGroup>
     {
         /// <summary>
         /// Creates a new instance of <see cref="PlayableCollectionGroupPluginBase"/>.

--- a/src/Sdk/StrixMusic.Sdk/Plugins/Model/PlayablePluginBase.cs
+++ b/src/Sdk/StrixMusic.Sdk/Plugins/Model/PlayablePluginBase.cs
@@ -18,7 +18,7 @@ namespace StrixMusic.Sdk.Plugins.Model
     /// An implementation of <see cref="IPlayable"/> which delegates all member access to the <see cref="Inner"/> implementation,
     /// unless the member is overridden in a derived class which changes the behavior.
     /// </summary>
-    public class PlayablePluginBase : IModelPlugin, IPlayable, IDelegatable<IPlayable>
+    public class PlayablePluginBase : IModelPlugin, IPlayable, IDelegable<IPlayable>
     {
         /// <summary>
         /// Creates a new instance of <see cref="PlayablePluginBase"/>.

--- a/src/Sdk/StrixMusic.Sdk/Plugins/Model/PlaylistCollectionPluginBase.cs
+++ b/src/Sdk/StrixMusic.Sdk/Plugins/Model/PlaylistCollectionPluginBase.cs
@@ -18,7 +18,7 @@ namespace StrixMusic.Sdk.Plugins.Model
     /// An implementation of <see cref="IPlaylistCollection"/> which delegates all member access to the <see cref="Inner"/> implementation,
     /// unless the member is overridden in a derived class which changes the behavior.
     /// </summary>
-    public class PlaylistCollectionPluginBase : IModelPlugin, IPlaylistCollection, IDelegatable<IPlaylistCollection>
+    public class PlaylistCollectionPluginBase : IModelPlugin, IPlaylistCollection, IDelegable<IPlaylistCollection>
     {
         /// <summary>
         /// Creates a new instance of <see cref="PlaylistCollectionPluginBase"/>.

--- a/src/Sdk/StrixMusic.Sdk/Plugins/Model/PlaylistPluginBase.cs
+++ b/src/Sdk/StrixMusic.Sdk/Plugins/Model/PlaylistPluginBase.cs
@@ -18,7 +18,7 @@ namespace StrixMusic.Sdk.Plugins.Model
     /// An implementation of <see cref="IPlaylist"/> which delegates all member access to the <see cref="Inner"/> implementation,
     /// unless the member is overridden in a derived class which changes the behavior.
     /// </summary>
-    public class PlaylistPluginBase : IModelPlugin, IPlaylist, IDelegatable<IPlaylist>
+    public class PlaylistPluginBase : IModelPlugin, IPlaylist, IDelegable<IPlaylist>
     {
         /// <summary>
         /// Creates a new instance of <see cref="PlaylistPluginBase"/>.

--- a/src/Sdk/StrixMusic.Sdk/Plugins/Model/RecentlyPlayedPluginBase.cs
+++ b/src/Sdk/StrixMusic.Sdk/Plugins/Model/RecentlyPlayedPluginBase.cs
@@ -14,7 +14,7 @@ namespace StrixMusic.Sdk.Plugins.Model;
 /// An implementation of <see cref="IRecentlyPlayed"/> which delegates all member access to the <see cref="Inner"/> implementation,
 /// unless the member is overridden in a derived class which changes the behavior.
 /// </summary>
-public class RecentlyPlayedPluginBase : PlayableCollectionGroupPluginBase, IModelPlugin, IRecentlyPlayed, IDelegatable<IRecentlyPlayed>
+public class RecentlyPlayedPluginBase : PlayableCollectionGroupPluginBase, IModelPlugin, IRecentlyPlayed, IDelegable<IRecentlyPlayed>
 {
     /// <summary>
     /// Creates a new instance of <see cref="PlayableCollectionGroupPluginBase"/>.

--- a/src/Sdk/StrixMusic.Sdk/Plugins/Model/SearchHistoryPluginBase.cs
+++ b/src/Sdk/StrixMusic.Sdk/Plugins/Model/SearchHistoryPluginBase.cs
@@ -14,7 +14,7 @@ namespace StrixMusic.Sdk.Plugins.Model;
 /// An implementation of <see cref="ISearchHistory"/> which delegates all member access to the <see cref="Inner"/> implementation,
 /// unless the member is overridden in a derived class which changes the behavior.
 /// </summary>
-public class SearchHistoryPluginBase : PlayableCollectionGroupPluginBase, IModelPlugin, ISearchHistory, IDelegatable<ISearchHistory>
+public class SearchHistoryPluginBase : PlayableCollectionGroupPluginBase, IModelPlugin, ISearchHistory, IDelegable<ISearchHistory>
 {
     /// <summary>
     /// Creates a new instance of <see cref="PlayableCollectionGroupPluginBase"/>.

--- a/src/Sdk/StrixMusic.Sdk/Plugins/Model/SearchResultsPluginBase.cs
+++ b/src/Sdk/StrixMusic.Sdk/Plugins/Model/SearchResultsPluginBase.cs
@@ -14,7 +14,7 @@ namespace StrixMusic.Sdk.Plugins.Model;
 /// An implementation of <see cref="ISearchResults"/> which delegates all member access to the <see cref="Inner"/> implementation,
 /// unless the member is overridden in a derived class which changes the behavior.
 /// </summary>
-public class SearchResultsPluginBase : PlayableCollectionGroupPluginBase, IModelPlugin, ISearchResults, IDelegatable<ISearchResults>
+public class SearchResultsPluginBase : PlayableCollectionGroupPluginBase, IModelPlugin, ISearchResults, IDelegable<ISearchResults>
 {
     /// <summary>
     /// Creates a new instance of <see cref="PlayableCollectionGroupPluginBase"/>.

--- a/src/Sdk/StrixMusic.Sdk/Plugins/Model/StrixDataRootPluginBase.cs
+++ b/src/Sdk/StrixMusic.Sdk/Plugins/Model/StrixDataRootPluginBase.cs
@@ -17,7 +17,7 @@ namespace StrixMusic.Sdk.Plugins.Model
     /// An implementation of <see cref="IStrixDataRoot"/> which delegates all member access to the <see cref="Inner"/> implementation,
     /// unless the member is overridden in a derived class which changes the behavior.
     /// </summary>
-    public class StrixDataRootPluginBase : IModelPlugin, IStrixDataRoot, IDelegatable<IStrixDataRoot>
+    public class StrixDataRootPluginBase : IModelPlugin, IStrixDataRoot, IDelegable<IStrixDataRoot>
     {
         /// <summary>
         /// Creates a new instance of <see cref="ImagePluginBase"/>.

--- a/src/Sdk/StrixMusic.Sdk/Plugins/Model/TrackCollectionPluginBase.cs
+++ b/src/Sdk/StrixMusic.Sdk/Plugins/Model/TrackCollectionPluginBase.cs
@@ -18,7 +18,7 @@ namespace StrixMusic.Sdk.Plugins.Model
     /// An implementation of <see cref="ITrackCollection"/> which delegates all member access to the <see cref="Inner"/> implementation,
     /// unless the member is overridden in a derived class which changes the behavior.
     /// </summary>
-    public class TrackCollectionPluginBase : IModelPlugin, ITrackCollection, IDelegatable<ITrackCollection>
+    public class TrackCollectionPluginBase : IModelPlugin, ITrackCollection, IDelegable<ITrackCollection>
     {
         /// <summary>
         /// Creates a new instance of <see cref="TrackCollectionPluginBase"/>.

--- a/src/Sdk/StrixMusic.Sdk/Plugins/Model/TrackPluginBase.cs
+++ b/src/Sdk/StrixMusic.Sdk/Plugins/Model/TrackPluginBase.cs
@@ -19,7 +19,7 @@ namespace StrixMusic.Sdk.Plugins.Model
     /// An implementation of <see cref="ITrack"/> which delegates all member access to the <see cref="Inner"/> implementation,
     /// unless the member is overridden in a derived class which changes the behavior.
     /// </summary>
-    public class TrackPluginBase : IModelPlugin, ITrack, IDelegatable<ITrack>
+    public class TrackPluginBase : IModelPlugin, ITrack, IDelegable<ITrack>
     {
         /// <summary>
         /// Creates a new instance of <see cref="TrackPluginBase"/>.

--- a/src/Sdk/StrixMusic.Sdk/Plugins/Model/UrlCollectionPluginBase.cs
+++ b/src/Sdk/StrixMusic.Sdk/Plugins/Model/UrlCollectionPluginBase.cs
@@ -16,7 +16,7 @@ namespace StrixMusic.Sdk.Plugins.Model
     /// An implementation of <see cref="IUrlCollection"/> which delegates all member access to the <see cref="Inner"/> implementation,
     /// unless the member is overridden in a derived class which changes the behavior.
     /// </summary>
-    public class UrlCollectionPluginBase : IModelPlugin, IUrlCollection, IDelegatable<IUrlCollection>
+    public class UrlCollectionPluginBase : IModelPlugin, IUrlCollection, IDelegable<IUrlCollection>
     {
         /// <summary>
         /// Creates a new instance of <see cref="UrlCollectionPluginBase"/>.

--- a/src/Sdk/StrixMusic.Sdk/Plugins/Model/UrlPluginBase.cs
+++ b/src/Sdk/StrixMusic.Sdk/Plugins/Model/UrlPluginBase.cs
@@ -14,7 +14,7 @@ namespace StrixMusic.Sdk.Plugins.Model
     /// An implementation of <see cref="IUrl"/> which delegates all member access to the <see cref="Inner"/> implementation,
     /// unless the member is overridden in a derived class which changes the behavior.
     /// </summary>
-    public class UrlPluginBase : IModelPlugin, IUrl, IDelegatable<IUrl>
+    public class UrlPluginBase : IModelPlugin, IUrl, IDelegable<IUrl>
     {
         /// <summary>
         /// Creates a new instance of <see cref="UrlPluginBase"/>.

--- a/src/Sdk/StrixMusic.Sdk/StrixMusic.Sdk.csproj
+++ b/src/Sdk/StrixMusic.Sdk/StrixMusic.Sdk.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net9.0</TargetFrameworks>
     <Nullable>enable</Nullable>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12</LangVersion>
     <WarningsAsErrors>nullable</WarningsAsErrors>
     <AssemblyVersion>0.1.0</AssemblyVersion>
 
@@ -34,26 +34,26 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommunityToolkit.Common" Version="8.2.0" />
-    <PackageReference Include="CommunityToolkit.Diagnostics" Version="8.2.0" />
-    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.0" />
-    <PackageReference Include="JetBrains.Annotations" Version="2022.3.1" />
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.1">
+    <PackageReference Include="CommunityToolkit.Common" Version="8.4.0" />
+    <PackageReference Include="CommunityToolkit.Diagnostics" Version="8.4.0" />
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
+    <PackageReference Include="JetBrains.Annotations" Version="2024.3.0" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="9.0.5" />
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.5" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.54.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="OwlCore" Version="0.4.0" />
+    <PackageReference Include="OwlCore" Version="0.6.1" />
     <PackageReference Include="SixLabors.ImageSharp" Version="2.1.3" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
-    <PackageReference Include="System.Text.Json" Version="7.0.2" />
+    <PackageReference Include="System.Text.Json" Version="9.0.5" />
     <PackageReference Include="TagLibSharp" Version="2.3.0" />
   </ItemGroup>
 

--- a/src/Sdk/StrixMusic.Sdk/ViewModels/AlbumCollectionViewModel.cs
+++ b/src/Sdk/StrixMusic.Sdk/ViewModels/AlbumCollectionViewModel.cs
@@ -26,7 +26,7 @@ namespace StrixMusic.Sdk.ViewModels
     /// <summary>
     /// A ViewModel for <see cref="IAlbumCollection"/>.
     /// </summary>
-    public sealed class AlbumCollectionViewModel : ObservableObject, ISdkViewModel, IAlbumCollectionViewModel, IUrlCollectionViewModel, IImageCollectionViewModel, IDelegatable<IAlbumCollection>
+    public sealed class AlbumCollectionViewModel : ObservableObject, ISdkViewModel, IAlbumCollectionViewModel, IUrlCollectionViewModel, IImageCollectionViewModel, IDelegable<IAlbumCollection>
     {
         private readonly IAlbumCollection _collection;
 
@@ -189,7 +189,7 @@ namespace StrixMusic.Sdk.ViewModels
         }, null);
 
         /// <inheritdoc/>
-        IAlbumCollection IDelegatable<IAlbumCollection>.Inner => _collection;
+        IAlbumCollection IDelegable<IAlbumCollection>.Inner => _collection;
 
         /// <inheritdoc/>
         public event EventHandler? SourcesChanged

--- a/src/Sdk/StrixMusic.Sdk/ViewModels/AlbumViewModel.cs
+++ b/src/Sdk/StrixMusic.Sdk/ViewModels/AlbumViewModel.cs
@@ -27,7 +27,7 @@ namespace StrixMusic.Sdk.ViewModels
     /// <summary>
     /// A ViewModel for <see cref="IAlbum"/>.
     /// </summary>
-    public sealed class AlbumViewModel : ObservableObject, ISdkViewModel, IAlbum, IArtistCollectionViewModel, ITrackCollectionViewModel, IImageCollectionViewModel, IUrlCollectionViewModel, IGenreCollectionViewModel, IDelegatable<IAlbum>
+    public sealed class AlbumViewModel : ObservableObject, ISdkViewModel, IAlbum, IArtistCollectionViewModel, ITrackCollectionViewModel, IImageCollectionViewModel, IUrlCollectionViewModel, IGenreCollectionViewModel, IDelegable<IAlbum>
     {
         private readonly IAlbum _album;
 
@@ -149,7 +149,7 @@ namespace StrixMusic.Sdk.ViewModels
         }
 
         /// <inheritdoc/>
-        IAlbum IDelegatable<IAlbum>.Inner => _album;
+        IAlbum IDelegable<IAlbum>.Inner => _album;
 
         /// <inheritdoc/>
         public event EventHandler? SourcesChanged

--- a/src/Sdk/StrixMusic.Sdk/ViewModels/ArtistCollectionViewModel.cs
+++ b/src/Sdk/StrixMusic.Sdk/ViewModels/ArtistCollectionViewModel.cs
@@ -26,7 +26,7 @@ namespace StrixMusic.Sdk.ViewModels
     /// <summary>
     /// A wrapper for <see cref="IArtistCollection"/> that contains props and methods for a ViewModel.
     /// </summary>
-    public class ArtistCollectionViewModel : ObservableObject, ISdkViewModel, IArtistCollectionViewModel, IImageCollectionViewModel, IDelegatable<IArtistCollection>
+    public class ArtistCollectionViewModel : ObservableObject, ISdkViewModel, IArtistCollectionViewModel, IImageCollectionViewModel, IDelegable<IArtistCollection>
     {
         private readonly IArtistCollection _collection;
 
@@ -203,7 +203,7 @@ namespace StrixMusic.Sdk.ViewModels
         }, null);
 
         /// <inheritdoc/>
-        IArtistCollection IDelegatable<IArtistCollection>.Inner => _collection;
+        IArtistCollection IDelegable<IArtistCollection>.Inner => _collection;
 
         /// <inheritdoc/>
         public event EventHandler? SourcesChanged

--- a/src/Sdk/StrixMusic.Sdk/ViewModels/ArtistViewModel.cs
+++ b/src/Sdk/StrixMusic.Sdk/ViewModels/ArtistViewModel.cs
@@ -28,7 +28,7 @@ namespace StrixMusic.Sdk.ViewModels
     /// <summary>
     /// A ViewModel for <see cref="IArtist"/>.
     /// </summary>
-    public sealed class ArtistViewModel : ObservableObject, IArtist, ISdkViewModel, IAlbumCollectionViewModel, ITrackCollectionViewModel, IImageCollectionViewModel, IGenreCollectionViewModel, IUrlCollectionViewModel, IDelegatable<IArtist>
+    public sealed class ArtistViewModel : ObservableObject, IArtist, ISdkViewModel, IAlbumCollectionViewModel, ITrackCollectionViewModel, IImageCollectionViewModel, IGenreCollectionViewModel, IUrlCollectionViewModel, IDelegable<IArtist>
     {
         private readonly IArtist _artist;
 
@@ -150,7 +150,7 @@ namespace StrixMusic.Sdk.ViewModels
         }
 
         /// <inheritdoc/>
-        IArtist IDelegatable<IArtist>.Inner => _artist;
+        IArtist IDelegable<IArtist>.Inner => _artist;
 
         /// <inheritdoc/>
         public event EventHandler? SourcesChanged

--- a/src/Sdk/StrixMusic.Sdk/ViewModels/CoreViewModel.cs
+++ b/src/Sdk/StrixMusic.Sdk/ViewModels/CoreViewModel.cs
@@ -18,7 +18,7 @@ namespace StrixMusic.Sdk.ViewModels
     /// <summary>
     /// A ViewModel for <see cref="ICore"/>.
     /// </summary>
-    public sealed partial class CoreViewModel : ObservableObject, ISdkViewModel, ICore, IDelegatable<ICore>
+    public sealed partial class CoreViewModel : ObservableObject, ISdkViewModel, ICore, IDelegable<ICore>
     {
         private readonly ICore _core;
         private readonly SynchronizationContext _syncContext;
@@ -67,7 +67,7 @@ namespace StrixMusic.Sdk.ViewModels
         }, null);
 
         /// <inheritdoc/>
-        ICore IDelegatable<ICore>.Inner => _core;
+        ICore IDelegable<ICore>.Inner => _core;
 
         /// <inheritdoc />
         public string Id => _core.Id;

--- a/src/Sdk/StrixMusic.Sdk/ViewModels/DeviceViewModel.cs
+++ b/src/Sdk/StrixMusic.Sdk/ViewModels/DeviceViewModel.cs
@@ -19,7 +19,7 @@ namespace StrixMusic.Sdk.ViewModels
     /// <summary>
     /// A ViewModel for <see cref="IDevice"/>.
     /// </summary>
-    public sealed class DeviceViewModel : ObservableObject, ISdkViewModel, IDevice, IDelegatable<IDevice>
+    public sealed class DeviceViewModel : ObservableObject, ISdkViewModel, IDevice, IDelegable<IDevice>
     {
         private readonly SynchronizationContext _syncContext;
         private readonly IDevice _model;
@@ -122,7 +122,7 @@ namespace StrixMusic.Sdk.ViewModels
         }, null);
 
         /// <inheritdoc/>
-        IDevice IDelegatable<IDevice>.Inner => _model;
+        IDevice IDelegable<IDevice>.Inner => _model;
 
         /// <inheritdoc />
         public ICore? SourceCore { get; set; }

--- a/src/Sdk/StrixMusic.Sdk/ViewModels/DiscoverablesViewModel.cs
+++ b/src/Sdk/StrixMusic.Sdk/ViewModels/DiscoverablesViewModel.cs
@@ -14,7 +14,7 @@ namespace StrixMusic.Sdk.ViewModels
     /// <summary>
     /// A ViewModel for <see cref="IDiscoverables"/>.
     /// </summary>
-    public class DiscoverablesViewModel : PlayableCollectionGroupViewModel, ISdkViewModel, IDiscoverables, IDelegatable<IDiscoverables>
+    public class DiscoverablesViewModel : PlayableCollectionGroupViewModel, ISdkViewModel, IDiscoverables, IDelegable<IDiscoverables>
     {
         private readonly IDiscoverables _discoverables;
 
@@ -29,7 +29,7 @@ namespace StrixMusic.Sdk.ViewModels
         }
 
         /// <inheritdoc/>
-        IDiscoverables IDelegatable<IDiscoverables>.Inner => _discoverables;
+        IDiscoverables IDelegable<IDiscoverables>.Inner => _discoverables;
 
         /// <inheritdoc />
         IReadOnlyList<ICoreDiscoverables> IMerged<ICoreDiscoverables>.Sources => this.GetSources<ICoreDiscoverables>();

--- a/src/Sdk/StrixMusic.Sdk/ViewModels/LibraryViewModel.cs
+++ b/src/Sdk/StrixMusic.Sdk/ViewModels/LibraryViewModel.cs
@@ -14,7 +14,7 @@ namespace StrixMusic.Sdk.ViewModels
     /// <summary>
     /// A ViewModel for <see cref="ILibrary"/>.
     /// </summary>
-    public sealed class LibraryViewModel : PlayableCollectionGroupViewModel, ISdkViewModel, ILibrary, IDelegatable<ILibrary>
+    public sealed class LibraryViewModel : PlayableCollectionGroupViewModel, ISdkViewModel, ILibrary, IDelegable<ILibrary>
     {
         private readonly ILibrary _library;
 
@@ -29,7 +29,7 @@ namespace StrixMusic.Sdk.ViewModels
         }
 
         /// <inheritdoc/>
-        ILibrary IDelegatable<ILibrary>.Inner => _library;
+        ILibrary IDelegable<ILibrary>.Inner => _library;
 
         /// <inheritdoc />
         IReadOnlyList<ICoreLibrary> IMerged<ICoreLibrary>.Sources => this.GetSources<ICoreLibrary>();

--- a/src/Sdk/StrixMusic.Sdk/ViewModels/PlayableCollectionGroupViewModel.cs
+++ b/src/Sdk/StrixMusic.Sdk/ViewModels/PlayableCollectionGroupViewModel.cs
@@ -27,7 +27,7 @@ namespace StrixMusic.Sdk.ViewModels
     /// <summary>
     /// A ViewModel for <see cref="IPlayableCollectionGroup"/>.
     /// </summary>
-    public class PlayableCollectionGroupViewModel : ObservableObject, ISdkViewModel, IPlayableCollectionGroup, IPlayableCollectionGroupChildrenViewModel, IAlbumCollectionViewModel, IArtistCollectionViewModel, ITrackCollectionViewModel, IPlaylistCollectionViewModel, IImageCollectionViewModel, IUrlCollectionViewModel, IDelegatable<IPlayableCollectionGroup>
+    public class PlayableCollectionGroupViewModel : ObservableObject, ISdkViewModel, IPlayableCollectionGroup, IPlayableCollectionGroupChildrenViewModel, IAlbumCollectionViewModel, IArtistCollectionViewModel, ITrackCollectionViewModel, IPlaylistCollectionViewModel, IImageCollectionViewModel, IUrlCollectionViewModel, IDelegable<IPlayableCollectionGroup>
     {
         private readonly IPlayableCollectionGroup _collectionGroup;
 
@@ -182,7 +182,7 @@ namespace StrixMusic.Sdk.ViewModels
         }
 
         /// <inheritdoc/>
-        IPlayableCollectionGroup IDelegatable<IPlayableCollectionGroup>.Inner => _collectionGroup;
+        IPlayableCollectionGroup IDelegable<IPlayableCollectionGroup>.Inner => _collectionGroup;
 
         /// <inheritdoc/>
         public event EventHandler? SourcesChanged

--- a/src/Sdk/StrixMusic.Sdk/ViewModels/PlaylistCollectionViewModel.cs
+++ b/src/Sdk/StrixMusic.Sdk/ViewModels/PlaylistCollectionViewModel.cs
@@ -26,7 +26,7 @@ namespace StrixMusic.Sdk.ViewModels
     /// <summary>
     /// A ViewModel for <see cref="IPlaylistCollection"/>.
     /// </summary>
-    public sealed class PlaylistCollectionViewModel : ObservableObject, ISdkViewModel, IPlaylistCollectionViewModel, IImageCollectionViewModel, IUrlCollectionViewModel, IDelegatable<IPlaylistCollection>
+    public sealed class PlaylistCollectionViewModel : ObservableObject, ISdkViewModel, IPlaylistCollectionViewModel, IImageCollectionViewModel, IUrlCollectionViewModel, IDelegable<IPlaylistCollection>
     {
         private readonly IPlaylistCollection _collection;
 
@@ -184,7 +184,7 @@ namespace StrixMusic.Sdk.ViewModels
         }, null);
 
         /// <inheritdoc/>
-        IPlaylistCollection IDelegatable<IPlaylistCollection>.Inner => _collection;
+        IPlaylistCollection IDelegable<IPlaylistCollection>.Inner => _collection;
 
         /// <inheritdoc/>
         public event EventHandler? SourcesChanged

--- a/src/Sdk/StrixMusic.Sdk/ViewModels/PlaylistViewModel.cs
+++ b/src/Sdk/StrixMusic.Sdk/ViewModels/PlaylistViewModel.cs
@@ -26,7 +26,7 @@ namespace StrixMusic.Sdk.ViewModels
     /// <summary>
     /// A ViewModel for <see cref="IPlaylist"/>.
     /// </summary>
-    public sealed class PlaylistViewModel : ObservableObject, ISdkViewModel, IPlaylist, ITrackCollectionViewModel, IImageCollectionViewModel, IDelegatable<IPlaylist>
+    public sealed class PlaylistViewModel : ObservableObject, ISdkViewModel, IPlaylist, ITrackCollectionViewModel, IImageCollectionViewModel, IDelegable<IPlaylist>
     {
         private readonly IPlaylist _playlist;
         private readonly IUserProfile? _owner;
@@ -136,7 +136,7 @@ namespace StrixMusic.Sdk.ViewModels
         }
 
         /// <inheritdoc/>
-        IPlaylist IDelegatable<IPlaylist>.Inner => _playlist;
+        IPlaylist IDelegable<IPlaylist>.Inner => _playlist;
 
         /// <inheritdoc/>
         public event EventHandler? SourcesChanged

--- a/src/Sdk/StrixMusic.Sdk/ViewModels/RecentlyPlayedViewModel.cs
+++ b/src/Sdk/StrixMusic.Sdk/ViewModels/RecentlyPlayedViewModel.cs
@@ -14,7 +14,7 @@ namespace StrixMusic.Sdk.ViewModels
     /// <summary>
     /// A ViewModel for <see cref="IRecentlyPlayed"/>.
     /// </summary>
-    public sealed class RecentlyPlayedViewModel : PlayableCollectionGroupViewModel, ISdkViewModel, IRecentlyPlayed, IDelegatable<IRecentlyPlayed>
+    public sealed class RecentlyPlayedViewModel : PlayableCollectionGroupViewModel, ISdkViewModel, IRecentlyPlayed, IDelegable<IRecentlyPlayed>
     {
         private readonly IRecentlyPlayed _recentlyPlayed;
 
@@ -29,7 +29,7 @@ namespace StrixMusic.Sdk.ViewModels
         }
 
         /// <inheritdoc/>
-        IRecentlyPlayed IDelegatable<IRecentlyPlayed>.Inner => _recentlyPlayed;
+        IRecentlyPlayed IDelegable<IRecentlyPlayed>.Inner => _recentlyPlayed;
 
         /// <inheritdoc />
         IReadOnlyList<ICoreRecentlyPlayed> IMerged<ICoreRecentlyPlayed>.Sources => this.GetSources<ICoreRecentlyPlayed>();

--- a/src/Sdk/StrixMusic.Sdk/ViewModels/SearchHistoryViewModel.cs
+++ b/src/Sdk/StrixMusic.Sdk/ViewModels/SearchHistoryViewModel.cs
@@ -14,7 +14,7 @@ namespace StrixMusic.Sdk.ViewModels
     /// <summary>
     /// A ViewModel for <see cref="ISearchHistory"/>.
     /// </summary>
-    public sealed class SearchHistoryViewModel : PlayableCollectionGroupViewModel, ISdkViewModel, ISearchHistory, IDelegatable<ISearchHistory>
+    public sealed class SearchHistoryViewModel : PlayableCollectionGroupViewModel, ISdkViewModel, ISearchHistory, IDelegable<ISearchHistory>
     {
         private readonly ISearchHistory _searchHistory;
 
@@ -29,7 +29,7 @@ namespace StrixMusic.Sdk.ViewModels
         }
 
         /// <inheritdoc/>
-        ISearchHistory IDelegatable<ISearchHistory>.Inner => _searchHistory;
+        ISearchHistory IDelegable<ISearchHistory>.Inner => _searchHistory;
 
         /// <inheritdoc />
         IReadOnlyList<ICoreSearchHistory> IMerged<ICoreSearchHistory>.Sources => this.GetSources<ICoreSearchHistory>();

--- a/src/Sdk/StrixMusic.Sdk/ViewModels/SearchResultsViewModel.cs
+++ b/src/Sdk/StrixMusic.Sdk/ViewModels/SearchResultsViewModel.cs
@@ -14,7 +14,7 @@ namespace StrixMusic.Sdk.ViewModels
     /// <summary>
     /// A ViewModel for <see cref="ISearchResults"/>.
     /// </summary>
-    public sealed class SearchResultsViewModel : PlayableCollectionGroupViewModel, ISdkViewModel, ISearchResults, IDelegatable<ISearchResults>
+    public sealed class SearchResultsViewModel : PlayableCollectionGroupViewModel, ISdkViewModel, ISearchResults, IDelegable<ISearchResults>
     {
         private readonly ISearchResults _searchResults;
 
@@ -29,7 +29,7 @@ namespace StrixMusic.Sdk.ViewModels
         }
 
         /// <inheritdoc/>
-        ISearchResults IDelegatable<ISearchResults>.Inner => _searchResults;
+        ISearchResults IDelegable<ISearchResults>.Inner => _searchResults;
 
         /// <inheritdoc />
         IReadOnlyList<ICoreSearchResults> IMerged<ICoreSearchResults>.Sources => this.GetSources<ICoreSearchResults>();

--- a/src/Sdk/StrixMusic.Sdk/ViewModels/SearchViewModel.cs
+++ b/src/Sdk/StrixMusic.Sdk/ViewModels/SearchViewModel.cs
@@ -16,7 +16,7 @@ namespace StrixMusic.Sdk.ViewModels
     /// <summary>
     /// A ViewModel for <see cref="ISearch"/>.
     /// </summary>
-    public sealed class SearchViewModel : ObservableObject, ISdkViewModel, ISearch, IDelegatable<ISearch>
+    public sealed class SearchViewModel : ObservableObject, ISdkViewModel, ISearch, IDelegable<ISearch>
     {
         private readonly ISearch _search;
 
@@ -55,7 +55,7 @@ namespace StrixMusic.Sdk.ViewModels
         public IAsyncEnumerable<ISearchQuery> GetRecentSearchQueries(CancellationToken cancellationToken = default) => _search.GetRecentSearchQueries(cancellationToken);
 
         /// <inheritdoc/>
-        ISearch IDelegatable<ISearch>.Inner => _search;
+        ISearch IDelegable<ISearch>.Inner => _search;
 
         /// <inheritdoc />
         ISearchHistory? ISearch.SearchHistory => _search.SearchHistory;

--- a/src/Sdk/StrixMusic.Sdk/ViewModels/StrixDataRootViewModel.cs
+++ b/src/Sdk/StrixMusic.Sdk/ViewModels/StrixDataRootViewModel.cs
@@ -20,7 +20,7 @@ namespace StrixMusic.Sdk.ViewModels;
 /// <summary>
 /// A ViewModel wrapper for an instance of <see cref="IStrixDataRoot"/>.
 /// </summary>
-public class StrixDataRootViewModel : ObservableObject, IStrixDataRoot, IDelegatable<IStrixDataRoot>
+public class StrixDataRootViewModel : ObservableObject, IStrixDataRoot, IDelegable<IStrixDataRoot>
 {
     private readonly IStrixDataRoot _dataRoot;
     private readonly ObservableCollection<IDevice> _devices;
@@ -126,7 +126,7 @@ public class StrixDataRootViewModel : ObservableObject, IStrixDataRoot, IDelegat
     }
 
     /// <inheritdoc/>
-    IStrixDataRoot IDelegatable<IStrixDataRoot>.Inner => _dataRoot;
+    IStrixDataRoot IDelegable<IStrixDataRoot>.Inner => _dataRoot;
 
     /// <inheritdoc/>
     public event EventHandler? SourcesChanged

--- a/src/Sdk/StrixMusic.Sdk/ViewModels/TrackCollectionViewModel.cs
+++ b/src/Sdk/StrixMusic.Sdk/ViewModels/TrackCollectionViewModel.cs
@@ -26,7 +26,7 @@ namespace StrixMusic.Sdk.ViewModels
     /// <summary>
     /// A ViewModel for <see cref="ITrackCollection"/>.
     /// </summary>
-    public class TrackCollectionViewModel : ObservableObject, ISdkViewModel, ITrackCollectionViewModel, IImageCollectionViewModel, IDelegatable<ITrackCollection>
+    public class TrackCollectionViewModel : ObservableObject, ISdkViewModel, ITrackCollectionViewModel, IImageCollectionViewModel, IDelegable<ITrackCollection>
     {
         private readonly ITrackCollection _collection;
 
@@ -193,7 +193,7 @@ namespace StrixMusic.Sdk.ViewModels
         }, null);
 
         /// <inheritdoc/>
-        ITrackCollection IDelegatable<ITrackCollection>.Inner => _collection;
+        ITrackCollection IDelegable<ITrackCollection>.Inner => _collection;
 
         /// <inheritdoc/>
         public event EventHandler? SourcesChanged

--- a/src/Sdk/StrixMusic.Sdk/ViewModels/TrackViewModel.cs
+++ b/src/Sdk/StrixMusic.Sdk/ViewModels/TrackViewModel.cs
@@ -26,7 +26,7 @@ namespace StrixMusic.Sdk.ViewModels
     /// <summary>
     /// A ViewModel for <see cref="ITrack"/>.
     /// </summary>
-    public sealed class TrackViewModel : ObservableObject, ISdkViewModel, ITrack, IArtistCollectionViewModel, IImageCollectionViewModel, IGenreCollectionViewModel, IDelegatable<ITrack>
+    public sealed class TrackViewModel : ObservableObject, ISdkViewModel, ITrack, IArtistCollectionViewModel, IImageCollectionViewModel, IGenreCollectionViewModel, IDelegable<ITrack>
     {
         private readonly SemaphoreSlim _populateArtistsMutex = new(1, 1);
         private readonly SemaphoreSlim _populateImagesMutex = new(1, 1);
@@ -146,7 +146,7 @@ namespace StrixMusic.Sdk.ViewModels
         }
 
         /// <inheritdoc/>
-        ITrack IDelegatable<ITrack>.Inner => _model;
+        ITrack IDelegable<ITrack>.Inner => _model;
 
         /// <inheritdoc/>
         public event EventHandler? SourcesChanged

--- a/src/Sdk/StrixMusic.Sdk/ViewModels/UserProfileViewModel.cs
+++ b/src/Sdk/StrixMusic.Sdk/ViewModels/UserProfileViewModel.cs
@@ -22,7 +22,7 @@ namespace StrixMusic.Sdk.ViewModels
     /// <summary>
     /// A ViewModel for <see cref="IUserProfile"/>.
     /// </summary>
-    public class UserProfileViewModel : ObservableObject, ISdkViewModel, IUserProfile, IImageCollectionViewModel, IUrlCollectionViewModel, IDelegatable<IUserProfile>
+    public class UserProfileViewModel : ObservableObject, ISdkViewModel, IUserProfile, IImageCollectionViewModel, IUrlCollectionViewModel, IDelegable<IUserProfile>
     {
         private readonly IUserProfile _userProfile;
         private readonly IReadOnlyList<ICoreUserProfile> _sources;
@@ -63,7 +63,7 @@ namespace StrixMusic.Sdk.ViewModels
         }
 
         /// <inheritdoc/>
-        IUserProfile IDelegatable<IUserProfile>.Inner => _userProfile;
+        IUserProfile IDelegable<IUserProfile>.Inner => _userProfile;
 
         /// <inheritdoc/>
         public event EventHandler? SourcesChanged

--- a/src/Sdk/StrixMusic.Sdk/ViewModels/UserViewModel.cs
+++ b/src/Sdk/StrixMusic.Sdk/ViewModels/UserViewModel.cs
@@ -12,7 +12,7 @@ namespace StrixMusic.Sdk.ViewModels
     /// <summary>
     /// Contains bindable information about an <see cref="IUser"/>
     /// </summary>
-    public class UserViewModel : UserProfileViewModel, ISdkViewModel, IDelegatable<IUser>
+    public class UserViewModel : UserProfileViewModel, ISdkViewModel, IDelegable<IUser>
     {
         private readonly IUser _user;
 
@@ -30,7 +30,7 @@ namespace StrixMusic.Sdk.ViewModels
         }
 
         /// <inheritdoc/>
-        IUser IDelegatable<IUser>.Inner => _user;
+        IUser IDelegable<IUser>.Inner => _user;
 
         /// <inheritdoc cref="ILibraryBase"/>
         public LibraryViewModel Library { get; }

--- a/src/Shared/App.xaml.cs
+++ b/src/Shared/App.xaml.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.Logging;
+﻿using CommunityToolkit.Diagnostics;
+using Microsoft.Extensions.Logging;
 using OwlCore.Storage.Uwp;
 using StrixMusic.AppModels;
 using StrixMusic.Controls;
@@ -72,6 +73,7 @@ public sealed partial class App : Application
 
         // Do not repeat app initialization when the Window already has content,
         // just ensure that the window is active
+        Guard.IsNotNull(MainWindow);
         MainWindow.Content ??= CreateMainWindowContent();
 
 #if !(NET6_0_OR_GREATER && WINDOWS)
@@ -96,7 +98,8 @@ public sealed partial class App : Application
             var appRoot = new AppRoot(new WindowsStorageFolder(ApplicationData.Current.LocalFolder))
             {
 #if __WASM__
-        HttpMessageHandler = new Uno.UI.Wasm.WasmHttpHandler(),
+        // TODO: Not needed anymore?
+        // HttpMessageHandler = new Uno.UI.Wasm.WasmHttpHandler(),
 #endif
             };
             return appRoot;

--- a/src/Shared/AppFrame.xaml.cs
+++ b/src/Shared/AppFrame.xaml.cs
@@ -73,7 +73,9 @@ public sealed partial class AppFrame : UserControl
         applicationView.TitleBar.InactiveForegroundColor = hostOptions?.InactiveForegroundColor;
 
         coreApplicationView.TitleBar.ExtendViewIntoTitleBar = hostOptions?.ExtendViewIntoTitleBar ?? true;
-        Window.Current.SetTitleBar(hostOptions?.CustomTitleBar);
+
+        if (Window.Current is not null)
+            Window.Current.SetTitleBar(hostOptions?.CustomTitleBar);
     }
 
     private void ShellOnPropertyChanged(object? sender, PropertyChangedEventArgs e) => SetupShellWindowHostOptions(CurrentApplicationView, CurrentCoreApplicationView, sender as ShellWindowHostOptions);

--- a/src/Shared/AppModels/AppReleaseContentLoader.cs
+++ b/src/Shared/AppModels/AppReleaseContentLoader.cs
@@ -157,7 +157,7 @@ public partial class AppReleaseContentLoader : ObservableObject, IAsyncInit
         var content = await _releaseSourceFolder.GetFirstByNameAsync("release-content-bundles.json", cancellationToken);
         var file = (IFile)content;
 
-        using var stream = await file.OpenStreamAsync(cancellationToken: cancellationToken);
+        using var stream = await file.OpenReadAsync(cancellationToken: cancellationToken);
         return await AppSettingsSerializer.Singleton.DeserializeAsync<List<AppReleaseContentBundle>>(stream, cancellationToken);
     }
 

--- a/src/Shared/AppModels/AppRoot.cs
+++ b/src/Shared/AppModels/AppRoot.cs
@@ -304,7 +304,7 @@ public partial class AppRoot : ObservableObject, IAsyncInit
         await MusicSourcesSettings.SaveAsync();
     }
 
-    private async void ConfiguredIpfsCores_CollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
+    private async void ConfiguredIpfsCores_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
     {
         Guard.IsNotNull(MusicSourcesSettings);
         Guard.IsNotNull(_ipfs);

--- a/src/Shared/AppModels/IpfsAccess.cs
+++ b/src/Shared/AppModels/IpfsAccess.cs
@@ -14,7 +14,7 @@ using OwlCore.Diagnostics;
 using OwlCore.Extensions;
 using OwlCore.Kubo;
 using OwlCore.Storage;
-using OwlCore.Storage.SystemIO;
+using OwlCore.Storage.System.IO;
 using StrixMusic.Settings;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
@@ -326,7 +326,7 @@ public partial class IpfsAccess : ObservableObject, IAsyncInit
 
         var repoFolder = (SystemFolder)await kuboBinParentFolder.CreateFolderAsync(".ipfs", overwrite: false, cancellationToken);
 
-        var bootstrapper = new KuboBootstrapper(kuboBin, repoFolder.Path)
+        var bootstrapper = new KuboBootstrapper(repoFolder.Path, ctx => Task.FromResult<IFile>(kuboBin))
         {
             BinaryWorkingFolder = kuboBinParentFolderParent,
             ApiUri = new Uri($"http://127.0.0.1:{Settings.NodeApiPort}"),
@@ -349,8 +349,7 @@ public partial class IpfsAccess : ObservableObject, IAsyncInit
         if (kuboBin is null)
         {
             InitStatus = "Downloading and extracting Kubo";
-            var downloader = new KuboDownloader { HttpMessageHandler = HttpMessageHandler };
-            var downloadedBinary = await downloader.DownloadBinaryAsync(new Version(0, 19, 0), cancellationToken);
+            var downloadedBinary = await KuboDownloader.GetBinaryVersionAsync(new Version(0, 19, 0), cancellationToken);
 
             kuboBin = await StoreDownloadedKuboBinaryAsync(downloadedBinary, cancellationToken);
         }

--- a/src/Shared/CoreModels/FileImage.cs
+++ b/src/Shared/CoreModels/FileImage.cs
@@ -1,5 +1,6 @@
 ﻿using System.IO;
 using System.Threading.Tasks;
+using CommunityToolkit.Diagnostics;
 using OwlCore.Extensions;
 using OwlCore.Storage;
 using StrixMusic.Sdk.CoreModels;
@@ -23,7 +24,7 @@ namespace StrixMusic.CoreModels
         }
 
         /// <inheritdoc/>
-        public string MimeType => Path.GetExtension(_file.Name).GetMimeType();
+        public string MimeType => Path.GetExtension(_file.Name).GetMimeType() ?? ThrowHelper.ThrowArgumentNullException<string>();
 
         /// <inheritdoc/>
         public double? Height { get; set; }
@@ -35,6 +36,6 @@ namespace StrixMusic.CoreModels
         public ICore SourceCore { get; set; } = null!;
 
         /// <inheritdoc/>
-        public Task<Stream> OpenStreamAsync() => _file.OpenStreamAsync();
+        public Task<Stream> OpenStreamAsync() => _file.OpenReadAsync();
     }
 }

--- a/src/Shells/StrixMusic.Shells.Groove/StrixMusic.Shells.Groove.csproj
+++ b/src/Shells/StrixMusic.Shells.Groove/StrixMusic.Shells.Groove.csproj
@@ -4,24 +4,24 @@
 	Please see https://github.com/unoplatform/uno/issues/3909 for more details.
 	-->
   <PropertyGroup>
-    <TargetFrameworks>uap10.0.19041;net7.0</TargetFrameworks>
+    <TargetFrameworks>uap10.0.19041;net9.0</TargetFrameworks>
     <!-- Ensures the .xr.xml files are generated in a proper layout folder -->
     <GenerateLibraryLayout>true</GenerateLibraryLayout>
     <AssemblyName>StrixMusic.Shells.Groove</AssemblyName>
     <RootNamespace>StrixMusic.Shells.Groove</RootNamespace>
     <Nullable>enable</Nullable>
-    <LangVersion>10</LangVersion>
+    <LangVersion>12</LangVersion>
     <WarningsAsErrors>nullable</WarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ClusterNet" Version="0.0.3-alpha" />
-    <PackageReference Include="OwlCore" Version="0.4.0" />
+    <PackageReference Include="OwlCore" Version="0.6.1" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.Text.Json" Version="7.0.2" />
-    <PackageReference Include="Uno.UI" Version="4.8.33" />
+    <PackageReference Include="System.Text.Json" Version="9.0.5" />
+    <PackageReference Include="Uno.UI" Version="5.6.99" />
   </ItemGroup>
   <ItemGroup>
     <Page Include="**\*.xaml" Exclude="bin\**\*.xaml;obj\**\*.xaml" />

--- a/src/Shells/StrixMusic.Shells.Strix/StrixMusic.Shells.Strix.csproj
+++ b/src/Shells/StrixMusic.Shells.Strix/StrixMusic.Shells.Strix.csproj
@@ -1,13 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="MSBuild.Sdk.Extras/2.0.54">
   <PropertyGroup>
-	<TargetFrameworks>uap10.0.19041;net7.0</TargetFrameworks>
+	<TargetFrameworks>uap10.0.19041;net9.0</TargetFrameworks>
     <!-- Ensures the .xr.xml files are generated in a proper layout folder -->
     <GenerateLibraryLayout>true</GenerateLibraryLayout>
     <RootNamespace>StrixMusic.Shells.Strix</RootNamespace>
     <AssemblyName>StrixMusic.Shells.Strix</AssemblyName>
     <Nullable>enable</Nullable>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>12</LangVersion>
     <WarningsAsErrors>nullable</WarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)'=='netstandard2.0'">

--- a/src/Shells/StrixMusic.Shells.ZuneDesktop/Controls/Views/Settings/SettingsView.xaml.cs
+++ b/src/Shells/StrixMusic.Shells.ZuneDesktop/Controls/Views/Settings/SettingsView.xaml.cs
@@ -21,7 +21,7 @@ namespace StrixMusic.Shells.ZuneDesktop.Controls.Views.Settings
 
             var localizationService = ResourceLoader.GetForCurrentView("StrixMusic.Shells.ZuneDesktop/ZuneSettings");
 
-            _displayPages = _displayPages.Select(x => localizationService.GetString(x).ToUpper()).ToList();
+            _displayPages = _displayPages.Select(x => localizationService.GetString(x)?.ToUpper() ?? string.Empty).ToList();
         }
 
         private ZuneDesktopSettingsViewModel? ViewModel => DataContext as ZuneDesktopSettingsViewModel;

--- a/src/Shells/StrixMusic.Shells.ZuneDesktop/Converters/ZuneSortStateToStringConverter.cs
+++ b/src/Shells/StrixMusic.Shells.ZuneDesktop/Converters/ZuneSortStateToStringConverter.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using CommunityToolkit.Diagnostics;
 using StrixMusic.Shells.ZuneDesktop.Controls.Views.Collection;
 using Windows.ApplicationModel.Resources;
 using Windows.UI.Xaml.Data;
@@ -19,11 +20,11 @@ namespace StrixMusic.Shells.ZuneDesktop.Converters
 
                 return zss switch
                 {
-                    ZuneSortState.AZ => loacalizationService.GetString("A-Z"),
-                    ZuneSortState.ZA => loacalizationService.GetString("Z-A"),
-                    ZuneSortState.Artists => loacalizationService.GetString("By Artists"),
-                    ZuneSortState.ReleaseYear => loacalizationService.GetString("By Release Year"),
-                    ZuneSortState.DateAdded => loacalizationService.GetString("By Date Added"),
+                    ZuneSortState.AZ => loacalizationService.GetString("A-Z") ?? ThrowHelper.ThrowArgumentNullException<string>(),
+                    ZuneSortState.ZA => loacalizationService.GetString("Z-A") ?? ThrowHelper.ThrowArgumentNullException<string>(),
+                    ZuneSortState.Artists => loacalizationService.GetString("By Artists") ?? ThrowHelper.ThrowArgumentNullException<string>(),
+                    ZuneSortState.ReleaseYear => loacalizationService.GetString("By Release Year") ?? ThrowHelper.ThrowArgumentNullException<string>(),
+                    ZuneSortState.DateAdded => loacalizationService.GetString("By Date Added") ?? ThrowHelper.ThrowArgumentNullException<string>(),
                     _ => throw new NotImplementedException(),
                 };
             }

--- a/src/Shells/StrixMusic.Shells.ZuneDesktop/Settings/ZuneDesktopSettingsViewModel.cs
+++ b/src/Shells/StrixMusic.Shells.ZuneDesktop/Settings/ZuneDesktopSettingsViewModel.cs
@@ -46,7 +46,7 @@ namespace StrixMusic.Shells.ZuneDesktop.Settings
             _localizationService = ResourceLoader.GetForCurrentView("StrixMusic.Shells.ZuneDesktop/ZuneSettings");
 
             _displayNameMap = _zuneBackgroundImages.Keys
-                .ToDictionary(_localizationService.GetString);
+                .ToDictionary((x) => _localizationService.GetString(x) ?? string.Empty);
 
             LoadInitialValues().Forget();
         }
@@ -79,7 +79,7 @@ namespace StrixMusic.Shells.ZuneDesktop.Settings
         {
             await _settings.LoadAsync();
 
-            string displayName = _localizationService.GetString(_settings.BackgroundImage.Name);
+            string displayName = _localizationService.GetString(_settings.BackgroundImage.Name) ?? string.Empty;
             SetProperty(ref _selectedBackgroundImage, displayName);
         }
     }

--- a/src/Shells/StrixMusic.Shells.ZuneDesktop/StrixMusic.Shells.ZuneDesktop.csproj
+++ b/src/Shells/StrixMusic.Shells.ZuneDesktop/StrixMusic.Shells.ZuneDesktop.csproj
@@ -1,12 +1,12 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras/3.0.23">
   <PropertyGroup>
-    <TargetFrameworks>uap10.0.19041;net7.0</TargetFrameworks>
+    <TargetFrameworks>uap10.0.19041;net9.0</TargetFrameworks>
     <!-- Ensures the .xr.xml files are generated in a proper layout folder -->
     <GenerateLibraryLayout>true</GenerateLibraryLayout>
     <RootNamespace>StrixMusic.Shells.ZuneDesktop</RootNamespace>
     <AssemblyName>StrixMusic.Shells.ZuneDesktop</AssemblyName>
     <Nullable>enable</Nullable>
-    <LangVersion>10</LangVersion>
+    <LangVersion>12</LangVersion>
     <WarningsAsErrors>nullable</WarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
@@ -20,9 +20,9 @@
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
-    <PackageReference Include="OwlCore" Version="0.4.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.5" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.5" />
+    <PackageReference Include="OwlCore" Version="0.6.1" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -114,9 +114,9 @@
     <UpToDateCheckInput Remove="Styles\ZuneTrackListViewItemStyle.xaml" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.Text.Json" Version="7.0.2" />
-    <PackageReference Include="Uno.Diagnostics.Eventing" Version="2.1.0-dev.1" />
-    <PackageReference Include="Uno.UI" Version="4.8.33" />
+    <PackageReference Include="System.Text.Json" Version="9.0.5" />
+    <PackageReference Include="Uno.Diagnostics.Eventing" Version="2.1.0" />
+    <PackageReference Include="Uno.UI" Version="5.6.99" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Libs\OwlCore.WinUI\OwlCore.WinUI.csproj" />

--- a/src/Shells/StrixMusic.Shells.ZuneDesktop/Styles/Collections/TrackTableStyle.xaml.cs
+++ b/src/Shells/StrixMusic.Shells.ZuneDesktop/Styles/Collections/TrackTableStyle.xaml.cs
@@ -21,7 +21,10 @@ namespace StrixMusic.Shells.ZuneDesktop.Styles.Collections
             this.InitializeComponent();
         }
 
-        private void DataGrid_Loaded(object sender, RoutedEventArgs e)
+        /// <summary>
+        /// Handles the <see cref="DataGrid.Loaded"/> event to initialize the DataGrid reference.
+        /// </summary>
+        public void DataGrid_Loaded(object sender, RoutedEventArgs e)
         {
             _grid = (DataGrid)sender;
         }
@@ -34,13 +37,19 @@ namespace StrixMusic.Shells.ZuneDesktop.Styles.Collections
             }
         }
 
-        private void DataGrid_Sorting(object sender, DataGridColumnEventArgs e)
+        /// <summary>
+        /// Handles the <see cref="DataGrid.Sorting"/> event to sort the tracks based on the clicked column.
+        /// </summary>
+        public void DataGrid_Sorting(object sender, DataGridColumnEventArgs e)
         {
             DataGrid grid = (DataGrid)sender;
             SortColumn(grid, e.Column);
         }
 
-        private void DataGrid_LoadingRow(object sender, DataGridRowEventArgs e)
+        /// <summary>
+        /// Handles the <see cref="DataGrid.LoadingRow"/> event to add a double-tap event handler to each row.
+        /// </summary>
+        public void DataGrid_LoadingRow(object sender, DataGridRowEventArgs e)
         {
             e.Row.DoubleTapped += Row_DoubleTapped;
         }

--- a/src/Shells/‏‏StrixMusic.Shells.ZuneHD/StrixMusic.Shells.ZuneHD.csproj
+++ b/src/Shells/‏‏StrixMusic.Shells.ZuneHD/StrixMusic.Shells.ZuneHD.csproj
@@ -1,13 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="MSBuild.Sdk.Extras/2.0.54">
   <PropertyGroup>
-	<TargetFrameworks>uap10.0.19041;net7.0</TargetFrameworks>
+	<TargetFrameworks>uap10.0.19041;net9.0</TargetFrameworks>
     <!-- Ensures the .xr.xml files are generated in a proper layout folder -->
     <GenerateLibraryLayout>true</GenerateLibraryLayout>
     <AssemblyName>StrixMusic.Shells.ZuneHD</AssemblyName>
     <RootNamespace>StrixMusic.Shells.ZuneHD</RootNamespace>
     <Nullable>enable</Nullable>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>12</LangVersion>
     <WarningsAsErrors>nullable</WarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)'=='netstandard2.0'">


### PR DESCRIPTION
- Updated multiple ViewModel classes to replace the usage of the obsolete IDelegatable with IDelegable for better consistency and clarity.
- Updated target frameworks for all net7.0 projects to net9.0.
- Increased language version to 12 in project files for better language features.
- Updated OwlCore and other package references to their latest versions for improved functionality and performance.
- Improved localization handling in ZuneDesktop settings and converters to ensure null safety.
- Added null checks and improved error handling across various files to enhance robustness.
- Updated comments and documentation for clarity and maintainability.

<!--
To categorize this PR in the generated changelog, include one of the following in the PR title: 
[breaking], [fix], [improvement], [new], [refactor], [cleanup]
-->

## Overview
<!-- Replace with the issue number. This will auto-close the issue once the PR is merged. If no issue exists, open one first. -->
Closes #0

<!-- Add a brief overview here of the change. -->

<!-- Include screenshots or a short video demonstrating the change, if possible -->

## Checklist
<!-- Note: Changes to the Sdk MUST be accompanied by unit tests, even if there were none before. -->
This PR meets the following requirements:
- [ ] Tested and contains **NO** breaking changes or known regressions.
- [ ] Tested with the upstream branch merged in.
- [ ] Tests have been added for bug fixes / features (or this option is not applicable)
- [ ] All new code has been documented (or this option is not applicable)
- [ ] Headers have been added to all new source files (or this option is not applicable)

<!-- 
Is this a breaking change?
Please describe the impact and migration path for existing applications below.
-->

## Additional info
<!--
Please add any other information that might be helpful to reviewers.
-->

Not provided
