### PR TITLE
[fix] Bad aliasing on album art

### DIFF
--- a/src/Sdk/StrixMusic.Sdk.WinUI/Controls/SafeImage.cs
+++ b/src/Sdk/StrixMusic.Sdk.WinUI/Controls/SafeImage.cs
@@ -113,6 +113,10 @@ namespace StrixMusic.Sdk.WinUI.Controls
 
             var imageSource = new BitmapImage();
 
+            // Connect the bitmap to the tree before we set the source to prevent bad aliasing.
+            // See https://learn.microsoft.com/en-us/windows/uwp/debug-test-perf/optimize-animations-and-media#right-sized-decoding
+            PART_ImageBrush.ImageSource = imageSource;
+
             if (image.Height is not null)
                 imageSource.DecodePixelHeight = (int)image.Height;
 
@@ -122,11 +126,9 @@ namespace StrixMusic.Sdk.WinUI.Controls
             if (!stream.CanSeek)
                 return;
 
-            await imageSource.SetSourceAsync(stream.AsRandomAccessStream());
-
             cancellationToken.ThrowIfCancellationRequested();
 
-            PART_ImageBrush.ImageSource = imageSource;
+            await imageSource.SetSourceAsync(stream.AsRandomAccessStream());
         }
     }
 }


### PR DESCRIPTION
<!--
To categorize this PR in the generated changelog, include one of the following in the PR title: 
[breaking], [fix], [improvement], [new], [refactor], [cleanup]
-->

## Overview
<!-- Replace with the issue number. This will auto-close the issue once the PR is merged. If no issue exists, open one first. -->
Closes #299 

<!-- Add a brief overview here of the change. -->
[The UWP docs for optimizing media](https://learn.microsoft.com/en-us/windows/uwp/debug-test-perf/optimize-animations-and-media#right-sized-decoding) note that an image may be decoded at a lower resolution in certain conditions. One of them is relevant to `StrixMusic.Sdk.WinUI.SafeImage`: "The [BitmapImage](https://learn.microsoft.com/en-us/uwp/api/Windows.UI.Xaml.Media.Imaging.BitmapImage) is connected to the live XAML tree after setting the content with [SetSourceAsync](https://learn.microsoft.com/en-us/uwp/api/windows.ui.xaml.media.imaging.bitmapsource.setsourceasync) or [UriSource](https://learn.microsoft.com/en-us/uwp/api/windows.ui.xaml.media.imaging.bitmapimage.urisource)."
This change makes sure the `ImageBrush`'s source is set before the `BitmapImage`'s source, which invalidates the aforementioned condition and allows the XAML runtime to properly decode and anti-alias the image.

<!-- Include screenshots or a short video demonstrating the change, if possible -->
Zune albums view with fix applied:
![ApplicationFrameHost_TjFe3O0Nvy](https://github.com/user-attachments/assets/3dca0b0b-82a4-4d5b-93bb-3c3e585e8253)

## Checklist
<!-- Note: Changes to the Sdk MUST be accompanied by unit tests, even if there were none before. -->
This PR meets the following requirements:
- [x] Tested and contains **NO** breaking changes or known regressions.
- [x] Tested with the upstream branch merged in.
- [x] Tests have been added for bug fixes / features (or this option is not applicable)
- [x] All new code has been documented (or this option is not applicable)
- [x] Headers have been added to all new source files (or this option is not applicable)

<!-- 
Is this a breaking change?
Please describe the impact and migration path for existing applications below.
-->

## Additional info
<!--
Please add any other information that might be helpful to reviewers.
-->

Not provided
